### PR TITLE
feat: implement worker-owned I/O queues with optional read verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,7 +235,6 @@ version = "0.0.0"
 dependencies = [
  "crc-fast",
  "libc",
- "parking_lot",
  "uuid",
 ]
 
@@ -247,6 +246,17 @@ dependencies = [
  "libc",
  "moat-common",
  "parking_lot",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
+name = "moat-server"
+version = "0.0.0"
+dependencies = [
+ "libc",
+ "moat-common",
+ "moat-engine",
  "tempfile",
  "thiserror",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ libc = "0.2"
 # Moat crates
 moat-common = { path = "core/moat-common" }
 moat-engine = { path = "core/moat-engine" }
+moat-server = { path = "core/moat-server" }
 parking_lot = "0.12"
 tempfile = "3"
 thiserror = "2"

--- a/README.md
+++ b/README.md
@@ -57,6 +57,13 @@ latency on a file or, with `MOAT_BENCH_DEVICE`, a raw device (which it
 `cargo test --workspace` runs the unit tests plus the engine's crash-injection,
 reclaim and randomized model tests against an in-memory device.
 
+Server-side payload CRC verification is disabled by default
+(`Options::verify_reads = false`). Set it to `true` to verify the record header
+and every 64 KiB checksum block touched by each read. Unchecked reads cover
+only the requested pages; expiring records still read and validate their
+header. Checksum generation and recovery/reclaim validation are unchanged.
+Client-side transport and verification are not implemented yet.
+
 ## Benchmarking
 
 Run the engine benchmark without additional configuration to use a temporary
@@ -87,6 +94,7 @@ The workload can be adjusted with the following environment variables:
 | `MOAT_BENCH_READERS` | Concurrent reader threads | 1 |
 | `MOAT_BENCH_LARGE` | Large-value size in bytes | 1 MiB |
 | `MOAT_BENCH_SMALL` | Small-value size in bytes | 4 KiB |
+| `MOAT_BENCH_VERIFY` | Enable CRC verification on every read in the engine and node benchmarks | unset |
 | `MOAT_BENCH_SYNC` | Use the blocking queue instead of io_uring when set | unset |
 
 Benchmark results are hardware-specific. Published results should include the

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The design document lives at [`docs/design/chunkserver.md`](docs/design/chunkser
 | [`moat-common`](core/moat-common) | Chunk identifiers, CRC32C block checksums, page alignment, huge-page arenas and the buddy buffer pool | usable |
 | [`moat-engine`](core/moat-engine) | Single-disk engine: segments, index, reclaim/eviction, recovery; io_uring with registered buffers, zero-copy read and write paths | usable on raw devices, files and in memory |
 | `moat-transport` | RDMA (verbs) and TCP transports behind one protocol | planned |
-| `moat-server` | Multi-disk node: NVMe discovery, placement, admission, workers | planned |
+| [`moat-server`](core/moat-server) | Multi-disk node: NVMe discovery, placement, recovery and workers | usable without a network transport |
 | `moat-client` | Node routing, connection management, large-object striping | planned |
 | `moat-tools` | `format`, `fsck`, `dump`, `bench` | planned |
 
@@ -32,24 +32,34 @@ The design document lives at [`docs/design/chunkserver.md`](docs/design/chunkser
 ```rust
 use std::sync::Arc;
 use moat_common::ChunkId;
-use moat_engine::{FileDevice, FormatOptions, Options, PutOptions, QueueOptions};
+use moat_engine::{
+    FileDevice, FormatOptions, Options, PutOptions, QueueOptions, blocking, uring::UringQueue,
+};
 
 let device = Arc::new(FileDevice::create("disk.img", 64 << 30, /* direct */ true)?);
 moat_engine::format(&*device, &FormatOptions::default())?;
 
-let opened = moat_engine::open(device, Options::default())?;
-let (mut writer, reader) = (opened.writer, opened.reader);
-let mut ring = reader.ring(&QueueOptions::default())?; // one per reading thread
+let (engine, _) = moat_engine::open(device, Options::default())?;
+let mut queue = UringQueue::new(&QueueOptions::default())?;
+let mut writer = engine.writer(&mut queue)?;
+let mut reader = engine.reader(&mut queue)?;
 
 let id = ChunkId::from_u128(1);
-writer.put(id, b"hello", PutOptions::default())?;
-writer.flush()?;
-assert_eq!(ring.get_sync(&id, None)?.as_deref(), Some(&b"hello"[..]));
+writer.put(&mut queue, id, b"hello", PutOptions::default())?;
+blocking::flush(&mut queue, &mut writer)?;
+assert_eq!(
+    blocking::get(&mut queue, &mut reader, &id, None)?.as_deref(),
+    Some(&b"hello"[..]),
+);
+blocking::seal(&mut queue, &mut writer)?;
+writer.detach(&mut queue);
+reader.detach(&mut queue);
 ```
 
-The writer and every read ring own an io_uring instance and a pool of
-pre-registered, huge-page backed buffers; values move between those buffers and
-the device without copies (`Writer::prepare_large` / `put_large` for writes,
+Each worker owns an io_uring queue and a pool of registered buffers. Its readers
+and writers share that queue across disks; each disk has a single writer.
+Values move between buffers and the device without copies
+(`Writer::prepare_large` / `put_large` for writes,
 `ChunkData` for reads). `cargo bench -p moat-engine` measures throughput and
 latency on a file or, with `MOAT_BENCH_DEVICE`, a raw device (which it
 **formats**).

--- a/core/moat-common/benches/checksum.rs
+++ b/core/moat-common/benches/checksum.rs
@@ -19,7 +19,7 @@
 
 use std::{hint::black_box, time::Instant};
 
-use moat_common::{CHECKSUM_BLOCK_SIZE, block_checksums, crc32c};
+use moat_common::{CHECKSUM_BLOCK_SIZE, block_checksums, crc32c, verify_blocks};
 
 fn median_gib_per_s(len: usize, mut f: impl FnMut()) -> f64 {
     let passes = (2usize << 30) / len.max(1);
@@ -42,7 +42,10 @@ fn main() {
     let sizes = [4 << 10, CHECKSUM_BLOCK_SIZE, 1 << 20, 4 << 20];
     let buf: Vec<u8> = (0..(4usize << 20)).map(|i| (i % 251) as u8).collect();
 
-    println!("{:>10} {:>16} {:>22}", "size", "crc32c GiB/s", "block_checksums GiB/s");
+    println!(
+        "{:>10} {:>16} {:>22} {:>20}",
+        "size", "crc32c GiB/s", "block_checksums GiB/s", "verify_blocks GiB/s"
+    );
     for &len in &sizes {
         let data = &buf[..len];
         let one_shot = median_gib_per_s(len, || {
@@ -51,6 +54,10 @@ fn main() {
         let per_block = median_gib_per_s(len, || {
             black_box(block_checksums(black_box(data)));
         });
-        println!("{:>10} {:>16.2} {:>22.2}", len, one_shot, per_block);
+        let checksums = block_checksums(data);
+        let verify = median_gib_per_s(len, || {
+            black_box(verify_blocks(black_box(data), 0, black_box(&checksums))).unwrap();
+        });
+        println!("{:>10} {:>16.2} {:>22.2} {:>20.2}", len, one_shot, per_block, verify);
     }
 }

--- a/core/moat-common/src/arena.rs
+++ b/core/moat-common/src/arena.rs
@@ -69,7 +69,8 @@ pub struct Arena {
 // SAFETY: the arena exclusively owns its mapping; sharing the owner across
 // threads is no different from sharing a `Box<[u8]>`.
 unsafe impl Send for Arena {}
-// SAFETY: as above; shared access is read-only through `as_ptr`/`as_slice`.
+// SAFETY: shared access exposes metadata and a raw pointer, not references
+// into memory that a buffer pool may be mutating.
 unsafe impl Sync for Arena {}
 
 impl Arena {
@@ -168,17 +169,6 @@ impl Arena {
     pub fn as_ptr(&self) -> *mut u8 {
         self.ptr.as_ptr()
     }
-
-    /// Views the whole arena as bytes.
-    ///
-    /// Only valid while no [`BufferPool`](crate::pool::BufferPool) has handed
-    /// out mutable slices into it; the pool never calls this.
-    #[inline]
-    pub fn as_slice(&self) -> &[u8] {
-        // SAFETY: the mapping is `len` bytes of zero-initialised (or since
-        // written) memory owned by `self`.
-        unsafe { std::slice::from_raw_parts(self.ptr.as_ptr(), self.len) }
-    }
 }
 
 impl Drop for Arena {
@@ -206,7 +196,9 @@ mod tests {
         let arena = Arena::new(3 * PAGE_SIZE as usize + 1, HugePages::Disabled).unwrap();
         assert_eq!(arena.len(), 4 * PAGE_SIZE as usize);
         assert_eq!(arena.as_ptr() as usize % PAGE_SIZE as usize, 0);
-        assert!(arena.as_slice().iter().all(|&b| b == 0));
+        // SAFETY: this arena has not been given to a pool or mutated.
+        let bytes = unsafe { std::slice::from_raw_parts(arena.as_ptr(), arena.len()) };
+        assert!(bytes.iter().all(|&b| b == 0));
         assert_eq!(arena.backing(), Backing::Plain);
     }
 

--- a/core/moat-common/src/buf.rs
+++ b/core/moat-common/src/buf.rs
@@ -25,8 +25,8 @@ use crate::align::PAGE_SIZE;
 /// A zero-initialised heap buffer whose address and length are both multiples
 /// of [`PAGE_SIZE`].
 ///
-/// This is the only buffer type that may be handed to a direct I/O device or
-/// registered with an RDMA NIC.
+/// Used for blocking direct I/O during formatting and recovery. Asynchronous
+/// queues use [`PooledBuf`](crate::PooledBuf) from registered arenas.
 pub struct AlignedBuf {
     ptr: NonNull<u8>,
     len: usize,

--- a/core/moat-common/src/checksum.rs
+++ b/core/moat-common/src/checksum.rs
@@ -16,16 +16,11 @@
 //!
 //! Chunk values are checksummed per [`CHECKSUM_BLOCK_SIZE`] block so that a
 //! range read only has to verify the blocks it touches. The same block
-//! checksums travel from the client over the wire to the disk and back, giving
-//! end-to-end integrity without recomputation at any hop.
+//! checksums can be carried by a transport to support end-to-end integrity
+//! without recomputation at every hop.
 //!
-//! The implementation is `crc-fast`, which folds the polynomial with
-//! carry-less multiplication (`VPCLMULQDQ` / `PCLMULQDQ` on x86, `PMULL` on
-//! AArch64) and selects the best kernel at runtime. On a modern server core it
-//! sustains tens of GiB/s independent of the input size, an order of magnitude
-//! faster than the single-stream `crc32` instruction, which matters because
-//! every 64 KiB block on a 100+ GB/s node is verified at least once.
-//! `cargo bench -p moat-common` measures it on the current machine.
+//! Uses `crc-fast` for both checksum generation and optional read verification.
+//! `cargo bench -p moat-common` measures throughput on the current machine.
 
 use crc_fast::{CrcAlgorithm, Digest};
 
@@ -155,5 +150,28 @@ mod tests {
         assert_eq!(verify_blocks(&corrupted, 0, &sums), Err(2));
         // Blocks before the corruption still verify on their own.
         assert!(verify_blocks(&corrupted[..CHECKSUM_BLOCK_SIZE * 2], 0, &sums).is_ok());
+    }
+
+    #[test]
+    fn preserves_partial_blocks_indices_and_first_error() {
+        let mut data = vec![0u8; CHECKSUM_BLOCK_SIZE * 4 + 17];
+        for (i, byte) in data.iter_mut().enumerate() {
+            *byte = (i % 251) as u8;
+        }
+        let checksums = block_checksums(&data);
+        let first = 7;
+        let verify = |input: &[u8]| verify_blocks_with(input, first, |i| checksums.get((i - first) as usize).copied());
+        assert_eq!(verify(&data), Ok(()));
+        for block in 0..checksums.len() {
+            let at = block * CHECKSUM_BLOCK_SIZE;
+            data[at] ^= 1;
+            assert_eq!(verify(&data), Err(first + block as u32));
+            data[at] ^= 1;
+        }
+        data[CHECKSUM_BLOCK_SIZE] ^= 1;
+        data[CHECKSUM_BLOCK_SIZE * 3] ^= 1;
+        assert_eq!(verify(&data), Err(first + 1));
+        assert_eq!(verify_blocks_with(&[], first, |_| None), Ok(()));
+        assert_eq!(verify_blocks_with(&data, first, |_| None), Err(first));
     }
 }

--- a/core/moat-common/src/pool.rs
+++ b/core/moat-common/src/pool.rs
@@ -23,8 +23,8 @@
 //! Sizes are rounded up to a power of two between one page and the configured
 //! maximum and served by a binary buddy allocator per arena, so a burst of
 //! large requests followed by small ones (or the reverse) never strands memory
-//! in the wrong size class. The allocator keeps its free lists inside the free
-//! blocks themselves, so allocation never touches the heap. Buffers are handed
+//! in the wrong size class. Preallocated per-order stacks recycle recent frees;
+//! intrusive links in free blocks support buddy coalescing. Buffers are handed
 //! out as [`PooledBuf`], an owning handle that returns the memory to the pool
 //! when dropped, so a buffer can be moved into an I/O queue and back without
 //! any lifetime bookkeeping.
@@ -117,8 +117,6 @@ struct Buddy {
     base: *mut u8,
     min_shift: u32,
     heads: Vec<usize>,
-    /// Blocks on each order's intrusive free list.
-    counts: Vec<usize>,
     /// Parked blocks per order: free, but not on the intrusive list and not
     /// marked in the bitmap.
     parked: Vec<Vec<usize>>,
@@ -143,7 +141,6 @@ impl Buddy {
             base: arena.as_ptr(),
             min_shift,
             heads: vec![NONE; orders],
-            counts: vec![0; orders],
             parked: (0..orders)
                 .map(|k| Vec::with_capacity((LAZY_BYTES_PER_ORDER >> (k as u32 + min_shift)).max(1)))
                 .collect(),
@@ -208,7 +205,6 @@ impl Buddy {
             self.set_links(head, offset, next);
         }
         self.heads[order] = offset;
-        self.counts[order] += 1;
         let (word, mask) = self.bit(order, offset);
         self.bitmaps[order][word] |= mask;
     }
@@ -225,7 +221,6 @@ impl Buddy {
             let [_, nn] = self.get_links(next);
             self.set_links(next, prev, nn);
         }
-        self.counts[order] -= 1;
         let (word, mask) = self.bit(order, offset);
         self.bitmaps[order][word] &= !mask;
     }
@@ -412,10 +407,10 @@ impl BufferPool {
     ///
     /// If called from a thread other than the one that created the pool.
     pub fn alloc(self: &Arc<Self>, len: usize) -> Option<PooledBuf> {
-        let size = self.class_size(len);
-        if size > self.max_class() {
+        if len > self.max_class() {
             return None;
         }
+        let size = self.class_size(len);
         let order = self.order(size);
         let (arena, offset) = self.with_buddies(|buddies| {
             self.drain_returned(buddies);
@@ -632,6 +627,7 @@ mod tests {
         let pool = pool(64 << 10, 64 << 10);
         let a = pool.alloc(64 << 10).unwrap();
         assert!(pool.alloc(4096).is_none());
+        assert!(pool.alloc(usize::MAX).is_none());
         drop(a);
         // The freed large block is split for the small request...
         let small = pool.alloc(4096).unwrap();

--- a/core/moat-common/src/pool.rs
+++ b/core/moat-common/src/pool.rs
@@ -25,20 +25,29 @@
 //! large requests followed by small ones (or the reverse) never strands memory
 //! in the wrong size class. The allocator keeps its free lists inside the free
 //! blocks themselves, so allocation never touches the heap. Buffers are handed
-//! out as
-//! [`PooledBuf`], an owning handle that returns the memory to the pool when
-//! dropped, so a buffer can be moved into an I/O queue and back without any
-//! lifetime bookkeeping.
+//! out as [`PooledBuf`], an owning handle that returns the memory to the pool
+//! when dropped, so a buffer can be moved into an I/O queue and back without
+//! any lifetime bookkeeping.
+//!
+//! # Threads
+//!
+//! A pool belongs to the thread that created it (its *home* thread) and has no
+//! lock: only the home thread allocates, and only the home thread runs the
+//! buddy allocator. A buffer may travel to another thread (a value read on one
+//! worker and handed to another, a landing buffer forwarded to a disk's owner)
+//! and be dropped there; such a drop does not touch the allocator but pushes
+//! the block onto a lock-free return stack that the home thread drains on its
+//! next allocation. Allocating from a foreign thread is a programming error and
+//! panics.
 
 use std::{
+    cell::{Cell, UnsafeCell},
     ops::{Deref, DerefMut},
     sync::{
         Arc,
-        atomic::{AtomicUsize, Ordering},
+        atomic::{AtomicU64, AtomicUsize, Ordering},
     },
 };
-
-use parking_lot::Mutex;
 
 use crate::{
     align::{PAGE_SIZE, align_up},
@@ -70,6 +79,21 @@ impl Default for PoolOptions {
     }
 }
 
+/// A process-unique identifier of the calling thread that costs a thread-local
+/// read (`std::thread::current()` clones an `Arc`).
+fn this_thread() -> u64 {
+    static NEXT: AtomicU64 = AtomicU64::new(1);
+    thread_local! {
+        static ID: Cell<u64> = const { Cell::new(0) };
+    }
+    ID.with(|id| {
+        if id.get() == 0 {
+            id.set(NEXT.fetch_add(1, Ordering::Relaxed));
+        }
+        id.get()
+    })
+}
+
 /// A binary buddy allocator over one arena, in units of pages.
 ///
 /// Free blocks are threaded into one doubly linked list per order, with the
@@ -79,20 +103,32 @@ impl Default for PoolOptions {
 /// construction: the hot path is a handful of loads and stores into memory the
 /// pool already owns. Non-power-of-two arenas are seeded with the binary
 /// decomposition of their length.
+///
+/// Coalescing is lazy: a released block is parked on a per-order stack of
+/// offsets, without looking at its buddy and without touching the block
+/// itself (whose memory the device just wrote and the CPU has no reason to
+/// pull into its cache), while that stack holds fewer than
+/// [`LAZY_BYTES_PER_ORDER`] bytes. A steady stream of same-class allocations
+/// (4 KiB reads) is then a pop and a push on a small hot array rather than a
+/// split down from a large block and a merge back up on every call. Beyond the
+/// limit, and whenever an allocation finds nothing big enough, parked blocks
+/// merge with their free buddies as usual, so large classes still recover.
 struct Buddy {
     base: *mut u8,
     min_shift: u32,
     heads: Vec<usize>,
+    /// Blocks on each order's intrusive free list.
+    counts: Vec<usize>,
+    /// Parked blocks per order: free, but not on the intrusive list and not
+    /// marked in the bitmap.
+    parked: Vec<Vec<usize>>,
     bitmaps: Vec<Vec<u64>>,
 }
 
 const NONE: usize = usize::MAX;
 
-// SAFETY: `base` points into an `Arena` owned by the same pool, which outlives
-// the allocator and is never moved; all access goes through `&mut self`.
-unsafe impl Send for Buddy {}
-// SAFETY: as above; the allocator is only used under the pool's mutex.
-unsafe impl Sync for Buddy {}
+/// Bytes each order may keep on its free list before releases coalesce.
+const LAZY_BYTES_PER_ORDER: usize = 8 << 20;
 
 impl Buddy {
     fn new(arena: &Arena, min_shift: u32, max_shift: u32) -> Self {
@@ -107,6 +143,10 @@ impl Buddy {
             base: arena.as_ptr(),
             min_shift,
             heads: vec![NONE; orders],
+            counts: vec![0; orders],
+            parked: (0..orders)
+                .map(|k| Vec::with_capacity((LAZY_BYTES_PER_ORDER >> (k as u32 + min_shift)).max(1)))
+                .collect(),
             bitmaps,
         };
         let mut offset = 0usize;
@@ -168,6 +208,7 @@ impl Buddy {
             self.set_links(head, offset, next);
         }
         self.heads[order] = offset;
+        self.counts[order] += 1;
         let (word, mask) = self.bit(order, offset);
         self.bitmaps[order][word] |= mask;
     }
@@ -184,12 +225,26 @@ impl Buddy {
             let [_, nn] = self.get_links(next);
             self.set_links(next, prev, nn);
         }
+        self.counts[order] -= 1;
         let (word, mask) = self.bit(order, offset);
         self.bitmaps[order][word] &= !mask;
     }
 
     fn alloc(&mut self, order: usize) -> Option<usize> {
-        let from = (order..self.heads.len()).find(|&k| self.heads[k] != NONE)?;
+        if let Some(offset) = self.parked[order].pop() {
+            return Some(offset);
+        }
+        let from = match (order..self.heads.len()).find(|&k| self.heads[k] != NONE) {
+            Some(from) => from,
+            None => {
+                // Parked blocks may merge into something big enough.
+                if self.parked.iter().all(Vec::is_empty) {
+                    return None;
+                }
+                self.compact();
+                (order..self.heads.len()).find(|&k| self.heads[k] != NONE)?
+            }
+        };
         let offset = self.heads[from];
         self.unlink(from, offset);
         // Split down to the requested order, keeping the upper halves free.
@@ -199,7 +254,27 @@ impl Buddy {
         Some(offset)
     }
 
-    fn release(&mut self, mut offset: usize, mut order: usize) {
+    fn release(&mut self, offset: usize, order: usize) {
+        let stack = &mut self.parked[order];
+        if stack.len() < stack.capacity() {
+            stack.push(offset);
+            return;
+        }
+        self.release_eager(offset, order);
+    }
+
+    /// Returns every parked block to the intrusive lists, merging with free
+    /// buddies bottom up, so that the largest possible blocks become
+    /// allocatable again.
+    fn compact(&mut self) {
+        for order in 0..self.heads.len() {
+            while let Some(offset) = self.parked[order].pop() {
+                self.release_eager(offset, order);
+            }
+        }
+    }
+
+    fn release_eager(&mut self, mut offset: usize, mut order: usize) {
         while order + 1 < self.heads.len() {
             let buddy = offset ^ self.size(order);
             if !self.is_free(order, buddy) {
@@ -213,17 +288,41 @@ impl Buddy {
     }
 }
 
+/// A block released from a foreign thread, waiting on the return stack. Lives
+/// in the first bytes of the free block itself.
+#[repr(C)]
+struct Returned {
+    next: usize,
+    arena: usize,
+    offset: usize,
+    len: usize,
+}
+
 /// A pool of page-aligned buffers. See the [module docs](self).
 pub struct BufferPool {
     arenas: Vec<Arena>,
     min_shift: u32,
     max_shift: u32,
-    buddies: Mutex<Vec<Buddy>>,
+    /// Only the home thread touches the allocators.
+    buddies: UnsafeCell<Vec<Buddy>>,
+    home: u64,
+    /// Head of the intrusive stack of blocks released from foreign threads
+    /// (address of the block, or zero).
+    returned: AtomicUsize,
     in_use: AtomicUsize,
 }
 
+// SAFETY: `buddies` is only accessed from the home thread (`alloc` and the
+// home-thread branch of `release` assert it); every other field is immutable
+// or atomic. Sharing the pool across threads therefore only exposes
+// thread-safe operations.
+unsafe impl Sync for BufferPool {}
+// SAFETY: as above; the raw arena pointers inside `Buddy` are owned by the
+// arenas the pool holds.
+unsafe impl Send for BufferPool {}
+
 impl BufferPool {
-    /// Maps the arenas and creates an empty pool.
+    /// Maps the arenas and creates an empty pool owned by the calling thread.
     pub fn new(opts: PoolOptions) -> std::io::Result<Arc<Self>> {
         let min_shift = PAGE_SIZE.trailing_zeros();
         assert!(
@@ -246,7 +345,9 @@ impl BufferPool {
             arenas,
             min_shift,
             max_shift,
-            buddies: Mutex::new(buddies),
+            buddies: UnsafeCell::new(buddies),
+            home: this_thread(),
+            returned: AtomicUsize::new(0),
             in_use: AtomicUsize::new(0),
         }))
     }
@@ -273,29 +374,56 @@ impl BufferPool {
         1 << self.max_shift
     }
 
+    /// Whether the calling thread is the pool's home thread.
+    pub fn is_home(&self) -> bool {
+        this_thread() == self.home
+    }
+
     /// Size class a request of `len` bytes is served from.
     #[inline]
     pub fn class_size(&self, len: usize) -> usize {
         (len.max(1).next_power_of_two()).max(1 << self.min_shift)
     }
 
+    #[inline]
+    fn order(&self, len: usize) -> usize {
+        (len.trailing_zeros() - self.min_shift) as usize
+    }
+
+    /// Runs `f` on the allocators. Callers must be on the home thread.
+    #[inline]
+    fn with_buddies<R>(&self, f: impl FnOnce(&mut [Buddy]) -> R) -> R {
+        assert!(
+            self.is_home(),
+            "buffer pool used from a thread other than its home thread"
+        );
+        // SAFETY: only the home thread reaches this point (asserted above), and
+        // the pool is never re-entered while the `&mut` is live: `f` is one
+        // of the leaf operations below, which do not call back into the pool.
+        f(unsafe { &mut *self.buddies.get() })
+    }
+
     /// Allocates a buffer of at least `len` bytes.
     ///
     /// Returns `None` if `len` exceeds the maximum class or the pool is
     /// exhausted; callers treat that as back-pressure, not as an error.
+    ///
+    /// # Panics
+    ///
+    /// If called from a thread other than the one that created the pool.
     pub fn alloc(self: &Arc<Self>, len: usize) -> Option<PooledBuf> {
         let size = self.class_size(len);
         if size > self.max_class() {
             return None;
         }
-        let order = (size.trailing_zeros() - self.min_shift) as usize;
-        let (arena, offset) = {
-            let mut buddies = self.buddies.lock();
+        let order = self.order(size);
+        let (arena, offset) = self.with_buddies(|buddies| {
+            self.drain_returned(buddies);
             buddies
                 .iter_mut()
                 .enumerate()
-                .find_map(|(i, b)| b.alloc(order).map(|off| (i as u32, off)))?
-        };
+                .find_map(|(i, b)| b.alloc(order).map(|off| (i as u32, off)))
+        })?;
         self.in_use.fetch_add(size, Ordering::Relaxed);
         Some(PooledBuf {
             pool: self.clone(),
@@ -305,10 +433,55 @@ impl BufferPool {
         })
     }
 
+    /// Moves every block released from a foreign thread back into the
+    /// allocators. Home thread only.
+    fn drain_returned(&self, buddies: &mut [Buddy]) {
+        let mut node = self.returned.swap(0, Ordering::Acquire);
+        while node != 0 {
+            // SAFETY: `node` is the address of a block that a foreign
+            // `release` pushed after writing a `Returned` at its start; the
+            // block is free, so nothing else touches that memory, and the
+            // Acquire swap above (paired with the pusher's Release) makes the
+            // fields visible.
+            let returned = unsafe { (node as *const Returned).read() };
+            buddies[returned.arena].release(returned.offset, self.order(returned.len));
+            node = returned.next;
+        }
+    }
+
     fn release(&self, arena: u32, offset: usize, len: usize) {
-        let order = (len.trailing_zeros() - self.min_shift) as usize;
-        self.buddies.lock()[arena as usize].release(offset, order);
         self.in_use.fetch_sub(len, Ordering::Relaxed);
+        if self.is_home() {
+            let order = self.order(len);
+            self.with_buddies(|buddies| buddies[arena as usize].release(offset, order));
+            return;
+        }
+        // Foreign thread: push the block onto the return stack. Its memory is
+        // ours to reuse for the node since the buffer has been released.
+        // SAFETY: `offset + len <= arena.len()` by construction, and a block is
+        // at least one page, so a `Returned` fits at its start.
+        let node = unsafe { self.arenas[arena as usize].as_ptr().add(offset) }.cast::<Returned>();
+        let addr = node as usize;
+        let mut head = self.returned.load(Ordering::Relaxed);
+        loop {
+            // SAFETY: as above; the block is exclusively ours until the CAS
+            // below publishes it to the home thread.
+            unsafe {
+                node.write(Returned {
+                    next: head,
+                    arena: arena as usize,
+                    offset,
+                    len,
+                });
+            }
+            match self
+                .returned
+                .compare_exchange_weak(head, addr, Ordering::Release, Ordering::Relaxed)
+            {
+                Ok(_) => return,
+                Err(current) => head = current,
+            }
+        }
     }
 }
 
@@ -324,11 +497,11 @@ impl std::fmt::Debug for BufferPool {
 }
 
 /// An owning handle to a pool buffer. Dereferences to its full class-sized
-/// capacity; the memory is returned to the pool on drop.
+/// capacity; the memory is returned to the pool on drop (from any thread).
 ///
-/// Contents are whatever the previous user left (the first 16 bytes of a block
-/// hold the allocator's free-list links while it is free): callers overwrite
-/// what they use and must not rely on zeroes.
+/// Contents are whatever the previous user left (the first bytes of a block
+/// hold the allocator's free-list links or return-stack node while it is
+/// free): callers overwrite what they use and must not rely on zeroes.
 pub struct PooledBuf {
     pool: Arc<BufferPool>,
     arena: u32,
@@ -337,7 +510,8 @@ pub struct PooledBuf {
 }
 
 // SAFETY: a `PooledBuf` is the unique owner of its byte range until dropped;
-// the pool never hands the same range out twice.
+// the pool never hands the same range out twice, and dropping on a foreign
+// thread goes through the lock-free return stack.
 unsafe impl Send for PooledBuf {}
 // SAFETY: as above; shared access only yields `&[u8]`.
 unsafe impl Sync for PooledBuf {}
@@ -370,7 +544,7 @@ impl PooledBuf {
 
     #[inline]
     fn base(&self) -> *mut u8 {
-        // SAFETY: `offset + len <= arena.len()` by construction in `carve`.
+        // SAFETY: `offset + len <= arena.len()` by construction in `alloc`.
         unsafe { self.pool.arenas[self.arena as usize].as_ptr().add(self.offset) }
     }
 
@@ -519,5 +693,28 @@ mod tests {
         })
         .unwrap();
         assert_eq!(pool.arenas().len(), 2);
+    }
+
+    #[test]
+    fn foreign_drops_come_home_on_next_alloc() {
+        let pool = pool(256 << 10, 64 << 10);
+        let bufs: Vec<PooledBuf> = (0..4).map(|_| pool.alloc(64 << 10).unwrap()).collect();
+        assert!(pool.alloc(4096).is_none());
+        let handles: Vec<_> = bufs.into_iter().map(|b| std::thread::spawn(move || drop(b))).collect();
+        for h in handles {
+            h.join().unwrap();
+        }
+        // Released on foreign threads: accounted immediately, allocator
+        // updated when the home thread allocates next.
+        assert_eq!(pool.in_use(), 0);
+        let bufs: Vec<PooledBuf> = (0..4).map(|_| pool.alloc(64 << 10).unwrap()).collect();
+        assert_eq!(bufs.len(), 4);
+    }
+
+    #[test]
+    fn foreign_alloc_panics() {
+        let pool = pool(64 << 10, 64 << 10);
+        let result = std::thread::spawn(move || pool.alloc(4096)).join();
+        assert!(result.is_err());
     }
 }

--- a/core/moat-engine/benches/engine.rs
+++ b/core/moat-engine/benches/engine.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Engine throughput and latency on a real file or block device.
+//! Single-engine throughput and latency on a real file or block device.
 //!
 //! ```sh
 //! cargo bench -p moat-engine
@@ -24,9 +24,19 @@
 //! formatted: **never point this at a device holding data you need.**
 //!
 //! Knobs: `MOAT_BENCH_BYTES` (device bytes to use; a quarter goes to each
-//! workload), `MOAT_BENCH_READERS` (reader threads, each with its own ring),
-//! `MOAT_BENCH_LARGE` / `MOAT_BENCH_SMALL` (value sizes), `MOAT_BENCH_SYNC`
-//! (use the blocking queue instead of io_uring).
+//! workload), `MOAT_BENCH_READERS` (reader threads, each with its own queue),
+//! `MOAT_BENCH_INFLIGHT` (comma-separated outstanding small reads per thread;
+//! each value is one run), `MOAT_BENCH_DEPTH` (queue depth, at least the
+//! largest in-flight count), `MOAT_BENCH_LARGE` / `MOAT_BENCH_SMALL` (value
+//! sizes), `MOAT_BENCH_SYNC` (use the blocking queue instead of io_uring),
+//! `MOAT_BENCH_REOPEN` (do not format or write; reopen the device from a
+//! previous run and go straight to the read phases, for profiling),
+//! `MOAT_BENCH_SECONDS` (duration per read phase, default 10; zero uses
+//! the original fixed request counts), `MOAT_BENCH_LARGE_INFLIGHT`
+//! (outstanding large reads per thread, default 16),
+//! `MOAT_BENCH_WRITE_BATCH` (puts between completion polls, default 64),
+//! `MOAT_BENCH_READ_PHASES` (comma-separated large,small,latency; all by default),
+//! `MOAT_BENCH_VERIFY` (enable header and value checksum verification on reads).
 
 use std::{
     hint::black_box,
@@ -36,21 +46,43 @@ use std::{
 
 use moat_common::{ChunkId, HugePages, PoolOptions, block_checksums};
 use moat_engine::{
-    FileDevice, FormatOptions, Options, PutOptions, PutOutcome, QueueOptions, ReadOutcome, ReadRing, Writer,
+    Engine, Error, FileDevice, FormatOptions, IoQueue, Options, PutOptions, PutOutcome, QueueOptions, ReadOutcome,
+    Reader, Writer, blocking,
+    io::{CompletionOrder, SyncQueue},
 };
 
 const SEGMENT: u64 = 256 << 20;
 const CHUNK_MAX: u32 = 4 << 20;
 
+fn env(name: &str, default: u64) -> u64 {
+    std::env::var(name).ok().and_then(|s| s.parse().ok()).unwrap_or(default)
+}
+
 fn queue_options() -> QueueOptions {
     QueueOptions {
-        depth: 256,
+        depth: env("MOAT_BENCH_DEPTH", 256) as u32,
         pool: PoolOptions {
             bytes: 512 << 20,
             max_class: 8 << 20,
             huge_pages: HugePages::Preferred,
         },
-        force_sync: std::env::var_os("MOAT_BENCH_SYNC").is_some(),
+        descriptors: 4,
+    }
+}
+
+/// Builds the queue for the calling thread.
+fn queue() -> Box<dyn IoQueue> {
+    let opts = queue_options();
+    if std::env::var_os("MOAT_BENCH_SYNC").is_some() {
+        return Box::new(SyncQueue::new(&opts, CompletionOrder::Fifo).unwrap());
+    }
+    #[cfg(target_os = "linux")]
+    {
+        Box::new(moat_engine::uring::UringQueue::new(&opts).unwrap())
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        Box::new(SyncQueue::new(&opts, CompletionOrder::Fifo).unwrap())
     }
 }
 
@@ -59,6 +91,9 @@ fn gib_per_s(bytes: u64, elapsed: Duration) -> f64 {
 }
 
 fn percentile(sorted: &[Duration], p: f64) -> Duration {
+    if sorted.is_empty() {
+        return Duration::ZERO;
+    }
     let idx = ((sorted.len() as f64 - 1.0) * p).round() as usize;
     sorted[idx.min(sorted.len() - 1)]
 }
@@ -67,33 +102,60 @@ fn id(n: u64) -> ChunkId {
     ChunkId::from_u128(n as u128)
 }
 
-/// Writes `count` values of `len` bytes through the zero-copy path with the
-/// pipeline kept full, returning aggregate throughput.
-fn bench_puts(writer: &mut Writer, first_id: u64, count: u64, len: usize, label: &str) {
+/// Writes `count` values of `len` bytes with the pipeline kept full,
+/// returning aggregate throughput. Large values go through the zero-copy path.
+fn bench_puts(q: &mut dyn IoQueue, writer: &mut Writer, first_id: u64, count: u64, len: usize, label: &str) {
     let pattern: Vec<u8> = (0..len).map(|i| (i % 253) as u8).collect();
     let sums = block_checksums(&pattern);
     let start = Instant::now();
     let mut done = Vec::new();
     let mut acked = 0u64;
+    let batch = env("MOAT_BENCH_WRITE_BATCH", 64);
+    assert!(batch > 0);
+    let mut reap = |q: &mut dyn IoQueue, writer: &mut Writer, wait: bool| {
+        q.poll(wait).unwrap();
+        writer.poll(q, &mut done).unwrap();
+        for c in done.drain(..) {
+            c.result.unwrap();
+            acked += 1;
+        }
+    };
     for i in 0..count {
-        let outcome = if len >= 64 << 10 {
-            let mut large = writer.prepare_large(len as u32).unwrap();
-            large.value_mut().copy_from_slice(&pattern);
-            writer
-                .put_large(id(first_id + i), large, Some(&sums), PutOptions::default())
-                .unwrap()
-        } else {
-            writer.put(id(first_id + i), &pattern, PutOptions::default()).unwrap()
-        };
-        assert!(matches!(outcome, PutOutcome::Written { .. }));
-        // Keep submitting; reap opportunistically so completions do not pile up.
-        if i % 8 == 7 {
-            writer.poll(&mut done, false).unwrap();
-            acked += done.len() as u64;
-            done.clear();
+        loop {
+            let outcome = if len >= 64 << 10 {
+                match writer.prepare_large(q, len as u32) {
+                    Ok(mut large) => {
+                        large.value_mut().copy_from_slice(&pattern);
+                        writer.put_large(q, id(first_id + i), large, Some(&sums), PutOptions::default())
+                    }
+                    Err(e) => Err(e),
+                }
+            } else {
+                writer.put(q, id(first_id + i), &pattern, PutOptions::default())
+            };
+            match outcome {
+                Ok(o) => {
+                    assert!(matches!(o, PutOutcome::Written { .. }));
+                    break;
+                }
+                // The pool is the back-pressure signal: reap and retry.
+                Err(Error::Busy) => reap(q, writer, true),
+                Err(e) => panic!("{e}"),
+            }
+        }
+        // Polling also closes the writer's partial batch. Give small puts a
+        // useful packing window rather than flushing every few records.
+        if (i + 1).is_multiple_of(batch) {
+            reap(q, writer, false);
         }
     }
-    writer.flush().unwrap();
+    let ticket = writer.flush(q).unwrap();
+    blocking::wait_with(q, writer, ticket, &mut done).unwrap();
+    for c in done.drain(..) {
+        c.result.unwrap();
+        acked += 1;
+    }
+    assert_eq!(acked, count, "every accepted put must complete successfully");
     let elapsed = start.elapsed();
     black_box(acked);
     println!(
@@ -104,17 +166,21 @@ fn bench_puts(writer: &mut Writer, first_id: u64, count: u64, len: usize, label:
     );
 }
 
-/// Random reads with `inflight` outstanding on one ring. Returns per-request
-/// latencies.
+/// Random reads with `inflight` outstanding on one queue. Returns the number
+/// of reads done and the sampled latencies.
+#[allow(clippy::too_many_arguments)]
 fn read_loop(
-    ring: &mut ReadRing,
+    q: &mut dyn IoQueue,
+    reader: &mut Reader,
     first_id: u64,
     count: u64,
     len: usize,
     inflight: usize,
     total: u64,
     seed: u64,
-) -> Vec<Duration> {
+    duration: Duration,
+) -> (u64, Vec<Duration>, Duration) {
+    assert!(inflight > 0 && count > 0);
     let mut rng = seed | 1;
     let mut next = || {
         rng ^= rng << 13;
@@ -122,47 +188,60 @@ fn read_loop(
         rng ^= rng << 17;
         rng
     };
-    let mut latencies = Vec::with_capacity(total as usize);
+    let mut latencies = Vec::with_capacity(1 << 20);
     let mut started: Vec<Option<Instant>> = vec![None; inflight];
     let mut out = Vec::new();
     let mut issued = 0u64;
     let mut completed = 0u64;
     let mut free_slots: Vec<usize> = (0..inflight).collect();
-    while completed < total {
-        while issued < total
+    let start = Instant::now();
+    let mut stop = false;
+    loop {
+        if !duration.is_zero() && start.elapsed() >= duration {
+            stop = true;
+        }
+        while !stop
+            && (!duration.is_zero() || issued < total)
             && let Some(slot) = free_slots.pop()
         {
             let key = id(first_id + next() % count);
-            started[slot] = Some(Instant::now());
-            match ring.get(&key, None, slot as u64) {
+            // Timestamps cost a vdso call each; sample one request in 16.
+            started[slot] = issued.is_multiple_of(16).then(Instant::now);
+            match reader.get(q, &key, None, slot as u64) {
                 Ok(ReadOutcome::Submitted) => issued += 1,
                 Ok(ReadOutcome::Miss) => panic!("missing key"),
-                Err(moat_engine::Error::Busy) => {
+                Err(Error::Busy) => {
                     free_slots.push(slot);
                     break;
                 }
                 Err(e) => panic!("{e}"),
             }
         }
-        ring.poll(&mut out, true).unwrap();
+        if completed == issued && (stop || duration.is_zero() && issued == total) {
+            break;
+        }
+        q.poll(true).unwrap();
+        reader.poll(q, &mut out).unwrap();
         for c in out.drain(..) {
             let slot = c.token as usize;
             let data = c.result.unwrap().expect("not expired");
             assert_eq!(data.len(), len);
             black_box(&*data);
-            latencies.push(started[slot].take().unwrap().elapsed());
+            if let Some(t) = started[slot].take() {
+                latencies.push(t.elapsed());
+            }
             free_slots.push(slot);
             completed += 1;
         }
     }
-    latencies
+    (completed, latencies, start.elapsed())
 }
 
-/// Random reads spread over `readers` threads, each with its own ring and
+/// Random reads spread over `readers` threads, each with its own queue and
 /// `inflight` outstanding requests.
 #[allow(clippy::too_many_arguments)]
 fn bench_reads(
-    reader: &moat_engine::Reader,
+    engine: &Engine,
     readers: usize,
     first_id: u64,
     count: u64,
@@ -171,35 +250,50 @@ fn bench_reads(
     total: u64,
     label: &str,
 ) {
+    assert!(readers > 0 && total >= readers as u64);
     let per_thread = total / readers as u64;
-    // Rings (and their pools) are created before the clock starts: mapping and
-    // registering a pool pins and clears hundreds of megabytes, which is
-    // start-up cost, not read-path cost.
-    let rings: Vec<ReadRing> = (0..readers).map(|_| reader.ring(&queue_options()).unwrap()).collect();
-    let start = Instant::now();
-    let handles: Vec<_> = rings
-        .into_iter()
-        .enumerate()
-        .map(|(t, mut ring)| {
+    let duration = Duration::from_secs(env("MOAT_BENCH_SECONDS", 10));
+    let barrier = Arc::new(std::sync::Barrier::new(readers + 1));
+    let handles: Vec<_> = (0..readers)
+        .map(|t| {
+            let engine = engine.clone();
+            let barrier = barrier.clone();
             std::thread::spawn(move || {
-                read_loop(
-                    &mut ring,
+                // Queues (and their pools) are created before the clock
+                // starts: mapping and registering a pool pins and clears
+                // hundreds of megabytes, which is start-up cost.
+                let mut q = queue();
+                let mut reader = engine.reader(&mut *q).unwrap();
+                barrier.wait();
+                let done = read_loop(
+                    &mut *q,
+                    &mut reader,
                     first_id,
                     count,
                     len,
                     inflight,
-                    per_thread,
+                    per_thread + u64::from((t as u64) < total % readers as u64),
                     0x9e37_79b9 + t as u64,
-                )
+                    duration,
+                );
+                reader.detach(&mut *q);
+                done
             })
         })
         .collect();
-    let mut latencies: Vec<Duration> = handles.into_iter().flat_map(|h| h.join().unwrap()).collect();
-    let elapsed = start.elapsed();
+    barrier.wait();
+    let mut done = 0u64;
+    let mut elapsed = Duration::ZERO;
+    let mut latencies: Vec<Duration> = Vec::new();
+    for h in handles {
+        let (n, l, took) = h.join().unwrap();
+        done += n;
+        elapsed = elapsed.max(took);
+        latencies.extend(l);
+    }
     latencies.sort();
-    let done = latencies.len() as u64;
     println!(
-        "{label:<34} {:>8.2} GiB/s {:>10.0} ops/s  p50 {:>8.1?} p99 {:>8.1?} p999 {:>8.1?}",
+        "{label:<34} {:>8.2} GiB/s {:>10.0} ops/s  p50 {:>8.1?} p99 {:>8.1?} p999 {:>8.1?}  ({done} ops in {elapsed:.2?})",
         gib_per_s(done * len as u64, elapsed),
         done as f64 / elapsed.as_secs_f64(),
         percentile(&latencies, 0.50),
@@ -209,10 +303,7 @@ fn bench_reads(
 }
 
 fn main() {
-    let bytes: u64 = std::env::var("MOAT_BENCH_BYTES")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(4 << 30);
+    let bytes: u64 = env("MOAT_BENCH_BYTES", 4 << 30);
     let dir = tempfile::tempdir().unwrap();
     let device = match std::env::var("MOAT_BENCH_DEVICE") {
         Ok(path) => FileDevice::open(&path, true).expect("open device"),
@@ -224,30 +315,36 @@ fn main() {
         }
     };
     let device = Arc::new(device);
-    moat_engine::format(
-        &*device,
-        &FormatOptions {
-            segment_size: SEGMENT,
-            chunk_max: CHUNK_MAX,
-            disk_uuid: [7; 16],
-        },
-    )
-    .unwrap();
-    let opened = moat_engine::open(
+    let reopen = std::env::var_os("MOAT_BENCH_REOPEN").is_some();
+    if !reopen {
+        moat_engine::format(
+            &*device,
+            &FormatOptions {
+                segment_size: SEGMENT,
+                chunk_max: CHUNK_MAX,
+                disk_uuid: [7; 16],
+            },
+        )
+        .unwrap();
+    }
+    let (engine, _) = moat_engine::open(
         device,
         Options {
-            queue: queue_options(),
+            index_capacity: 4 << 20,
+            verify_reads: std::env::var_os("MOAT_BENCH_VERIFY").is_some(),
             ..Default::default()
         },
     )
     .unwrap();
-    let mut writer = opened.writer;
-    let reader = opened.reader;
-    let env =
-        |name: &str, default: u64| -> u64 { std::env::var(name).ok().and_then(|s| s.parse().ok()).unwrap_or(default) };
+    let mut q = queue();
+    let mut writer = engine.writer(&mut *q).unwrap();
     let readers = env("MOAT_BENCH_READERS", 1) as usize;
     let large = env("MOAT_BENCH_LARGE", 1 << 20) as usize;
     let small = env("MOAT_BENCH_SMALL", 4 << 10) as usize;
+    let large_inflight = env("MOAT_BENCH_LARGE_INFLIGHT", 16) as usize;
+    assert!(readers > 0 && large > 0 && small > 0 && large_inflight > 0);
+    let phases = std::env::var("MOAT_BENCH_READ_PHASES").unwrap_or_else(|_| "large,small,latency".into());
+    let phase = |name| phases.split(',').any(|p| p.trim() == name);
 
     // Budget: roughly a quarter of the device per size class so nothing
     // triggers reclaim during the measurement.
@@ -256,55 +353,72 @@ fn main() {
     let small_count = (budget / small as u64).min(2_000_000);
 
     println!(
-        "device {} GiB, segment {} MiB, chunk max {} MiB, {readers} reader thread(s), io_uring={}",
+        "device {} GiB, segment {} MiB, chunk max {} MiB, {readers} reader thread(s), io_uring={}, verify_reads={}",
         bytes >> 30,
         SEGMENT >> 20,
         CHUNK_MAX >> 20,
-        !queue_options().force_sync
+        std::env::var_os("MOAT_BENCH_SYNC").is_none(),
+        std::env::var_os("MOAT_BENCH_VERIFY").is_some()
     );
-    bench_puts(
-        &mut writer,
-        0,
-        large_count,
-        large,
-        &format!("put {} KiB (zero-copy)", large >> 10),
-    );
-    bench_puts(
-        &mut writer,
-        1 << 40,
-        small_count,
-        small,
-        &format!("put {} KiB (packed)", small >> 10),
-    );
-    bench_reads(
-        &reader,
-        readers,
-        0,
-        large_count,
-        large,
-        16,
-        large_count.min(16_384),
-        &format!("get {} KiB, 16 in flight/thread", large >> 10),
-    );
-    bench_reads(
-        &reader,
-        readers,
-        1 << 40,
-        small_count,
-        small,
-        64,
-        small_count.min(2_000_000),
-        &format!("get {} KiB, 64 in flight/thread", small >> 10),
-    );
-    bench_reads(
-        &reader,
-        1,
-        1 << 40,
-        small_count,
-        small,
-        1,
-        50_000,
-        &format!("get {} KiB, 1 in flight, 1 thread", small >> 10),
-    );
-    writer.close().unwrap();
+    if !reopen {
+        bench_puts(
+            &mut *q,
+            &mut writer,
+            0,
+            large_count,
+            large,
+            &format!("put {} KiB (includes copy)", large >> 10),
+        );
+        bench_puts(
+            &mut *q,
+            &mut writer,
+            1 << 40,
+            small_count,
+            small,
+            &format!("put {} KiB (packed)", small >> 10),
+        );
+    }
+    if phase("large") {
+        bench_reads(
+            &engine,
+            readers,
+            0,
+            large_count,
+            large,
+            large_inflight,
+            large_count.min(16_384),
+            &format!("get {} KiB, {large_inflight} in flight/thread", large >> 10),
+        );
+    }
+    let inflights: Vec<usize> = std::env::var("MOAT_BENCH_INFLIGHT")
+        .ok()
+        .map(|s| s.split(',').filter_map(|v| v.trim().parse().ok()).collect())
+        .unwrap_or_else(|| vec![64]);
+    for inflight in inflights.into_iter().filter(|_| phase("small")) {
+        bench_reads(
+            &engine,
+            readers,
+            1 << 40,
+            small_count,
+            small,
+            inflight,
+            small_count.min(2_000_000),
+            &format!("get {} KiB, {inflight} in flight/thread", small >> 10),
+        );
+    }
+    if phase("latency") {
+        bench_reads(
+            &engine,
+            1,
+            1 << 40,
+            small_count,
+            small,
+            1,
+            50_000,
+            &format!("get {} KiB, 1 in flight, 1 thread", small >> 10),
+        );
+    }
+    blocking::seal(&mut *q, &mut writer).unwrap();
+    blocking::drain(&mut *q, &mut writer).unwrap();
+    writer.detach(&mut *q);
 }

--- a/core/moat-engine/src/blocking.rs
+++ b/core/moat-engine/src/blocking.rs
@@ -1,0 +1,117 @@
+// Copyright 2026- Moat Project Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Blocking conveniences for tests and single-threaded tools.
+//!
+//! The engine itself never waits; these helpers drive a queue and a pipeline
+//! until a particular completion arrives. They are the only place where the
+//! worker loop of `engine-api.md` is spelled out inside this crate, and they
+//! are not meant for the data path of a server.
+
+use std::ops::Range;
+
+use moat_common::ChunkId;
+
+use crate::{
+    error::{Error, Result},
+    io::IoQueue,
+    reader::{ChunkData, ReadOutcome, Reader},
+    writer::{Completion, Outcome, Ticket, Writer},
+};
+
+/// Drives `q` and `w` until the completion for `ticket` arrives and returns
+/// its outcome. Other completions delivered meanwhile are appended to `others`.
+pub fn wait_with(q: &mut dyn IoQueue, w: &mut Writer, ticket: Ticket, others: &mut Vec<Completion>) -> Result<Outcome> {
+    let mut out = Vec::new();
+    loop {
+        w.poll(q, &mut out)?;
+        if let Some(pos) = out.iter().position(|c| c.ticket == ticket) {
+            let done = out.swap_remove(pos);
+            others.append(&mut out);
+            return done.result;
+        }
+        others.append(&mut out);
+        if w.in_flight() == 0 && q.in_flight() == 0 && w.is_idle() {
+            return Err(Error::InvalidOption(format!("ticket {ticket} is not pending")));
+        }
+        q.poll(true)?;
+    }
+}
+
+/// Drives `q` and `w` until the completion for `ticket` arrives and returns
+/// its outcome. Other completions delivered meanwhile are discarded.
+pub fn wait(q: &mut dyn IoQueue, w: &mut Writer, ticket: Ticket) -> Result<Outcome> {
+    let mut others = Vec::new();
+    wait_with(q, w, ticket, &mut others)
+}
+
+/// Issues a barrier and waits for it: every previous write is durable and
+/// visible afterwards. Returns the barrier's result.
+pub fn flush(q: &mut dyn IoQueue, w: &mut Writer) -> Result<()> {
+    let ticket = w.flush(q)?;
+    wait(q, w, ticket).map(|_| ())
+}
+
+/// Seals both active segments and waits for it.
+pub fn seal(q: &mut dyn IoQueue, w: &mut Writer) -> Result<()> {
+    let ticket = w.seal(q)?;
+    wait(q, w, ticket).map(|_| ())
+}
+
+/// Runs one reclaim pass to completion. `None` if there was nothing to
+/// reclaim.
+pub fn reclaim(
+    q: &mut dyn IoQueue,
+    w: &mut Writer,
+    policy: crate::writer::ReclaimPolicy,
+) -> Result<Option<crate::writer::ReclaimReport>> {
+    let Some(ticket) = w.reclaim(q, policy)? else {
+        return Ok(None);
+    };
+    match wait(q, w, ticket)? {
+        Outcome::Reclaim(report) => Ok(Some(report)),
+        other => Err(Error::InvalidOption(format!("unexpected outcome {other:?}"))),
+    }
+}
+
+/// Reads a chunk synchronously: submits, waits, returns the value (or the
+/// requested range of it).
+pub fn get(q: &mut dyn IoQueue, r: &mut Reader, id: &ChunkId, range: Option<Range<u64>>) -> Result<Option<ChunkData>> {
+    const TOKEN: u64 = u64::MAX;
+    match r.get(q, id, range, TOKEN)? {
+        ReadOutcome::Miss => return Ok(None),
+        ReadOutcome::Submitted => {}
+    }
+    let mut out = Vec::with_capacity(1);
+    loop {
+        r.poll(q, &mut out)?;
+        if let Some(pos) = out.iter().position(|c| c.token == TOKEN) {
+            return out.swap_remove(pos).result;
+        }
+        q.poll(true)?;
+    }
+}
+
+/// Polls until the writer has nothing outstanding (after `seal` this means
+/// it is safe to detach).
+pub fn drain(q: &mut dyn IoQueue, w: &mut Writer) -> Result<Vec<Completion>> {
+    let mut out = Vec::new();
+    loop {
+        w.poll(q, &mut out)?;
+        if w.is_idle() {
+            return Ok(out);
+        }
+        q.poll(true)?;
+    }
+}

--- a/core/moat-engine/src/device.rs
+++ b/core/moat-engine/src/device.rs
@@ -14,11 +14,14 @@
 
 //! The block device abstraction the engine runs on.
 //!
-//! A [`Device`] offers two things: blocking, page-aligned positional I/O for
-//! metadata (superblocks, segment headers, footers, recovery scans), and
-//! [`IoQueue`]s for the data path, one per thread. Keeping the interface this
-//! small lets the same engine run on a raw NVMe namespace, a file
-//! (development), or an in-memory buffer (tests with fault injection).
+//! A [`Device`] offers blocking, page-aligned positional I/O (used by
+//! formatting and recovery, which run before any queue exists) and, where it
+//! has one, a file descriptor for the asynchronous data path: an
+//! [`IoQueue`](crate::io::IoQueue) attaches the device through
+//! [`Device::fd`]. Keeping the interface this small lets the same engine run on
+//! a raw NVMe namespace, a file (development), or an in-memory buffer (tests
+//! with fault injection; served by the blocking
+//! [`SyncQueue`](crate::io::SyncQueue)).
 //!
 //! All offsets and lengths passed to a [`Device`] are multiples of
 //! [`PAGE_SIZE`]; implementations may rely on it. Buffers passed to a device
@@ -30,18 +33,16 @@ use std::{
     fs::{File, OpenOptions},
     io,
     ops::Range,
-    os::unix::fs::FileExt,
-    path::Path,
-    sync::{
-        Arc,
-        atomic::{AtomicBool, Ordering},
+    os::{
+        fd::{AsFd, BorrowedFd},
+        unix::fs::FileExt,
     },
+    path::Path,
+    sync::Arc,
 };
 
 use moat_common::{PAGE_SIZE, is_aligned};
 use parking_lot::{Mutex, RwLock};
-
-use crate::io::{BlockingIo, CompletionOrder, IoQueue, QueueOptions, SyncQueue};
 
 /// A block device.
 pub trait Device: Send + Sync + 'static {
@@ -60,8 +61,10 @@ pub trait Device: Send + Sync + 'static {
     /// Flushes the device's volatile write cache.
     fn sync(&self) -> io::Result<()>;
 
-    /// Opens an asynchronous queue for the calling thread.
-    fn open_queue(&self, opts: &QueueOptions) -> io::Result<Box<dyn IoQueue>>;
+    /// The file descriptor an asynchronous queue registers, if the device has
+    /// one. Devices without a descriptor can only be driven through the
+    /// blocking [`SyncQueue`](crate::io::SyncQueue).
+    fn fd(&self) -> Option<BorrowedFd<'_>>;
 }
 
 fn check_io(buf_len: usize, offset: u64, capacity: u64) -> io::Result<()> {
@@ -136,20 +139,6 @@ fn device_len(file: &File) -> io::Result<u64> {
     f.seek(SeekFrom::End(0))
 }
 
-impl BlockingIo for File {
-    fn read_at(&self, buf: &mut [u8], offset: u64) -> io::Result<()> {
-        FileExt::read_exact_at(self, buf, offset)
-    }
-
-    fn write_at(&self, buf: &[u8], offset: u64) -> io::Result<()> {
-        FileExt::write_all_at(self, buf, offset)
-    }
-
-    fn sync(&self) -> io::Result<()> {
-        self.sync_data()
-    }
-}
-
 impl Device for FileDevice {
     fn capacity(&self) -> u64 {
         self.len
@@ -169,13 +158,8 @@ impl Device for FileDevice {
         self.file.sync_data()
     }
 
-    fn open_queue(&self, opts: &QueueOptions) -> io::Result<Box<dyn IoQueue>> {
-        let file = self.file.try_clone()?;
-        #[cfg(target_os = "linux")]
-        if !opts.force_sync {
-            return Ok(Box::new(crate::uring::UringQueue::new(file, opts)?));
-        }
-        Ok(Box::new(SyncQueue::new(file, opts, CompletionOrder::Fifo)?))
+    fn fd(&self) -> Option<BorrowedFd<'_>> {
+        Some(self.file.as_fd())
     }
 }
 
@@ -187,15 +171,15 @@ struct MemState {
     data: RwLock<Vec<u8>>,
     /// Writes overlapping this range fail with `EIO`.
     fail_writes: Mutex<Option<Range<u64>>>,
-    reverse_completions: AtomicBool,
 }
 
 /// An in-memory device for tests.
 ///
 /// Besides the [`Device`] interface it exposes the raw bytes so tests can
 /// simulate torn writes, bit rot and truncated tails between an engine
-/// shutdown and the next open, plus knobs to fail writes in a byte range and
-/// to deliver queue completions out of order.
+/// shutdown and the next open, plus a knob to fail writes in a byte range.
+/// It has no file descriptor, so it is driven through a
+/// [`SyncQueue`](crate::io::SyncQueue).
 pub struct MemDevice {
     state: Arc<MemState>,
 }
@@ -208,7 +192,6 @@ impl MemDevice {
             state: Arc::new(MemState {
                 data: RwLock::new(vec![0; len as usize]),
                 fail_writes: Mutex::new(None),
-                reverse_completions: AtomicBool::new(false),
             }),
         }
     }
@@ -226,11 +209,6 @@ impl MemDevice {
     /// Makes every write that overlaps `range` fail with `EIO` (`None` clears).
     pub fn fail_writes_in(&self, range: Option<Range<u64>>) {
         *self.state.fail_writes.lock() = range;
-    }
-
-    /// Makes queues opened afterwards report completions in reverse order.
-    pub fn set_reverse_completions(&self, reverse: bool) {
-        self.state.reverse_completions.store(reverse, Ordering::Relaxed);
     }
 }
 
@@ -258,20 +236,6 @@ impl MemState {
     }
 }
 
-impl BlockingIo for Arc<MemState> {
-    fn read_at(&self, buf: &mut [u8], offset: u64) -> io::Result<()> {
-        MemState::read_at(self, buf, offset)
-    }
-
-    fn write_at(&self, buf: &[u8], offset: u64) -> io::Result<()> {
-        MemState::write_at(self, buf, offset)
-    }
-
-    fn sync(&self) -> io::Result<()> {
-        Ok(())
-    }
-}
-
 impl Device for MemDevice {
     fn capacity(&self) -> u64 {
         self.state.data.read().len() as u64
@@ -289,13 +253,8 @@ impl Device for MemDevice {
         Ok(())
     }
 
-    fn open_queue(&self, opts: &QueueOptions) -> io::Result<Box<dyn IoQueue>> {
-        let order = if self.state.reverse_completions.load(Ordering::Relaxed) {
-            CompletionOrder::Reverse
-        } else {
-            CompletionOrder::Fifo
-        };
-        Ok(Box::new(SyncQueue::new(self.state.clone(), opts, order)?))
+    fn fd(&self) -> Option<BorrowedFd<'_>> {
+        None
     }
 }
 

--- a/core/moat-engine/src/device.rs
+++ b/core/moat-engine/src/device.rs
@@ -38,7 +38,6 @@ use std::{
         unix::fs::FileExt,
     },
     path::Path,
-    sync::Arc,
 };
 
 use moat_common::{PAGE_SIZE, is_aligned};
@@ -167,12 +166,6 @@ impl Device for FileDevice {
 // MemDevice
 // ---------------------------------------------------------------------------
 
-struct MemState {
-    data: RwLock<Vec<u8>>,
-    /// Writes overlapping this range fail with `EIO`.
-    fail_writes: Mutex<Option<Range<u64>>>,
-}
-
 /// An in-memory device for tests.
 ///
 /// Besides the [`Device`] interface it exposes the raw bytes so tests can
@@ -181,7 +174,9 @@ struct MemState {
 /// It has no file descriptor, so it is driven through a
 /// [`SyncQueue`](crate::io::SyncQueue).
 pub struct MemDevice {
-    state: Arc<MemState>,
+    data: RwLock<Vec<u8>>,
+    /// Writes overlapping this range fail with `EIO`.
+    fail_writes: Mutex<Option<Range<u64>>>,
 }
 
 impl MemDevice {
@@ -189,30 +184,32 @@ impl MemDevice {
     pub fn new(len: u64) -> Self {
         assert!(is_aligned(len, PAGE_SIZE), "device length must be page aligned");
         Self {
-            state: Arc::new(MemState {
-                data: RwLock::new(vec![0; len as usize]),
-                fail_writes: Mutex::new(None),
-            }),
+            data: RwLock::new(vec![0; len as usize]),
+            fail_writes: Mutex::new(None),
         }
     }
 
     /// Runs `f` with mutable access to the raw device contents.
     pub fn with_data_mut<R>(&self, f: impl FnOnce(&mut [u8]) -> R) -> R {
-        f(&mut self.state.data.write())
+        f(&mut self.data.write())
     }
 
     /// Runs `f` with read access to the raw device contents.
     pub fn with_data<R>(&self, f: impl FnOnce(&[u8]) -> R) -> R {
-        f(&self.state.data.read())
+        f(&self.data.read())
     }
 
     /// Makes every write that overlaps `range` fail with `EIO` (`None` clears).
     pub fn fail_writes_in(&self, range: Option<Range<u64>>) {
-        *self.state.fail_writes.lock() = range;
+        *self.fail_writes.lock() = range;
     }
 }
 
-impl MemState {
+impl Device for MemDevice {
+    fn capacity(&self) -> u64 {
+        self.data.read().len() as u64
+    }
+
     fn read_at(&self, buf: &mut [u8], offset: u64) -> io::Result<()> {
         let data = self.data.read();
         check_io(buf.len(), offset, data.len() as u64)?;
@@ -233,20 +230,6 @@ impl MemState {
         let start = offset as usize;
         data[start..start + buf.len()].copy_from_slice(buf);
         Ok(())
-    }
-}
-
-impl Device for MemDevice {
-    fn capacity(&self) -> u64 {
-        self.state.data.read().len() as u64
-    }
-
-    fn read_at(&self, buf: &mut [u8], offset: u64) -> io::Result<()> {
-        self.state.read_at(buf, offset)
-    }
-
-    fn write_at(&self, buf: &[u8], offset: u64) -> io::Result<()> {
-        self.state.write_at(buf, offset)
     }
 
     fn sync(&self) -> io::Result<()> {

--- a/core/moat-engine/src/engine.rs
+++ b/core/moat-engine/src/engine.rs
@@ -12,26 +12,34 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Formatting and opening (recovery).
+//! Formatting, opening (recovery) and the per-disk [`Engine`] handle.
 
-use std::{collections::VecDeque, ops::ControlFlow, sync::Arc};
+use std::{
+    ops::ControlFlow,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicU64, Ordering},
+    },
+};
 
-use moat_common::{AlignedBuf, PAGE_SIZE};
+use moat_common::{AlignedBuf, ChunkId, PAGE_SIZE};
 
 use crate::{
     device::Device,
     error::{Error, Result},
-    index::{FLAG_DEAD, Index, IndexValue, Location, flags_from_record},
+    index::{FLAG_DEAD, Index, IndexValue, IndexWriter, Location, flags_from_record},
+    io::IoQueue,
     layout::{
         Extent, FooterEntry, RecordGeometry, RecordKind, SEGMENT_HEADER_LEN, SUPERBLOCK_A_OFFSET, SUPERBLOCK_B_OFFSET,
-        SUPERBLOCK_LEN, SegmentHeader, SegmentKind, SegmentState, Superblock, decode_footer, large_batch_len,
+        SUPERBLOCK_LEN, SegmentHeader, SegmentKind, SegmentState, Superblock, decode_footer, encode_footer, footer_len,
+        large_batch_len,
     },
     options::{Clock, FormatOptions, Options, SystemClock},
     reader::Reader,
     scan::{parse_batch, scan_batches_blocking},
     segments::{Geometry, SegmentTable},
     shared::Shared,
-    writer::{Writer, seal_segment},
+    writer::{Lsn, Writer},
 };
 
 /// Formats `device`, destroying any previous contents.
@@ -101,24 +109,201 @@ pub struct RecoveryReport {
     pub next_lsn: u64,
 }
 
-/// An opened engine.
-pub struct Opened {
-    /// The single writer.
-    pub writer: Writer,
-    /// A reader handle; clone it freely.
-    pub reader: Reader,
-    /// What recovery did.
-    pub report: RecoveryReport,
+/// Metadata about a stored chunk.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ChunkStat {
+    /// Value length in bytes.
+    pub len: u32,
+    /// LSN of the newest record.
+    pub lsn: Lsn,
+    /// Physical segment holding the record.
+    pub segment: u32,
+    /// Offset of the value within the segment.
+    pub value_offset: u32,
+    /// Whether the record is stored framed (header apart from the page
+    /// aligned value).
+    pub framed: bool,
+}
+
+impl ChunkStat {
+    pub(crate) fn from_value(v: &IndexValue) -> Self {
+        Self {
+            len: v.value_len,
+            lsn: v.lsn,
+            segment: v.loc.seg_no,
+            value_offset: v.value_off,
+            framed: v.is_framed(),
+        }
+    }
+}
+
+/// Space usage of an engine.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Usage {
+    /// Total number of segments.
+    pub segments: u32,
+    /// Segments not in use.
+    pub free_segments: u32,
+    /// Segments closed and eligible for reclaim.
+    pub sealed_segments: u32,
+    /// Bytes of records the index points at, across all segments.
+    pub live_bytes: u64,
+    /// Number of chunks in the index.
+    pub chunks: usize,
+    /// Bytes the index table occupies.
+    pub index_bytes: usize,
+}
+
+/// One disk: the state every pipeline of the disk shares (index, segment
+/// table, superblock, options). Cheap to clone, `Send + Sync`, and does no
+/// I/O itself; create a [`Writer`] or [`Reader`] on a queue to move data.
+#[derive(Clone)]
+pub struct Engine {
+    shared: Arc<Shared>,
+}
+
+impl Engine {
+    /// Returns metadata about a chunk without touching the disk.
+    ///
+    /// Expiry is not evaluated here; an expired chunk still reports its stat
+    /// until reclaim drops it. Management path: a thread that reads regularly
+    /// should use [`Reader::stat`] instead.
+    pub fn stat(&self, id: &ChunkId) -> Option<ChunkStat> {
+        self.shared
+            .index
+            .get_unregistered(id)
+            .map(|v| ChunkStat::from_value(&v))
+    }
+
+    /// Whether a chunk exists in the index.
+    pub fn contains(&self, id: &ChunkId) -> bool {
+        self.stat(id).is_some()
+    }
+
+    /// Current space usage.
+    pub fn usage(&self) -> Usage {
+        let segments = &self.shared.segments;
+        let mut usage = Usage {
+            segments: segments.len(),
+            free_segments: 0,
+            sealed_segments: 0,
+            live_bytes: 0,
+            chunks: self.shared.index.len(),
+            index_bytes: self.shared.index.table_bytes(),
+        };
+        for s in segments.iter() {
+            match segments.state(s) {
+                SegmentState::Free => usage.free_segments += 1,
+                SegmentState::Sealed => usage.sealed_segments += 1,
+                SegmentState::Active => {}
+            }
+            usage.live_bytes += segments.live_bytes(s);
+        }
+        usage
+    }
+
+    /// The segment size this device was formatted with.
+    pub fn segment_size(&self) -> u64 {
+        self.shared.superblock.segment_size
+    }
+
+    /// The largest value this device accepts.
+    pub fn chunk_max(&self) -> u32 {
+        self.shared.superblock.chunk_max
+    }
+
+    /// The device's identity as recorded in the superblock.
+    pub fn disk_uuid(&self) -> [u8; 16] {
+        self.shared.superblock.disk_uuid
+    }
+
+    /// The device capacity in bytes.
+    pub fn capacity(&self) -> u64 {
+        self.shared.device.capacity()
+    }
+
+    /// The disk's single write pipeline, attached to `q`.
+    ///
+    /// Fails with [`Error::InvalidOption`] if `q`'s pool cannot hold the
+    /// largest buffer the writer will request, and with [`Error::Busy`] if a
+    /// writer already exists (call [`Writer::detach`] first).
+    pub fn writer(&self, q: &mut dyn IoQueue) -> Result<Writer> {
+        self.check_pool(q)?;
+        if self.shared.writer_taken.swap(true, Ordering::AcqRel) {
+            return Err(Error::Busy);
+        }
+        let desc = match q.attach(&self.shared.device) {
+            Ok(desc) => desc,
+            Err(e) => {
+                self.shared.writer_taken.store(false, Ordering::Release);
+                return Err(Error::Io(e));
+            }
+        };
+        Ok(Writer::new(self.shared.clone(), desc))
+    }
+
+    /// A read pipeline for the calling thread, attached to `q`. Any number may
+    /// exist.
+    pub fn reader(&self, q: &mut dyn IoQueue) -> Result<Reader> {
+        self.check_pool(q)?;
+        let slot = self
+            .shared
+            .index
+            .register()
+            .ok_or_else(|| Error::InvalidOption("too many readers registered on this engine".into()))?;
+        let desc = match q.attach(&self.shared.device) {
+            Ok(desc) => desc,
+            Err(e) => {
+                self.shared.index.unregister(slot);
+                return Err(Error::Io(e));
+            }
+        };
+        Ok(Reader::new(self.shared.clone(), desc, slot))
+    }
+
+    /// The pool must hold a maximal batch and a staging batch.
+    fn check_pool(&self, q: &dyn IoQueue) -> Result<()> {
+        let needed = self.shared.largest_buffer();
+        if q.pool().max_class() < needed {
+            return Err(Error::InvalidOption(format!(
+                "queue pool max class {} is below the {needed} bytes this engine needs",
+                q.pool().max_class()
+            )));
+        }
+        Ok(())
+    }
+}
+
+impl std::fmt::Debug for Engine {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Engine")
+            .field("disk_uuid", &self.shared.superblock.disk_uuid)
+            .field("segments", &self.shared.geometry.segment_count)
+            .field("chunks", &self.shared.index.len())
+            .finish()
+    }
+}
+
+impl Shared {
+    /// Largest pool buffer any pipeline of this engine needs: a maximal large
+    /// batch or a staging batch (the reclaim window shrinks to the pool if it
+    /// has to).
+    pub(crate) fn largest_buffer(&self) -> usize {
+        let largest = large_batch_len(self.superblock.chunk_max) as usize;
+        largest.max(self.options.batch_limit).next_power_of_two()
+    }
 }
 
 /// Opens a formatted device, rebuilding the in-memory index.
 ///
-/// Sealed segments are indexed from their footers; segments left active by a
-/// crash are scanned forward, verified record by record, and sealed. Every key
-/// resolves to its highest-LSN record, and keys whose newest record is a
-/// tombstone are dropped. The cost is proportional to the number of records
-/// on the device, not its capacity.
-pub fn open(device: Arc<dyn Device>, mut options: Options) -> Result<Opened> {
+/// Blocking, and touches no queue: it runs before the engine is attached to
+/// any worker, once per process start, and disks recover in parallel by
+/// calling it on several threads. Sealed segments are indexed from their
+/// footers; segments left active by a crash are scanned forward, verified
+/// record by record, and sealed. Every key resolves to its highest-LSN record,
+/// and keys whose newest record is a tombstone are dropped. The cost is
+/// proportional to the number of records on the device, not its capacity.
+pub fn open(device: Arc<dyn Device>, mut options: Options) -> Result<(Engine, RecoveryReport)> {
     options.validate()?;
     let superblock = read_superblock(&*device)?;
     // A pending batch must always fit in a fresh segment together with the
@@ -131,18 +316,6 @@ pub fn open(device: Arc<dyn Device>, mut options: Options) -> Result<Opened> {
         .next_power_of_two()
         .max(2 * PAGE_SIZE as usize);
     options.pack_threshold = options.pack_threshold.min((options.batch_limit / 2) as u32);
-    // The writer's pool must be able to hold a maximal batch, a staging batch
-    // and a scan window.
-    let largest = large_batch_len(superblock.chunk_max) as usize;
-    let needed = largest
-        .max(options.batch_limit)
-        .max(options.scan_window)
-        .next_power_of_two();
-    options.queue.pool.max_class = options.queue.pool.max_class.max(needed);
-    let minimum_pool_bytes = needed
-        .checked_mul(options.writer_pool_capacity_multiplier)
-        .ok_or_else(|| Error::InvalidOption("writer pool capacity exceeds addressable memory".into()))?;
-    options.queue.pool.bytes = options.queue.pool.bytes.max(minimum_pool_bytes);
     let geometry = Geometry::for_device(device.capacity(), superblock.segment_size);
     if geometry.segment_count < superblock.segment_count {
         return Err(Error::Unformatted(format!(
@@ -157,18 +330,21 @@ pub fn open(device: Arc<dyn Device>, mut options: Options) -> Result<Opened> {
 
     let shared = Arc::new(Shared {
         device,
-        index: Index::new(options.index_shards),
+        index: Arc::new(Index::new(options.index_capacity, options.index_memory_budget)),
         segments: SegmentTable::new(geometry.segment_count),
         geometry,
         superblock,
         options,
+        writer_taken: AtomicBool::new(false),
+        next_lsn: AtomicU64::new(1),
+        next_seq: AtomicU64::new(1),
     });
+    let mut index = IndexWriter::new(shared.index.clone());
 
     let mut report = RecoveryReport {
         segments: geometry.segment_count,
         ..Default::default()
     };
-    let mut free = Vec::new();
     let mut actives: Vec<(SegmentHeader, u64, Vec<FooterEntry>)> = Vec::new();
     let mut max_seq = 0u64;
     let mut max_lsn = 0u64;
@@ -178,13 +354,11 @@ pub fn open(device: Arc<dyn Device>, mut options: Options) -> Result<Opened> {
             Ok(h) if h.disk_uuid == shared.superblock.disk_uuid && h.seg_no == seg_no => h,
             _ => {
                 report.unreadable_headers += 1;
-                free.push(seg_no);
                 continue;
             }
         };
         max_seq = max_seq.max(header.seq);
         if header.state == SegmentState::Free {
-            free.push(seg_no);
             continue;
         }
         shared.segments.set(seg_no, header.state, header.kind, header.seq);
@@ -213,10 +387,11 @@ pub fn open(device: Arc<dyn Device>, mut options: Options) -> Result<Opened> {
         match footer_entries {
             Some(entries) => {
                 report.sealed += 1;
+                shared.segments.set_sealed(seg_no, header.footer_offset);
                 for entry in entries {
                     report.records += 1;
                     max_lsn = max_lsn.max(entry.lsn);
-                    merge_entry(&shared.index, seg_no, &entry);
+                    merge_entry(&mut index, seg_no, &entry)?;
                 }
             }
             None => {
@@ -225,19 +400,24 @@ pub fn open(device: Arc<dyn Device>, mut options: Options) -> Result<Opened> {
                 for entry in &entries {
                     report.records += 1;
                     max_lsn = max_lsn.max(entry.lsn);
-                    merge_entry(&shared.index, seg_no, entry);
+                    merge_entry(&mut index, seg_no, entry)?;
                 }
                 actives.push((header, tail, entries));
             }
         }
     }
 
-    // Keys whose newest record is a tombstone are gone.
-    shared.index.retain(|_, v| v.flags & FLAG_DEAD == 0);
+    // Keys whose newest record is a tombstone are gone; the rebuild drops the
+    // tombstone slots they leave behind.
+    index.retain(|_, v| v.flags & FLAG_DEAD == 0);
+    if index.tombstones() > 0 {
+        let capacity = shared.index.capacity();
+        index.rebuild(capacity);
+    }
 
     // Live bytes follow from the final index, not from the order records
     // were merged in.
-    shared.index.for_each(|_, v| {
+    index.for_each(|_, v| {
         shared
             .segments
             .add_live(v.loc.seg_no, RecordGeometry::footprint(v.value_len, v.record_flags()));
@@ -246,16 +426,15 @@ pub fn open(device: Arc<dyn Device>, mut options: Options) -> Result<Opened> {
     // Seal whatever was active so the tail is described by a footer and the
     // writer starts on fresh segments.
     for (header, tail, entries) in actives {
-        seal_segment(&shared, header.seg_no, header.seq, header.kind, tail, &entries)?;
+        seal_segment_blocking(&shared, header.seg_no, header.seq, header.kind, tail, &entries)?;
     }
 
     report.chunks = shared.index.len();
     report.next_lsn = max_lsn + 1;
-    free.sort_unstable();
-    let queue = shared.device.open_queue(&shared.options.queue)?;
-    let writer = Writer::new(shared.clone(), queue, VecDeque::from(free), max_seq + 1, max_lsn + 1);
-    let reader = Reader::new(shared);
-    Ok(Opened { writer, reader, report })
+    drop(index);
+    shared.next_lsn.store(max_lsn + 1, Ordering::Release);
+    shared.next_seq.store(max_seq + 1, Ordering::Release);
+    Ok((Engine { shared }, report))
 }
 
 /// Scans a segment forward, verifying every record, and returns the offset at
@@ -296,12 +475,12 @@ fn scan_segment(shared: &Shared, seg_no: u32, seq: u64) -> Result<(u64, Vec<Foot
 
 /// Merges one recovered record into the index: highest LSN wins, tombstones
 /// are kept as dead markers until every record has been seen.
-fn merge_entry(index: &Index, seg_no: u32, entry: &FooterEntry) {
+fn merge_entry(index: &mut IndexWriter, seg_no: u32, entry: &FooterEntry) -> Result<()> {
     let mut flags = flags_from_record(entry.flags);
     if entry.kind == RecordKind::Tombstone {
         flags |= FLAG_DEAD;
     }
-    index.insert_if_newer(
+    let outcome = index.insert_if_newer(
         entry.key,
         IndexValue {
             loc: Location {
@@ -311,10 +490,37 @@ fn merge_entry(index: &Index, seg_no: u32, entry: &FooterEntry) {
             value_off: entry.value_off,
             value_len: entry.value_len,
             flags,
-            crc: entry.crc,
             lsn: entry.lsn,
         },
     );
+    if outcome == crate::index::InsertOutcome::Full {
+        return Err(Error::IndexFull);
+    }
+    Ok(())
+}
+
+/// Writes a footer at `tail` and marks the segment sealed (blocking; recovery
+/// only — the writer seals asynchronously through its queue).
+pub(crate) fn seal_segment_blocking(
+    shared: &Shared,
+    seg_no: u32,
+    seq: u64,
+    kind: SegmentKind,
+    tail: u64,
+    footer: &[FooterEntry],
+) -> Result<()> {
+    let len = footer_len(footer.len());
+    let mut buf = AlignedBuf::zeroed(len as usize);
+    encode_footer(seq, footer, &mut buf);
+    shared.write_segment_bytes(seg_no, tail, &buf)?;
+    shared.write_segment_header(&SegmentHeader {
+        footer_offset: tail,
+        footer_len: len,
+        record_count: footer.len() as u64,
+        ..shared.segment_header(seg_no, SegmentState::Sealed, kind, seq)
+    })?;
+    shared.segments.set_sealed(seg_no, tail);
+    Ok(())
 }
 
 fn read_superblock(device: &dyn Device) -> Result<Superblock> {

--- a/core/moat-engine/src/error.rs
+++ b/core/moat-engine/src/error.rs
@@ -37,9 +37,15 @@ pub enum Error {
     #[error("no free segment available")]
     NoSpace,
 
-    /// No I/O buffer or queue slot is available right now and nothing is in
-    /// flight that could free one. Retry after releasing buffers.
-    #[error("no i/o buffer or queue slot available")]
+    /// The index has reached its memory budget; no new chunk can be added
+    /// until others are deleted or reclaimed.
+    #[error("index memory budget exhausted")]
+    IndexFull,
+
+    /// The buffer pool has no buffer of the requested class right now (or the
+    /// resource asked for already exists: a second writer, a running reclaim
+    /// pass). Poll to return buffers and retry.
+    #[error("resource busy: no buffer available or the operation is already running")]
     Busy,
 
     /// The value exceeds the chunk size limit recorded in the superblock.

--- a/core/moat-engine/src/index.rs
+++ b/core/moat-engine/src/index.rs
@@ -411,17 +411,12 @@ pub struct Index {
     current: std::sync::atomic::AtomicPtr<Table>,
     epochs: Box<[Epoch]>,
     live: AtomicUsize,
+    /// Read without dereferencing a table that the writer may retire.
+    capacity: AtomicUsize,
     tombstones: AtomicUsize,
     /// Maximum table bytes; growth beyond it reports the table full.
     budget: usize,
 }
-
-// SAFETY: the table pointer is only replaced by the single writer, which
-// retires the old table through the epoch protocol; readers only perform
-// atomic loads.
-unsafe impl Send for Index {}
-// SAFETY: as above.
-unsafe impl Sync for Index {}
 
 impl Index {
     /// Creates an empty index with room for `capacity` slots (rounded up to a
@@ -429,6 +424,7 @@ impl Index {
     pub fn new(capacity: usize, budget: usize) -> Self {
         let table = Box::new(Table::new(capacity));
         Self {
+            capacity: AtomicUsize::new(table.capacity()),
             current: std::sync::atomic::AtomicPtr::new(Box::into_raw(table)),
             epochs: (0..MAX_READERS).map(|_| Epoch(AtomicU64::new(0))).collect(),
             live: AtomicUsize::new(0),
@@ -493,25 +489,37 @@ impl Index {
     ///
     /// The caller must unpin the segment once it has finished reading.
     pub fn get_and_pin(&self, slot: &ReaderSlot, id: &ChunkId, segments: &SegmentTable) -> Option<IndexValue> {
-        let table = self.enter(slot);
+        let mut table = self.enter(slot);
         let result = loop {
             let Some((i, seq, value)) = table.find(id) else {
                 break None;
             };
-            segments.pin(value.loc.seg_no);
-            // Pin before re-reading the sequence number; reclaim removes the
-            // entry before it looks at the pin count.
-            fence(Ordering::SeqCst);
-            if table.slots[i].seq.load(Ordering::Relaxed) == seq {
-                if value.flags & FLAG_ACCESSED == 0 {
-                    table.slots[i].flags.fetch_or(FLAG_ACCESSED, Ordering::Relaxed);
-                }
+            if self.try_pin(table, i, seq, value, segments) {
                 break Some(value);
             }
-            segments.unpin(value.loc.seg_no);
+            table = self.table();
         };
         self.exit(slot);
         result
+    }
+
+    /// Validates both the table and the slot after pinning. A retired table
+    /// no longer observes removals made by reclaim in its replacement.
+    fn try_pin(&self, table: &Table, i: usize, seq: u32, value: IndexValue, segments: &SegmentTable) -> bool {
+        segments.pin(value.loc.seg_no);
+        // Reclaim removes entries before checking pins; rebuild publishes the
+        // replacement before reclaim can remove entries from it.
+        fence(Ordering::SeqCst);
+        if std::ptr::eq(table, self.current.load(Ordering::Acquire))
+            && table.slots[i].seq.load(Ordering::Relaxed) == seq
+        {
+            if value.flags & FLAG_ACCESSED == 0 {
+                table.slots[i].flags.fetch_or(FLAG_ACCESSED, Ordering::Relaxed);
+            }
+            return true;
+        }
+        segments.unpin(value.loc.seg_no);
+        false
     }
 
     /// Looks a chunk up from a thread without a registered slot (management
@@ -530,7 +538,7 @@ impl Index {
 
     /// Number of slots in the current table.
     pub fn capacity(&self) -> usize {
-        self.table().capacity()
+        self.capacity.load(Ordering::Relaxed)
     }
 
     /// Bytes the current table occupies.
@@ -755,6 +763,7 @@ impl IndexWriter {
             }
         }
         self.index.tombstones.store(0, Ordering::Relaxed);
+        self.index.capacity.store(new.capacity(), Ordering::Relaxed);
         let old_ptr = self.index.current.swap(Box::into_raw(new), Ordering::AcqRel);
         // Readers store an odd epoch, fence, then load the table pointer.
         // After this fence, any reader we observe outside a lookup will load
@@ -837,6 +846,45 @@ mod tests {
             flags: 0,
             lsn,
         }
+    }
+
+    #[test]
+    fn a_retired_table_cannot_pin_an_entry_removed_after_rebuild() {
+        let index = Arc::new(Index::new(16, usize::MAX));
+        let mut writer = IndexWriter::new(index.clone());
+        let key = ChunkId::from_u128(1);
+        writer.insert_if_newer(key, value(0, 4096, 1));
+        let slot = index.register().unwrap();
+        let table = index.enter(&slot);
+        let (i, seq, value) = table.find(&key).unwrap();
+        writer.rebuild(32);
+        writer.remove(&key).unwrap();
+        let segments = SegmentTable::new(1);
+        assert!(!index.try_pin(table, i, seq, value, &segments));
+        assert_eq!(segments.pins(0), 0);
+        index.exit(&slot);
+        assert_eq!(index.get_and_pin(&slot, &key, &segments), None);
+        index.unregister(slot);
+        writer.gc();
+        assert_eq!(writer.retired(), 0);
+    }
+
+    #[test]
+    fn capacity_is_safe_to_read_during_rebuild_and_retirement() {
+        let index = Arc::new(Index::new(16, usize::MAX));
+        let mut writer = IndexWriter::new(index.clone());
+        std::thread::scope(|scope| {
+            scope.spawn(|| {
+                for _ in 0..10_000 {
+                    assert!(matches!(index.capacity(), 16 | 32));
+                    assert!(matches!(index.table_bytes(), 1024 | 2048));
+                }
+            });
+            for _ in 0..1_000 {
+                writer.rebuild(32);
+                writer.rebuild(16);
+            }
+        });
     }
 
     #[test]

--- a/core/moat-engine/src/index.rs
+++ b/core/moat-engine/src/index.rs
@@ -12,24 +12,37 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! The in-memory chunk index.
+//! The in-memory chunk index: one open-addressing hash table per disk, with a
+//! single writer and any number of lock-free readers.
 //!
-//! One sharded hash table per disk, mapping [`ChunkId`] to the location of the
-//! newest record. Readers only look entries up; every mutation is performed by
-//! the disk's single writer. Shard mutexes therefore see negligible contention
-//! and are held only for memory operations.
+//! Every slot is 64 bytes (one cache line) and carries a sequence number that
+//! works as a seqlock: the writer bumps it to odd, stores the fields, bumps it
+//! to even; a reader retries a slot whose number was odd or changed under it.
+//! Readers therefore never block and never observe a torn entry. Removal
+//! leaves a tombstone in the slot (entries are never shifted, so a probe
+//! sequence a reader is walking stays valid); the writer rebuilds the table
+//! when live entries plus tombstones exceed the load limit, publishing the new
+//! table with one pointer store and retiring the old one once every reader
+//! that might still be inside it has left.
 //!
-//! The index is the *only* structure shared between the writer and readers,
-//! and the segment pin protocol ([`Index::get_and_pin`]) is anchored on its
-//! shard lock: a reader pins the segment inside the same critical section that
-//! looks the entry up, and reclaim removes entries under the same lock before
-//! waiting for pins to drain. A reader can therefore never observe a segment
-//! that reclaim has already freed.
+//! Mutation goes through [`IndexWriter`], of which exactly one exists per
+//! engine (created by the disk's single [`Writer`](crate::Writer), or
+//! temporarily by recovery). Reads go through [`Index`], which every thread
+//! shares. A thread that reads registers a [`ReaderSlot`], the epoch counter the
+//! writer consults before freeing a retired table.
+//!
+//! The segment pin protocol is anchored here as well: a reader pins the
+//! segment an entry points at and then re-checks the slot's sequence number
+//! ([`Index::get_and_pin`]). Reclaim removes entries first and only then waits
+//! for pins to drain, so a reader whose pin is visible to reclaim also saw the
+//! entry before its removal and never observes a reused segment.
 
-use std::collections::HashMap;
+use std::sync::{
+    Arc,
+    atomic::{AtomicU32, AtomicU64, AtomicUsize, Ordering, fence},
+};
 
-use moat_common::{ChunkId, chunk_id::ChunkIdHashBuilder};
-use parking_lot::Mutex;
+use moat_common::ChunkId;
 
 use crate::segments::SegmentTable;
 
@@ -71,8 +84,8 @@ pub struct Location {
     pub offset: u32,
 }
 
-/// What the index knows about the newest record of a chunk: enough to read
-/// and verify a single-block value without touching its header.
+/// What the index knows about the newest record of a chunk: its location,
+/// layout and version.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct IndexValue {
     /// Where the record header is.
@@ -83,8 +96,6 @@ pub struct IndexValue {
     pub value_len: u32,
     /// `FLAG_*` bits.
     pub flags: u32,
-    /// CRC32C of the value's first checksum block.
-    pub crc: u32,
     /// The record's LSN.
     pub lsn: u64,
 }
@@ -133,7 +144,7 @@ impl IndexValue {
     }
 }
 
-/// Result of [`Index::insert_if_newer`].
+/// Result of [`IndexWriter::insert_if_newer`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InsertOutcome {
     /// No entry existed; the value was inserted.
@@ -142,50 +153,456 @@ pub enum InsertOutcome {
     Replaced(IndexValue),
     /// The existing entry is at least as new; nothing changed.
     Rejected,
+    /// The table is at its memory budget; nothing changed.
+    Full,
 }
 
-type Shard = Mutex<HashMap<ChunkId, IndexValue, ChunkIdHashBuilder>>;
+// ---------------------------------------------------------------------------
+// Slots and tables
+// ---------------------------------------------------------------------------
 
-/// The sharded chunk index of one disk.
-pub struct Index {
-    shards: Box<[Shard]>,
-    mask: u64,
+const EMPTY: u32 = 0;
+const LIVE: u32 = 1;
+const TOMBSTONE: u32 = 2;
+
+/// One cache line: a seqlock and the entry it protects.
+#[repr(C, align(64))]
+struct Slot {
+    seq: AtomicU32,
+    state: AtomicU32,
+    key_lo: AtomicU64,
+    key_hi: AtomicU64,
+    seg_no: AtomicU32,
+    offset: AtomicU32,
+    value_off: AtomicU32,
+    value_len: AtomicU32,
+    flags: AtomicU32,
+    lsn: AtomicU64,
 }
 
-impl Index {
-    /// Creates an empty index with `shard_count` shards (rounded up to a power
-    /// of two).
-    pub fn new(shard_count: usize) -> Self {
-        let n = shard_count.max(1).next_power_of_two();
-        let shards = (0..n).map(|_| Mutex::new(HashMap::default())).collect();
+/// Size of one slot in bytes.
+pub const SLOT_BYTES: usize = std::mem::size_of::<Slot>();
+
+/// A snapshot of a slot's contents, read under its seqlock.
+#[derive(Clone, Copy)]
+struct Snapshot {
+    state: u32,
+    key: ChunkId,
+    value: IndexValue,
+}
+
+impl Slot {
+    const fn new() -> Self {
         Self {
-            shards,
-            mask: n as u64 - 1,
+            seq: AtomicU32::new(0),
+            state: AtomicU32::new(EMPTY),
+            key_lo: AtomicU64::new(0),
+            key_hi: AtomicU64::new(0),
+            seg_no: AtomicU32::new(0),
+            offset: AtomicU32::new(0),
+            value_off: AtomicU32::new(0),
+            value_len: AtomicU32::new(0),
+            flags: AtomicU32::new(0),
+            lsn: AtomicU64::new(0),
+        }
+    }
+
+    /// Reads the slot consistently; spins while the writer is mid-update.
+    /// Returns the sequence number the snapshot is valid for.
+    #[inline]
+    fn read(&self) -> (u32, Snapshot) {
+        loop {
+            let s1 = self.seq.load(Ordering::Acquire);
+            if s1 & 1 != 0 {
+                std::hint::spin_loop();
+                continue;
+            }
+            let snapshot = Snapshot {
+                state: self.state.load(Ordering::Relaxed),
+                key: key_from(self.key_lo.load(Ordering::Relaxed), self.key_hi.load(Ordering::Relaxed)),
+                value: IndexValue {
+                    loc: Location {
+                        seg_no: self.seg_no.load(Ordering::Relaxed),
+                        offset: self.offset.load(Ordering::Relaxed),
+                    },
+                    value_off: self.value_off.load(Ordering::Relaxed),
+                    value_len: self.value_len.load(Ordering::Relaxed),
+                    flags: self.flags.load(Ordering::Relaxed),
+                    lsn: self.lsn.load(Ordering::Relaxed),
+                },
+            };
+            fence(Ordering::Acquire);
+            if self.seq.load(Ordering::Relaxed) == s1 {
+                return (s1, snapshot);
+            }
+        }
+    }
+
+    /// Writer only: publishes `state`/`key`/`value` under the seqlock.
+    fn write(&self, state: u32, key: &ChunkId, value: &IndexValue) {
+        let s = self.seq.load(Ordering::Relaxed);
+        self.seq.store(s.wrapping_add(1), Ordering::Relaxed);
+        fence(Ordering::Release);
+        let (lo, hi) = key_parts(key);
+        self.key_lo.store(lo, Ordering::Relaxed);
+        self.key_hi.store(hi, Ordering::Relaxed);
+        self.seg_no.store(value.loc.seg_no, Ordering::Relaxed);
+        self.offset.store(value.loc.offset, Ordering::Relaxed);
+        self.value_off.store(value.value_off, Ordering::Relaxed);
+        self.value_len.store(value.value_len, Ordering::Relaxed);
+        self.flags.store(value.flags, Ordering::Relaxed);
+        self.lsn.store(value.lsn, Ordering::Relaxed);
+        self.state.store(state, Ordering::Relaxed);
+        self.seq.store(s.wrapping_add(2), Ordering::Release);
+    }
+
+    /// Writer only: marks the slot as a tombstone (the key stays readable so a
+    /// concurrent reader that matched it re-checks and moves on).
+    fn bury(&self) {
+        let s = self.seq.load(Ordering::Relaxed);
+        self.seq.store(s.wrapping_add(1), Ordering::Relaxed);
+        fence(Ordering::Release);
+        self.state.store(TOMBSTONE, Ordering::Relaxed);
+        self.seq.store(s.wrapping_add(2), Ordering::Release);
+    }
+}
+
+#[inline]
+fn key_parts(key: &ChunkId) -> (u64, u64) {
+    let b = key.as_bytes();
+    (
+        u64::from_le_bytes(b[..8].try_into().expect("8 bytes")),
+        u64::from_le_bytes(b[8..].try_into().expect("8 bytes")),
+    )
+}
+
+#[inline]
+fn key_from(lo: u64, hi: u64) -> ChunkId {
+    let mut b = [0u8; 16];
+    b[..8].copy_from_slice(&lo.to_le_bytes());
+    b[8..].copy_from_slice(&hi.to_le_bytes());
+    ChunkId::from_bytes(b)
+}
+
+struct Table {
+    slots: Box<[Slot]>,
+    mask: usize,
+}
+
+impl Table {
+    fn new(capacity: usize) -> Self {
+        let capacity = capacity.max(16).next_power_of_two();
+        let slots = (0..capacity).map(|_| Slot::new()).collect();
+        Self {
+            slots,
+            mask: capacity - 1,
         }
     }
 
     #[inline]
-    fn shard(&self, id: &ChunkId) -> &Shard {
-        // hashbrown consumes the low and the top bits of the hash; take shard
-        // bits from the middle so shards stay well distributed internally.
-        &self.shards[((id.mix() >> 32) & self.mask) as usize]
+    fn capacity(&self) -> usize {
+        self.slots.len()
     }
 
-    /// Looks up a chunk.
-    pub fn get(&self, id: &ChunkId) -> Option<IndexValue> {
-        self.shard(id).lock().get(id).copied()
+    #[inline]
+    fn home(&self, key: &ChunkId) -> usize {
+        (key.mix() as usize) & self.mask
     }
 
-    /// Looks up a chunk and, while still holding the shard lock, pins the
-    /// segment it lives in and marks the entry as accessed.
+    /// Lock-free lookup. Returns the slot index and the entry's sequence number
+    /// alongside the value so callers can re-validate.
+    fn find(&self, key: &ChunkId) -> Option<(usize, u32, IndexValue)> {
+        let mut i = self.home(key);
+        for _ in 0..self.capacity() {
+            let (seq, snap) = self.slots[i].read();
+            match snap.state {
+                EMPTY => return None,
+                LIVE if snap.key == *key => return Some((i, seq, snap.value)),
+                _ => {}
+            }
+            i = (i + 1) & self.mask;
+        }
+        None
+    }
+
+    /// Writer only: the slot holding `key`, or the slot an insert of `key`
+    /// would use (the first tombstone on the way, else the terminating empty
+    /// slot). `None` if the table has no room at all.
+    fn locate(&self, key: &ChunkId) -> Located {
+        let mut i = self.home(key);
+        let mut first_tombstone = None;
+        for _ in 0..self.capacity() {
+            let (_, snap) = self.slots[i].read();
+            match snap.state {
+                EMPTY => {
+                    return Located::Vacant(first_tombstone.unwrap_or(i));
+                }
+                TOMBSTONE => {
+                    first_tombstone.get_or_insert(i);
+                }
+                _ if snap.key == *key => return Located::Occupied(i, snap.value),
+                _ => {}
+            }
+            i = (i + 1) & self.mask;
+        }
+        match first_tombstone {
+            Some(i) => Located::Vacant(i),
+            None => Located::Exhausted,
+        }
+    }
+}
+
+enum Located {
+    Occupied(usize, IndexValue),
+    Vacant(usize),
+    Exhausted,
+}
+
+enum Room {
+    /// The current table has a free slot within the load limit.
+    Fits,
+    /// The table was rebuilt; probe again.
+    Rebuilt,
+    /// The memory budget forbids growth.
+    Full,
+}
+
+// ---------------------------------------------------------------------------
+// Reader registration
+// ---------------------------------------------------------------------------
+
+/// Maximum number of concurrently registered readers per index.
+pub const MAX_READERS: usize = 1024;
+
+/// One reader's epoch on its own cache line: even when outside a lookup, odd
+/// while inside one, zero when the slot is unused.
+#[repr(align(64))]
+struct Epoch(AtomicU64);
+
+/// A registered reader of an [`Index`]; obtained from [`Index::register`] and
+/// returned with [`Index::unregister`]. Not `Clone`: one per reading thread.
+#[derive(Debug, PartialEq, Eq)]
+pub struct ReaderSlot(usize);
+
+impl ReaderSlot {
+    /// A placeholder that is not registered anywhere.
+    pub(crate) const fn detached() -> Self {
+        Self(usize::MAX)
+    }
+
+    pub(crate) fn is_detached(&self) -> bool {
+        self.0 == usize::MAX
+    }
+}
+
+/// A retired table waiting for the readers that were inside it to leave.
+pub(crate) struct Retired {
+    table: Box<Table>,
+    /// `(slot, epoch)` of every reader that was inside a lookup at retirement.
+    inside: Vec<(usize, u64)>,
+}
+
+// ---------------------------------------------------------------------------
+// Index (shared, read side)
+// ---------------------------------------------------------------------------
+
+/// The chunk index of one disk. See the [module docs](self).
+pub struct Index {
+    current: std::sync::atomic::AtomicPtr<Table>,
+    epochs: Box<[Epoch]>,
+    live: AtomicUsize,
+    tombstones: AtomicUsize,
+    /// Maximum table bytes; growth beyond it reports the table full.
+    budget: usize,
+}
+
+// SAFETY: the table pointer is only replaced by the single writer, which
+// retires the old table through the epoch protocol; readers only perform
+// atomic loads.
+unsafe impl Send for Index {}
+// SAFETY: as above.
+unsafe impl Sync for Index {}
+
+impl Index {
+    /// Creates an empty index with room for `capacity` slots (rounded up to a
+    /// power of two) and a memory budget of `budget` bytes for the table.
+    pub fn new(capacity: usize, budget: usize) -> Self {
+        let table = Box::new(Table::new(capacity));
+        Self {
+            current: std::sync::atomic::AtomicPtr::new(Box::into_raw(table)),
+            epochs: (0..MAX_READERS).map(|_| Epoch(AtomicU64::new(0))).collect(),
+            live: AtomicUsize::new(0),
+            tombstones: AtomicUsize::new(0),
+            budget,
+        }
+    }
+
+    #[inline]
+    fn table(&self) -> &Table {
+        // SAFETY: the pointer is always a live table: the writer replaces it
+        // with `Release` and frees the old one only after every reader that
+        // entered while it was current has left (`Retired::is_quiescent`).
+        unsafe { &*self.current.load(Ordering::Acquire) }
+    }
+
+    /// Registers the calling thread as a reader. `None` if [`MAX_READERS`]
+    /// are already registered.
+    pub fn register(&self) -> Option<ReaderSlot> {
+        for (i, e) in self.epochs.iter().enumerate() {
+            if e.0.compare_exchange(0, 2, Ordering::AcqRel, Ordering::Relaxed).is_ok() {
+                return Some(ReaderSlot(i));
+            }
+        }
+        None
+    }
+
+    /// Releases a reader registration.
+    pub fn unregister(&self, slot: ReaderSlot) {
+        self.epochs[slot.0].0.store(0, Ordering::Release);
+    }
+
+    #[inline]
+    fn enter(&self, slot: &ReaderSlot) -> &Table {
+        let e = &self.epochs[slot.0].0;
+        let v = e.load(Ordering::Relaxed);
+        debug_assert!(v != 0 && v & 1 == 0, "reader slot re-entered");
+        e.store(v + 1, Ordering::Relaxed);
+        // The writer publishes a new table, fences, then reads our epoch. If
+        // it saw us outside, our table load below must see its store.
+        fence(Ordering::SeqCst);
+        self.table()
+    }
+
+    #[inline]
+    fn exit(&self, slot: &ReaderSlot) {
+        let e = &self.epochs[slot.0].0;
+        e.store(e.load(Ordering::Relaxed) + 1, Ordering::Release);
+    }
+
+    /// Looks a chunk up.
+    pub fn get(&self, slot: &ReaderSlot, id: &ChunkId) -> Option<IndexValue> {
+        let table = self.enter(slot);
+        let found = table.find(id).map(|(_, _, v)| v);
+        self.exit(slot);
+        found
+    }
+
+    /// Looks a chunk up and pins the segment it lives in before returning,
+    /// re-validating the entry after the pin so that a segment reclaim removed
+    /// the entry from is never returned. Marks the entry as accessed.
     ///
     /// The caller must unpin the segment once it has finished reading.
-    pub fn get_and_pin(&self, id: &ChunkId, segments: &SegmentTable) -> Option<IndexValue> {
-        let mut shard = self.shard(id).lock();
-        let value = shard.get_mut(id)?;
-        value.flags |= FLAG_ACCESSED;
-        segments.pin(value.loc.seg_no);
-        Some(*value)
+    pub fn get_and_pin(&self, slot: &ReaderSlot, id: &ChunkId, segments: &SegmentTable) -> Option<IndexValue> {
+        let table = self.enter(slot);
+        let result = loop {
+            let Some((i, seq, value)) = table.find(id) else {
+                break None;
+            };
+            segments.pin(value.loc.seg_no);
+            // Pin before re-reading the sequence number; reclaim removes the
+            // entry before it looks at the pin count.
+            fence(Ordering::SeqCst);
+            if table.slots[i].seq.load(Ordering::Relaxed) == seq {
+                if value.flags & FLAG_ACCESSED == 0 {
+                    table.slots[i].flags.fetch_or(FLAG_ACCESSED, Ordering::Relaxed);
+                }
+                break Some(value);
+            }
+            segments.unpin(value.loc.seg_no);
+        };
+        self.exit(slot);
+        result
+    }
+
+    /// Looks a chunk up from a thread without a registered slot (management
+    /// paths). Registers temporarily; `None` when no slot is free.
+    pub fn get_unregistered(&self, id: &ChunkId) -> Option<IndexValue> {
+        let slot = self.register()?;
+        let found = self.get(&slot, id);
+        self.unregister(slot);
+        found
+    }
+
+    /// Number of live entries.
+    pub fn len(&self) -> usize {
+        self.live.load(Ordering::Relaxed)
+    }
+
+    /// Number of slots in the current table.
+    pub fn capacity(&self) -> usize {
+        self.table().capacity()
+    }
+
+    /// Bytes the current table occupies.
+    pub fn table_bytes(&self) -> usize {
+        self.capacity() * SLOT_BYTES
+    }
+}
+
+impl Drop for Index {
+    fn drop(&mut self) {
+        // SAFETY: `current` always holds a table allocated by `Box::into_raw`,
+        // and no reader can exist once the index is being dropped.
+        unsafe { drop(Box::from_raw(self.current.load(Ordering::Acquire))) };
+    }
+}
+
+// ---------------------------------------------------------------------------
+// IndexWriter (exclusive, write side)
+// ---------------------------------------------------------------------------
+
+/// The single mutator of an [`Index`].
+///
+/// Holds the tables retired by rebuilds until every reader has left them;
+/// [`IndexWriter::gc`] frees what has become unreferenced and should be called
+/// periodically (the engine's writer does so on every poll).
+pub struct IndexWriter {
+    index: Arc<Index>,
+    retired: Vec<Retired>,
+}
+
+impl IndexWriter {
+    /// Creates the writer. The caller guarantees no other `IndexWriter` for
+    /// `index` exists.
+    pub(crate) fn new(index: Arc<Index>) -> Self {
+        Self {
+            index,
+            retired: Vec::new(),
+        }
+    }
+
+    /// Number of tombstone slots in the current table.
+    pub fn tombstones(&self) -> usize {
+        self.index.tombstones.load(Ordering::Relaxed)
+    }
+
+    /// Reads without an epoch: the writer is the only party that swaps tables.
+    pub fn get(&self, id: &ChunkId) -> Option<IndexValue> {
+        self.index.table().find(id).map(|(_, _, v)| v)
+    }
+
+    /// Fetches the first index slot for an upcoming writer lookup.
+    #[inline]
+    pub(crate) fn prefetch(&self, id: &ChunkId) {
+        #[cfg(target_arch = "x86_64")]
+        {
+            let table = self.index.table();
+            let address = &table.slots[table.home(id)] as *const Slot;
+            // SAFETY: only this writer replaces the table, and the masked
+            // home slot is in bounds for the duration of this shared borrow.
+            unsafe {
+                std::arch::x86_64::_mm_prefetch(address.cast(), std::arch::x86_64::_MM_HINT_T0);
+            }
+        }
+        #[cfg(not(target_arch = "x86_64"))]
+        let _ = id;
+    }
+
+    /// Whether an insert of a new key would be refused for lack of budget.
+    pub fn is_full(&self) -> bool {
+        let table = self.index.table();
+        let used = self.index.live.load(Ordering::Relaxed) + self.index.tombstones.load(Ordering::Relaxed);
+        used + 1 > load_limit(table.capacity()) && !self.can_rebuild(table.capacity())
     }
 
     /// Inserts `value` unless the existing entry has an equal or higher LSN.
@@ -194,41 +611,81 @@ impl Index {
     /// before an earlier small record still sitting in a pending batch, and
     /// recovery sees records in arbitrary order), so the highest LSN must win
     /// regardless of arrival order.
-    pub fn insert_if_newer(&self, id: ChunkId, value: IndexValue) -> InsertOutcome {
-        let mut shard = self.shard(&id).lock();
-        match shard.get_mut(&id) {
-            Some(existing) if existing.lsn >= value.lsn => InsertOutcome::Rejected,
-            Some(existing) => InsertOutcome::Replaced(std::mem::replace(existing, value)),
-            None => {
-                shard.insert(id, value);
-                InsertOutcome::Inserted
+    pub fn insert_if_newer(&mut self, id: ChunkId, value: IndexValue) -> InsertOutcome {
+        let table = self.index.table();
+        let vacant = match table.locate(&id) {
+            Located::Occupied(i, existing) => {
+                if existing.lsn >= value.lsn {
+                    return InsertOutcome::Rejected;
+                }
+                table.slots[i].write(LIVE, &id, &value);
+                return InsertOutcome::Replaced(existing);
             }
+            Located::Vacant(i) => Some(i),
+            Located::Exhausted => None,
+        };
+        let i = match (self.make_room(), vacant) {
+            (Room::Full, _) => return InsertOutcome::Full,
+            (Room::Fits, Some(i)) => i,
+            // Rebuilt (or no slot before): the old table is gone, probe the
+            // current one.
+            _ => match self.index.table().locate(&id) {
+                Located::Vacant(i) => i,
+                Located::Occupied(..) | Located::Exhausted => unreachable!("key vanished or table full after rebuild"),
+            },
+        };
+        self.fill_vacant(self.index.table(), i, &id, &value);
+        InsertOutcome::Inserted
+    }
+
+    fn fill_vacant(&self, table: &Table, i: usize, id: &ChunkId, value: &IndexValue) {
+        let was_tombstone = table.slots[i].state.load(Ordering::Relaxed) == TOMBSTONE;
+        table.slots[i].write(LIVE, id, value);
+        if was_tombstone {
+            self.index.tombstones.fetch_sub(1, Ordering::Relaxed);
         }
+        self.index.live.fetch_add(1, Ordering::Relaxed);
     }
 
     /// Removes an entry, returning it.
-    pub fn remove(&self, id: &ChunkId) -> Option<IndexValue> {
-        self.shard(id).lock().remove(id)
+    pub fn remove(&mut self, id: &ChunkId) -> Option<IndexValue> {
+        let table = self.index.table();
+        match table.locate(id) {
+            Located::Occupied(i, existing) => {
+                self.bury(table, i);
+                Some(existing)
+            }
+            _ => None,
+        }
     }
 
     /// Removes the entry if it still points at `expected`.
-    pub fn remove_if_at(&self, id: &ChunkId, expected: Location) -> Option<IndexValue> {
-        let mut shard = self.shard(id).lock();
-        match shard.get(id) {
-            Some(v) if v.loc == expected => shard.remove(id),
+    pub fn remove_if_at(&mut self, id: &ChunkId, expected: Location) -> Option<IndexValue> {
+        let table = self.index.table();
+        match table.locate(id) {
+            Located::Occupied(i, existing) if existing.loc == expected => {
+                self.bury(table, i);
+                Some(existing)
+            }
             _ => None,
         }
+    }
+
+    fn bury(&self, table: &Table, i: usize) {
+        table.slots[i].bury();
+        self.index.live.fetch_sub(1, Ordering::Relaxed);
+        self.index.tombstones.fetch_add(1, Ordering::Relaxed);
     }
 
     /// Replaces the entry with `value` if it still points at `expected`.
     ///
     /// The accessed flag of the existing entry is *not* carried over: a
     /// relocated record starts a fresh access history.
-    pub fn replace_if_at(&self, id: &ChunkId, expected: Location, value: IndexValue) -> bool {
-        let mut shard = self.shard(id).lock();
-        match shard.get_mut(id) {
-            Some(v) if v.loc == expected => {
-                *v = value;
+    pub fn replace_if_at(&mut self, id: &ChunkId, expected: Location, value: IndexValue) -> bool {
+        let table = self.index.table();
+        match table.locate(id) {
+            Located::Occupied(i, existing) if existing.loc == expected => {
+                table.slots[i].write(LIVE, id, &value);
                 true
             }
             _ => false,
@@ -236,26 +693,133 @@ impl Index {
     }
 
     /// Removes every entry for which `keep` returns `false`.
-    pub fn retain(&self, mut keep: impl FnMut(&ChunkId, &IndexValue) -> bool) {
-        for shard in &self.shards {
-            shard.lock().retain(|k, v| keep(k, v));
-        }
-    }
-
-    /// Visits every entry. Shards are locked one at a time; the visitor must
-    /// not call back into the index.
-    pub fn for_each(&self, mut f: impl FnMut(&ChunkId, &IndexValue)) {
-        for shard in &self.shards {
-            for (k, v) in shard.lock().iter() {
-                f(k, v);
+    pub fn retain(&mut self, mut keep: impl FnMut(&ChunkId, &IndexValue) -> bool) {
+        let table = self.index.table();
+        for i in 0..table.capacity() {
+            let (_, snap) = table.slots[i].read();
+            if snap.state == LIVE && !keep(&snap.key, &snap.value) {
+                self.bury(table, i);
             }
         }
     }
 
-    /// Number of entries.
-    pub fn len(&self) -> usize {
-        self.shards.iter().map(|s| s.lock().len()).sum()
+    /// Visits every live entry.
+    pub fn for_each(&self, mut f: impl FnMut(&ChunkId, &IndexValue)) {
+        let table = self.index.table();
+        for slot in table.slots.iter() {
+            let (_, snap) = slot.read();
+            if snap.state == LIVE {
+                f(&snap.key, &snap.value);
+            }
+        }
     }
+
+    fn can_rebuild(&self, capacity: usize) -> bool {
+        let live = self.index.live.load(Ordering::Relaxed);
+        // Same size (drop tombstones) if the live count allows, else double.
+        live < grow_limit(capacity) || capacity * 2 * SLOT_BYTES <= self.index.budget
+    }
+
+    /// Makes room for one more entry, rebuilding if needed.
+    fn make_room(&mut self) -> Room {
+        let capacity = self.index.capacity();
+        let live = self.index.live.load(Ordering::Relaxed);
+        let used = live + self.index.tombstones.load(Ordering::Relaxed);
+        if used < load_limit(capacity) {
+            return Room::Fits;
+        }
+        let new_capacity = if live < grow_limit(capacity) {
+            capacity
+        } else {
+            capacity * 2
+        };
+        if new_capacity > capacity && new_capacity * SLOT_BYTES > self.index.budget {
+            return Room::Full;
+        }
+        self.rebuild(new_capacity);
+        Room::Rebuilt
+    }
+
+    /// Rebuilds into a table of `capacity` slots (tombstones dropped) and
+    /// retires the old one.
+    pub fn rebuild(&mut self, capacity: usize) {
+        let old = self.index.table();
+        let new = Box::new(Table::new(capacity));
+        for slot in old.slots.iter() {
+            let (_, snap) = slot.read();
+            if snap.state == LIVE {
+                match new.locate(&snap.key) {
+                    Located::Vacant(i) => new.slots[i].write(LIVE, &snap.key, &snap.value),
+                    _ => unreachable!("fresh table cannot hold the key or be full"),
+                }
+            }
+        }
+        self.index.tombstones.store(0, Ordering::Relaxed);
+        let old_ptr = self.index.current.swap(Box::into_raw(new), Ordering::AcqRel);
+        // Readers store an odd epoch, fence, then load the table pointer.
+        // After this fence, any reader we observe outside a lookup will load
+        // the new table.
+        fence(Ordering::SeqCst);
+        let inside: Vec<(usize, u64)> = self
+            .index
+            .epochs
+            .iter()
+            .enumerate()
+            .filter_map(|(i, e)| {
+                let v = e.0.load(Ordering::Acquire);
+                (v & 1 == 1).then_some((i, v))
+            })
+            .collect();
+        // SAFETY: `old_ptr` came from `Box::into_raw` and is no longer
+        // reachable through `current`; it is freed only when quiescent.
+        let table = unsafe { Box::from_raw(old_ptr) };
+        self.retired.push(Retired { table, inside });
+        self.gc();
+    }
+
+    /// Frees retired tables no reader can still be inside.
+    pub fn gc(&mut self) {
+        let index = &self.index;
+        self.retired.retain(|r| !r.is_quiescent(index));
+    }
+
+    /// Retired tables still held.
+    #[cfg(test)]
+    pub fn retired(&self) -> usize {
+        self.retired.len()
+    }
+}
+
+impl Retired {
+    fn is_quiescent(&self, index: &Index) -> bool {
+        self.inside
+            .iter()
+            .all(|&(slot, epoch)| index.epochs[slot].0.load(Ordering::Acquire) != epoch)
+    }
+}
+
+impl Drop for IndexWriter {
+    fn drop(&mut self) {
+        // Tables still referenced by readers are leaked rather than freed
+        // under them; this only happens if a writer is dropped while readers
+        // are mid-lookup, which the engine's shutdown order prevents.
+        self.gc();
+        for r in self.retired.drain(..) {
+            std::mem::forget(r.table);
+        }
+    }
+}
+
+/// Live plus tombstone slots allowed before a rebuild (7/8 load).
+#[inline]
+fn load_limit(capacity: usize) -> usize {
+    capacity - capacity / 8
+}
+
+/// Live entries allowed before a rebuild must grow the table (3/4 load).
+#[inline]
+fn grow_limit(capacity: usize) -> usize {
+    capacity - capacity / 4
 }
 
 #[cfg(test)]
@@ -271,54 +835,183 @@ mod tests {
             value_off: off + 68,
             value_len: 10,
             flags: 0,
-            crc: 0,
             lsn,
         }
     }
 
     #[test]
     fn newer_wins() {
-        let index = Index::new(4);
+        let index = Arc::new(Index::new(16, usize::MAX));
+        let mut w = IndexWriter::new(index.clone());
         let id = ChunkId::from_u128(1);
-        assert_eq!(index.insert_if_newer(id, value(1, 0, 5)), InsertOutcome::Inserted);
-        assert_eq!(index.insert_if_newer(id, value(2, 0, 3)), InsertOutcome::Rejected);
-        assert_eq!(index.insert_if_newer(id, value(1, 0, 5)), InsertOutcome::Rejected);
-        assert_eq!(index.get(&id).unwrap().lsn, 5);
+        assert_eq!(w.insert_if_newer(id, value(1, 0, 5)), InsertOutcome::Inserted);
+        assert_eq!(w.insert_if_newer(id, value(2, 0, 3)), InsertOutcome::Rejected);
+        assert_eq!(w.insert_if_newer(id, value(1, 0, 5)), InsertOutcome::Rejected);
+        assert_eq!(w.get(&id).unwrap().lsn, 5);
         assert_eq!(
-            index.insert_if_newer(id, value(3, 0, 9)),
+            w.insert_if_newer(id, value(3, 0, 9)),
             InsertOutcome::Replaced(value(1, 0, 5))
         );
-        assert_eq!(index.get(&id).unwrap().loc.seg_no, 3);
+        assert_eq!(w.get(&id).unwrap().loc.seg_no, 3);
+        assert_eq!(index.len(), 1);
     }
 
     #[test]
     fn conditional_updates() {
-        let index = Index::new(4);
+        let index = Arc::new(Index::new(16, usize::MAX));
+        let mut w = IndexWriter::new(index.clone());
         let id = ChunkId::from_u128(2);
-        index.insert_if_newer(id, value(1, 64, 1));
+        w.insert_if_newer(id, value(1, 64, 1));
         let wrong = Location { seg_no: 1, offset: 128 };
         let right = Location { seg_no: 1, offset: 64 };
-        assert!(!index.replace_if_at(&id, wrong, value(5, 0, 2)));
-        assert!(index.replace_if_at(&id, right, value(5, 0, 2)));
-        assert_eq!(index.get(&id).unwrap().loc.seg_no, 5);
-        assert!(index.remove_if_at(&id, right).is_none());
-        assert!(index.remove_if_at(&id, Location { seg_no: 5, offset: 0 }).is_some());
+        assert!(!w.replace_if_at(&id, wrong, value(5, 0, 2)));
+        assert!(w.replace_if_at(&id, right, value(5, 0, 2)));
+        assert_eq!(w.get(&id).unwrap().loc.seg_no, 5);
+        assert!(w.remove_if_at(&id, right).is_none());
+        assert!(w.remove_if_at(&id, Location { seg_no: 5, offset: 0 }).is_some());
         assert_eq!(index.len(), 0);
+        assert!(w.get(&id).is_none());
     }
 
     #[test]
     fn pin_and_access_flag() {
-        let index = Index::new(4);
+        let index = Arc::new(Index::new(16, usize::MAX));
         let segments = SegmentTable::new(4);
+        let mut w = IndexWriter::new(index.clone());
         let id = ChunkId::from_u128(3);
-        index.insert_if_newer(id, value(2, 0, 1));
-        let v = index.get_and_pin(&id, &segments).unwrap();
-        assert!(v.is_accessed());
+        w.insert_if_newer(id, value(2, 0, 1));
+        let slot = index.register().unwrap();
+        let v = index.get_and_pin(&slot, &id, &segments).unwrap();
+        assert!(!v.is_accessed(), "the returned snapshot predates the mark");
+        assert!(index.get(&slot, &id).unwrap().is_accessed());
         assert_eq!(segments.pins(2), 1);
         segments.unpin(2);
         assert_eq!(segments.pins(2), 0);
         // Relocation starts a fresh access history.
-        assert!(index.replace_if_at(&id, v.loc, value(3, 0, 2)));
-        assert!(!index.get(&id).unwrap().is_accessed());
+        assert!(w.replace_if_at(&id, v.loc, value(3, 0, 2)));
+        assert!(!w.get(&id).unwrap().is_accessed());
+        index.unregister(slot);
+    }
+
+    #[test]
+    fn grows_reuses_tombstones_and_respects_budget() {
+        let index = Arc::new(Index::new(16, 64 * SLOT_BYTES));
+        let mut w = IndexWriter::new(index.clone());
+        for i in 0..40u128 {
+            assert_eq!(
+                w.insert_if_newer(ChunkId::from_u128(i), value(0, i as u32, 1)),
+                InsertOutcome::Inserted,
+                "insert {i}"
+            );
+        }
+        assert_eq!(index.capacity(), 64);
+        assert_eq!(index.len(), 40);
+        // Churn: delete and re-insert far more keys than the table holds; the
+        // same-size rebuild must clear tombstones without growing.
+        for round in 0..20u128 {
+            for i in 0..40u128 {
+                assert!(w.remove(&ChunkId::from_u128(i + round * 40)).is_some());
+                assert_eq!(
+                    w.insert_if_newer(ChunkId::from_u128(i + (round + 1) * 40), value(0, 0, 1)),
+                    InsertOutcome::Inserted
+                );
+            }
+        }
+        assert_eq!(index.capacity(), 64);
+        assert_eq!(index.len(), 40);
+        // The budget stops growth: 3/4 of 64 = 48 live entries.
+        let mut inserted = 0;
+        for i in 10_000..10_100u128 {
+            match w.insert_if_newer(ChunkId::from_u128(i), value(0, 0, 1)) {
+                InsertOutcome::Inserted => inserted += 1,
+                InsertOutcome::Full => break,
+                other => panic!("{other:?}"),
+            }
+        }
+        assert!((8..=16).contains(&inserted), "inserted {inserted}");
+        assert!(w.is_full());
+        assert_eq!(index.capacity(), 64);
+        for i in 0..40u128 {
+            assert!(w.get(&ChunkId::from_u128(i + 20 * 40)).is_some());
+        }
+    }
+
+    #[test]
+    fn retired_tables_wait_for_readers_inside() {
+        let index = Arc::new(Index::new(16, usize::MAX));
+        let mut w = IndexWriter::new(index.clone());
+        let slot = index.register().unwrap();
+        // Simulate a reader that entered a lookup and has not left.
+        let table = index.enter(&slot);
+        let _ = table;
+        for i in 0..100u128 {
+            w.insert_if_newer(ChunkId::from_u128(i), value(0, 0, 1));
+        }
+        assert!(
+            w.retired() >= 1,
+            "the old table must be held while the reader is inside"
+        );
+        index.exit(&slot);
+        w.gc();
+        assert_eq!(w.retired(), 0);
+        // Readers outside a lookup never hold a table.
+        for i in 100..1000u128 {
+            w.insert_if_newer(ChunkId::from_u128(i), value(0, 0, 1));
+        }
+        assert_eq!(w.retired(), 0);
+        assert_eq!(index.get(&slot, &ChunkId::from_u128(999)).unwrap().lsn, 1);
+        index.unregister(slot);
+    }
+
+    #[test]
+    fn concurrent_readers_see_whole_entries() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        let index = Arc::new(Index::new(1024, usize::MAX));
+        let stop = Arc::new(AtomicBool::new(false));
+        let keys = 512u128;
+        {
+            let mut w = IndexWriter::new(index.clone());
+            for k in 0..keys {
+                w.insert_if_newer(ChunkId::from_u128(k), value(k as u32, k as u32, 1));
+            }
+        }
+        let readers: Vec<_> = (0..4)
+            .map(|_| {
+                let index = index.clone();
+                let stop = stop.clone();
+                std::thread::spawn(move || {
+                    let slot = index.register().unwrap();
+                    let mut n = 0u64;
+                    while !stop.load(Ordering::Relaxed) {
+                        let k = n as u128 % keys;
+                        if let Some(v) = index.get(&slot, &ChunkId::from_u128(k)) {
+                            // A whole entry: every field derived from the same version.
+                            assert_eq!(v.loc.offset, v.loc.seg_no);
+                            assert_eq!(v.value_off, v.loc.seg_no + 68);
+                        }
+                        n += 1;
+                    }
+                    index.unregister(slot);
+                    n
+                })
+            })
+            .collect();
+        let mut w = IndexWriter::new(index.clone());
+        for round in 2..200u64 {
+            for k in 0..keys {
+                let ver = (k as u64 * 7 + round) as u32;
+                w.insert_if_newer(ChunkId::from_u128(k), value(ver, ver, round));
+                if k % 5 == 0 {
+                    w.remove(&ChunkId::from_u128(k));
+                }
+            }
+            if round % 50 == 0 {
+                w.rebuild(index.capacity());
+            }
+            w.gc();
+        }
+        stop.store(true, Ordering::Relaxed);
+        let total: u64 = readers.into_iter().map(|h| h.join().unwrap()).sum();
+        assert!(total > 0);
     }
 }

--- a/core/moat-engine/src/io.rs
+++ b/core/moat-engine/src/io.rs
@@ -100,7 +100,8 @@ pub trait IoQueue: Send {
     fn attach(&mut self, device: &Arc<dyn Device>) -> io::Result<Descriptor>;
 
     /// Closes a descriptor. Completions still in flight for it are discarded
-    /// on arrival (their buffers return to the pool).
+    /// on arrival (their buffers return to the pool). The slot stays reserved
+    /// until all accepted operations have been reaped.
     fn detach(&mut self, desc: Descriptor);
 
     /// Enqueues a read of `len` bytes at `offset` into the start of `buf`.
@@ -146,44 +147,61 @@ pub trait IoQueue: Send {
 /// Completion inboxes indexed by descriptor, shared by both queue
 /// implementations.
 pub(crate) struct Inboxes {
-    boxes: Vec<Option<Vec<IoCompletion>>>,
+    boxes: Vec<Inbox>,
+}
+
+#[derive(Default)]
+struct Inbox {
+    open: bool,
+    pending: usize,
+    done: Vec<IoCompletion>,
 }
 
 impl Inboxes {
     pub(crate) fn new(capacity: u32) -> Self {
         Self {
-            boxes: (0..capacity.max(1)).map(|_| None).collect(),
+            boxes: (0..capacity.max(1)).map(|_| Inbox::default()).collect(),
         }
     }
 
     /// Opens the lowest free inbox.
     pub(crate) fn open(&mut self) -> Option<Descriptor> {
-        let slot = self.boxes.iter().position(Option::is_none)?;
-        self.boxes[slot] = Some(Vec::new());
+        let slot = self.boxes.iter().position(|b| !b.open && b.pending == 0)?;
+        self.boxes[slot].open = true;
         Some(Descriptor(slot as u32))
     }
 
-    pub(crate) fn close(&mut self, desc: Descriptor) {
-        if let Some(b) = self.boxes.get_mut(desc.0 as usize) {
-            *b = None;
-        }
+    /// Closes the inbox; returns whether its file slot can be released now.
+    pub(crate) fn close(&mut self, desc: Descriptor) -> bool {
+        let Some(b) = self.boxes.get_mut(desc.0 as usize).filter(|b| b.open) else {
+            return false;
+        };
+        b.open = false;
+        b.done.clear();
+        b.pending == 0
     }
 
-    pub(crate) fn is_open(&self, desc: Descriptor) -> bool {
-        self.boxes.get(desc.0 as usize).is_some_and(Option::is_some)
+    pub(crate) fn start(&mut self, desc: Descriptor) {
+        let b = &mut self.boxes[desc.0 as usize];
+        assert!(b.open, "operation on a detached descriptor");
+        b.pending += 1;
     }
 
-    /// Delivers a completion; completions for closed descriptors are dropped.
-    pub(crate) fn deliver(&mut self, desc: Descriptor, done: IoCompletion) {
-        if let Some(Some(inbox)) = self.boxes.get_mut(desc.0 as usize) {
-            inbox.push(done);
+    /// Returns whether the last operation of a closed descriptor was reaped.
+    pub(crate) fn deliver(&mut self, desc: Descriptor, done: IoCompletion) -> bool {
+        let b = &mut self.boxes[desc.0 as usize];
+        b.pending -= 1;
+        if b.open {
+            b.done.push(done);
         }
+        !b.open && b.pending == 0
     }
 
     pub(crate) fn take(&mut self, desc: Descriptor, out: &mut Vec<IoCompletion>) -> usize {
-        let Some(Some(inbox)) = self.boxes.get_mut(desc.0 as usize) else {
+        let Some(b) = self.boxes.get_mut(desc.0 as usize).filter(|b| b.open) else {
             return 0;
         };
+        let inbox = &mut b.done;
         let n = inbox.len();
         if n == 0 {
             return 0;
@@ -276,6 +294,7 @@ impl IoQueue for SyncQueue {
             return Err(buf);
         }
         let result = self.device(desc).read_at(&mut buf[..len], offset).map(|()| len);
+        self.inboxes.start(desc);
         self.done.push((
             desc,
             IoCompletion {
@@ -299,6 +318,7 @@ impl IoQueue for SyncQueue {
             return Err(buf);
         }
         let result = self.device(desc).write_at(&buf[..len], offset).map(|()| len);
+        self.inboxes.start(desc);
         self.done.push((
             desc,
             IoCompletion {
@@ -315,6 +335,7 @@ impl IoQueue for SyncQueue {
             return Err(Full);
         }
         let result = self.device(desc).sync().map(|()| 0);
+        self.inboxes.start(desc);
         self.done.push((
             desc,
             IoCompletion {
@@ -332,10 +353,11 @@ impl IoQueue for SyncQueue {
 
     fn poll(&mut self, _wait: bool) -> io::Result<usize> {
         let n = self.done.len();
-        let done = std::mem::take(&mut self.done);
-        match self.order {
-            CompletionOrder::Fifo => done.into_iter().for_each(|(d, c)| self.inboxes.deliver(d, c)),
-            CompletionOrder::Reverse => done.into_iter().rev().for_each(|(d, c)| self.inboxes.deliver(d, c)),
+        if self.order == CompletionOrder::Reverse {
+            self.done.reverse();
+        }
+        for (desc, done) in self.done.drain(..) {
+            self.inboxes.deliver(desc, done);
         }
         Ok(n)
     }
@@ -350,5 +372,71 @@ impl IoQueue for SyncQueue {
 
     fn depth(&self) -> usize {
         self.depth
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use moat_common::HugePages;
+
+    use super::*;
+    use crate::device::MemDevice;
+
+    pub(crate) fn check_detach(q: &mut dyn IoQueue, a: Arc<dyn Device>, b: Arc<dyn Device>) {
+        let old = q.attach(&a).unwrap();
+        let mut buf = q.pool().alloc(4096).unwrap();
+        buf[..4096].fill(1);
+        q.write(old, buf, 4096, 0, 1).unwrap();
+        // Detach before submit: the fixed-file binding must survive staging.
+        q.detach(old);
+        let new = q.attach(&b).unwrap();
+        assert_ne!(old, new, "an outstanding operation still owns the old slot");
+        assert!(q.attach(&a).is_err(), "both descriptor slots are reserved");
+        let mut buf = q.pool().alloc(4096).unwrap();
+        buf[..4096].fill(2);
+        q.write(new, buf, 4096, 0, 2).unwrap();
+        while q.in_flight() > 0 {
+            q.poll(true).unwrap();
+        }
+        let mut done = Vec::new();
+        assert_eq!(q.take(old, &mut done), 0);
+        assert_eq!(q.take(new, &mut done), 1);
+        let completion = done.pop().unwrap();
+        assert_eq!(completion.token, 2);
+        assert_eq!(completion.result.unwrap(), 4096);
+        drop(completion.buf);
+        let mut bytes = [0; 4096];
+        a.read_at(&mut bytes, 0).unwrap();
+        assert_eq!(bytes, [1; 4096]);
+        b.read_at(&mut bytes, 0).unwrap();
+        assert_eq!(bytes, [2; 4096]);
+        assert_eq!(q.attach(&a).unwrap(), old, "completed slots can be reused");
+        q.detach(old);
+        q.detach(new);
+        assert_eq!(q.pool().in_use(), 0);
+    }
+
+    pub(crate) fn detach_options() -> QueueOptions {
+        QueueOptions {
+            depth: 4,
+            descriptors: 2,
+            pool: PoolOptions {
+                bytes: 1 << 20,
+                max_class: 64 << 10,
+                huge_pages: HugePages::Disabled,
+            },
+        }
+    }
+
+    #[test]
+    fn detached_descriptors_wait_for_outstanding_completions() {
+        for order in [CompletionOrder::Fifo, CompletionOrder::Reverse] {
+            let mut queue = SyncQueue::new(&detach_options(), order).unwrap();
+            check_detach(
+                &mut queue,
+                Arc::new(MemDevice::new(4096)),
+                Arc::new(MemDevice::new(4096)),
+            );
+        }
     }
 }

--- a/core/moat-engine/src/io.rs
+++ b/core/moat-engine/src/io.rs
@@ -12,24 +12,34 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Asynchronous, batched I/O queues.
+//! Asynchronous, batched I/O queues shared by every engine on a thread.
 //!
-//! The data path never blocks on a single I/O. A thread owns an [`IoQueue`],
-//! submits reads and writes against buffers from the queue's own
-//! [`BufferPool`], and later reaps [`IoCompletion`]s. Buffers are *moved* into
-//! the queue for the duration of the operation and handed back with the
-//! completion, so ownership is always unambiguous and no lifetime crosses the
-//! submission boundary.
+//! A worker thread owns exactly one [`IoQueue`] and drives any number of
+//! engine pipelines through it. A pipeline *attaches* a device to the queue and
+//! receives a [`Descriptor`]: one open of that device on this queue, naming
+//! both the registered file the operations go to and the inbox its completions
+//! are routed to. Buffers are *moved* into the queue for the duration of an
+//! operation and handed back with the completion, so ownership is always
+//! unambiguous and no lifetime crosses the submission boundary.
 //!
-//! Two implementations exist: io_uring with registered fixed buffers (Linux,
-//! the production path) and [`SyncQueue`], which performs each operation
-//! immediately on a blocking device and merely defers the completion. The sync
-//! queue keeps the engine portable and deterministic under test; every piece of
-//! engine logic is identical on both.
+//! Enqueueing never blocks and never touches the device. When `depth`
+//! operations are already in flight the operation is rejected *losslessly*: the
+//! buffer comes back to the caller, who keeps the operation in its own ready
+//! queue and retries after the next poll. [`IoQueue::vacant`] tells a caller
+//! exactly how many operations it can enqueue without a rejection.
+//!
+//! Two implementations exist: io_uring with registered fixed buffers and a
+//! fixed-file table ([`UringQueue`](crate::uring::UringQueue), Linux, the
+//! production path) and [`SyncQueue`], which performs each operation
+//! immediately through the blocking [`Device`] interface and merely defers the
+//! completion. The sync queue keeps the engine portable and deterministic under
+//! test; every piece of engine logic is identical on both.
 
-use std::{collections::VecDeque, io, sync::Arc};
+use std::{io, sync::Arc};
 
 use moat_common::{BufferPool, PoolOptions, PooledBuf};
+
+use crate::device::Device;
 
 /// Configuration of one [`IoQueue`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -38,8 +48,8 @@ pub struct QueueOptions {
     pub depth: u32,
     /// The buffer pool owned by the queue.
     pub pool: PoolOptions,
-    /// Use the blocking implementation even where io_uring is available.
-    pub force_sync: bool,
+    /// Maximum number of attached descriptors.
+    pub descriptors: u32,
 }
 
 impl Default for QueueOptions {
@@ -47,10 +57,27 @@ impl Default for QueueOptions {
         Self {
             depth: 256,
             pool: PoolOptions::default(),
-            force_sync: false,
+            descriptors: 256,
         }
     }
 }
+
+/// One open of a device on a queue: a registered-file slot plus a completion
+/// inbox. Scoped to the queue that issued it; not the kernel's file descriptor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Descriptor(pub(crate) u32);
+
+impl Descriptor {
+    /// The slot index within the queue.
+    #[inline]
+    pub fn index(self) -> u32 {
+        self.0
+    }
+}
+
+/// The queue has `depth` operations in flight; retry after a poll.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Full;
 
 /// A finished operation. `buf` is the buffer the operation was issued with
 /// (absent for `fsync`).
@@ -63,49 +90,111 @@ pub struct IoCompletion {
     pub buf: Option<PooledBuf>,
 }
 
-/// An asynchronous I/O queue bound to one device and one thread.
-///
-/// `read`/`write`/`fsync` only enqueue; [`IoQueue::submit`] pushes queued
-/// operations to the device and [`IoQueue::poll`] reaps completions (and
-/// submits first). Enqueueing fails with [`io::ErrorKind::WouldBlock`] when
-/// `depth` operations are already in flight; callers poll and retry.
+/// An asynchronous I/O queue owned by one thread and shared by the pipelines
+/// on it. See the [module docs](self).
 pub trait IoQueue: Send {
     /// The pool every buffer passed to this queue must come from.
     fn pool(&self) -> &Arc<BufferPool>;
 
-    /// Reads `len` bytes at `offset` into the start of `buf`.
-    fn read(&mut self, buf: PooledBuf, len: usize, offset: u64, token: u64) -> io::Result<()>;
+    /// Registers `device` and opens an inbox for it.
+    fn attach(&mut self, device: &Arc<dyn Device>) -> io::Result<Descriptor>;
 
-    /// Writes the first `len` bytes of `buf` at `offset`.
-    fn write(&mut self, buf: PooledBuf, len: usize, offset: u64, token: u64) -> io::Result<()>;
+    /// Closes a descriptor. Completions still in flight for it are discarded
+    /// on arrival (their buffers return to the pool).
+    fn detach(&mut self, desc: Descriptor);
 
-    /// Flushes the device's volatile write cache once all previously
-    /// *completed* writes are on the device. Ordering against in-flight writes
-    /// is the caller's responsibility (wait for them first).
-    fn fsync(&mut self, token: u64) -> io::Result<()>;
+    /// Enqueues a read of `len` bytes at `offset` into the start of `buf`.
+    /// Rejected, with the buffer handed back untouched, when `depth`
+    /// operations are in flight.
+    fn read(&mut self, desc: Descriptor, buf: PooledBuf, len: usize, offset: u64, token: u64) -> Result<(), PooledBuf>;
+
+    /// Enqueues a write of the first `len` bytes of `buf` at `offset`.
+    /// Rejected, with the buffer handed back untouched, when `depth`
+    /// operations are in flight.
+    fn write(&mut self, desc: Descriptor, buf: PooledBuf, len: usize, offset: u64, token: u64)
+    -> Result<(), PooledBuf>;
+
+    /// Enqueues a flush of the device's volatile write cache. Ordering against
+    /// in-flight writes is the caller's responsibility (wait for them first).
+    fn fsync(&mut self, desc: Descriptor, token: u64) -> Result<(), Full>;
+
+    /// `depth() - in_flight()`: how many operations can be enqueued right now
+    /// without being rejected.
+    fn vacant(&self) -> usize {
+        self.depth() - self.in_flight()
+    }
 
     /// Pushes enqueued operations to the device without waiting.
     fn submit(&mut self) -> io::Result<()>;
 
-    /// Submits, then collects finished operations into `out`. With `wait` set
-    /// and operations in flight, blocks until at least one completes.
-    fn poll(&mut self, out: &mut Vec<IoCompletion>, wait: bool) -> io::Result<usize>;
+    /// Submits, then reaps every finished operation into its descriptor's
+    /// inbox. With `wait` set and anything in flight, blocks until at least
+    /// one completes. Returns the number reaped. This is a worker's single
+    /// blocking point.
+    fn poll(&mut self, wait: bool) -> io::Result<usize>;
 
-    /// Operations submitted but not yet reaped.
+    /// Moves the inbox of `desc` into `out`. Returns the number moved.
+    fn take(&mut self, desc: Descriptor, out: &mut Vec<IoCompletion>) -> usize;
+
+    /// Operations enqueued but not yet reaped.
     fn in_flight(&self) -> usize;
 
-    /// Maximum operations in flight; enqueueing beyond it fails.
+    /// Maximum operations in flight.
     fn depth(&self) -> usize;
 }
 
-/// The blocking primitives a [`SyncQueue`] is built on.
-pub trait BlockingIo: Send + 'static {
-    /// Reads `buf.len()` bytes at `offset`.
-    fn read_at(&self, buf: &mut [u8], offset: u64) -> io::Result<()>;
-    /// Writes `buf` at `offset`.
-    fn write_at(&self, buf: &[u8], offset: u64) -> io::Result<()>;
-    /// Flushes the write cache.
-    fn sync(&self) -> io::Result<()>;
+/// Completion inboxes indexed by descriptor, shared by both queue
+/// implementations.
+pub(crate) struct Inboxes {
+    boxes: Vec<Option<Vec<IoCompletion>>>,
+}
+
+impl Inboxes {
+    pub(crate) fn new(capacity: u32) -> Self {
+        Self {
+            boxes: (0..capacity.max(1)).map(|_| None).collect(),
+        }
+    }
+
+    /// Opens the lowest free inbox.
+    pub(crate) fn open(&mut self) -> Option<Descriptor> {
+        let slot = self.boxes.iter().position(Option::is_none)?;
+        self.boxes[slot] = Some(Vec::new());
+        Some(Descriptor(slot as u32))
+    }
+
+    pub(crate) fn close(&mut self, desc: Descriptor) {
+        if let Some(b) = self.boxes.get_mut(desc.0 as usize) {
+            *b = None;
+        }
+    }
+
+    pub(crate) fn is_open(&self, desc: Descriptor) -> bool {
+        self.boxes.get(desc.0 as usize).is_some_and(Option::is_some)
+    }
+
+    /// Delivers a completion; completions for closed descriptors are dropped.
+    pub(crate) fn deliver(&mut self, desc: Descriptor, done: IoCompletion) {
+        if let Some(Some(inbox)) = self.boxes.get_mut(desc.0 as usize) {
+            inbox.push(done);
+        }
+    }
+
+    pub(crate) fn take(&mut self, desc: Descriptor, out: &mut Vec<IoCompletion>) -> usize {
+        let Some(Some(inbox)) = self.boxes.get_mut(desc.0 as usize) else {
+            return 0;
+        };
+        let n = inbox.len();
+        if n == 0 {
+            return 0;
+        }
+        if out.is_empty() {
+            std::mem::swap(inbox, out);
+        } else {
+            out.append(inbox);
+        }
+        n
+    }
 }
 
 /// How a [`SyncQueue`] orders its deferred completions. Reverse order is a
@@ -120,71 +209,120 @@ pub enum CompletionOrder {
     Reverse,
 }
 
-/// An [`IoQueue`] that performs each operation synchronously at submission and
-/// reports the completion on the next poll.
-pub struct SyncQueue<B: BlockingIo> {
-    io: B,
+/// An [`IoQueue`] that performs each operation synchronously at submission
+/// through [`Device::read_at`] / [`Device::write_at`] and reports the
+/// completion on the next poll.
+pub struct SyncQueue {
     pool: Arc<BufferPool>,
     depth: usize,
-    done: VecDeque<IoCompletion>,
+    devices: Vec<Option<Arc<dyn Device>>>,
+    inboxes: Inboxes,
+    /// Operations performed but not yet reaped, in submission order.
+    done: Vec<(Descriptor, IoCompletion)>,
     order: CompletionOrder,
 }
 
-impl<B: BlockingIo> SyncQueue<B> {
-    /// Creates a queue over `io` with a fresh pool.
-    pub fn new(io: B, opts: &QueueOptions, order: CompletionOrder) -> io::Result<Self> {
+impl SyncQueue {
+    /// Creates a queue with a fresh pool owned by the calling thread.
+    pub fn new(opts: &QueueOptions, order: CompletionOrder) -> io::Result<Self> {
         Ok(Self {
-            io,
             pool: BufferPool::new(opts.pool)?,
             depth: opts.depth.max(1) as usize,
-            done: VecDeque::new(),
+            devices: (0..opts.descriptors.max(1)).map(|_| None).collect(),
+            inboxes: Inboxes::new(opts.descriptors),
+            done: Vec::new(),
             order,
         })
     }
 
-    fn check_capacity(&self) -> io::Result<()> {
-        if self.done.len() >= self.depth {
-            return Err(io::Error::new(io::ErrorKind::WouldBlock, "queue full"));
-        }
-        Ok(())
+    fn device(&self, desc: Descriptor) -> &Arc<dyn Device> {
+        self.devices
+            .get(desc.0 as usize)
+            .and_then(Option::as_ref)
+            .expect("operation on a detached descriptor")
     }
 }
 
-impl<B: BlockingIo> IoQueue for SyncQueue<B> {
+impl IoQueue for SyncQueue {
     fn pool(&self) -> &Arc<BufferPool> {
         &self.pool
     }
 
-    fn read(&mut self, mut buf: PooledBuf, len: usize, offset: u64, token: u64) -> io::Result<()> {
-        self.check_capacity()?;
-        let result = self.io.read_at(&mut buf[..len], offset).map(|()| len);
-        self.done.push_back(IoCompletion {
-            token,
-            result,
-            buf: Some(buf),
-        });
+    fn attach(&mut self, device: &Arc<dyn Device>) -> io::Result<Descriptor> {
+        let desc = self
+            .inboxes
+            .open()
+            .ok_or_else(|| io::Error::new(io::ErrorKind::OutOfMemory, "no free descriptor"))?;
+        self.devices[desc.0 as usize] = Some(device.clone());
+        Ok(desc)
+    }
+
+    fn detach(&mut self, desc: Descriptor) {
+        self.inboxes.close(desc);
+        if let Some(d) = self.devices.get_mut(desc.0 as usize) {
+            *d = None;
+        }
+    }
+
+    fn read(
+        &mut self,
+        desc: Descriptor,
+        mut buf: PooledBuf,
+        len: usize,
+        offset: u64,
+        token: u64,
+    ) -> Result<(), PooledBuf> {
+        if self.done.len() >= self.depth {
+            return Err(buf);
+        }
+        let result = self.device(desc).read_at(&mut buf[..len], offset).map(|()| len);
+        self.done.push((
+            desc,
+            IoCompletion {
+                token,
+                result,
+                buf: Some(buf),
+            },
+        ));
         Ok(())
     }
 
-    fn write(&mut self, buf: PooledBuf, len: usize, offset: u64, token: u64) -> io::Result<()> {
-        self.check_capacity()?;
-        let result = self.io.write_at(&buf[..len], offset).map(|()| len);
-        self.done.push_back(IoCompletion {
-            token,
-            result,
-            buf: Some(buf),
-        });
+    fn write(
+        &mut self,
+        desc: Descriptor,
+        buf: PooledBuf,
+        len: usize,
+        offset: u64,
+        token: u64,
+    ) -> Result<(), PooledBuf> {
+        if self.done.len() >= self.depth {
+            return Err(buf);
+        }
+        let result = self.device(desc).write_at(&buf[..len], offset).map(|()| len);
+        self.done.push((
+            desc,
+            IoCompletion {
+                token,
+                result,
+                buf: Some(buf),
+            },
+        ));
         Ok(())
     }
 
-    fn fsync(&mut self, token: u64) -> io::Result<()> {
-        self.check_capacity()?;
-        let result = self.io.sync().map(|()| 0);
-        self.done.push_back(IoCompletion {
-            token,
-            result,
-            buf: None,
-        });
+    fn fsync(&mut self, desc: Descriptor, token: u64) -> Result<(), Full> {
+        if self.done.len() >= self.depth {
+            return Err(Full);
+        }
+        let result = self.device(desc).sync().map(|()| 0);
+        self.done.push((
+            desc,
+            IoCompletion {
+                token,
+                result,
+                buf: None,
+            },
+        ));
         Ok(())
     }
 
@@ -192,13 +330,18 @@ impl<B: BlockingIo> IoQueue for SyncQueue<B> {
         Ok(())
     }
 
-    fn poll(&mut self, out: &mut Vec<IoCompletion>, _wait: bool) -> io::Result<usize> {
+    fn poll(&mut self, _wait: bool) -> io::Result<usize> {
         let n = self.done.len();
+        let done = std::mem::take(&mut self.done);
         match self.order {
-            CompletionOrder::Fifo => out.extend(self.done.drain(..)),
-            CompletionOrder::Reverse => out.extend(self.done.drain(..).rev()),
+            CompletionOrder::Fifo => done.into_iter().for_each(|(d, c)| self.inboxes.deliver(d, c)),
+            CompletionOrder::Reverse => done.into_iter().rev().for_each(|(d, c)| self.inboxes.deliver(d, c)),
         }
         Ok(n)
+    }
+
+    fn take(&mut self, desc: Descriptor, out: &mut Vec<IoCompletion>) -> usize {
+        self.inboxes.take(desc, out)
     }
 
     fn in_flight(&self) -> usize {

--- a/core/moat-engine/src/layout.rs
+++ b/core/moat-engine/src/layout.rs
@@ -30,8 +30,7 @@
 //!   pages its length allows.
 //! - A *framed* batch keeps all record headers in a header area at the front and every value page aligned after it. It
 //!   is used for values whose length is (just under) a multiple of the page size, where an inline header would push the
-//!   value across one more page: a 4 KiB value then costs exactly one page to read, verified against the CRC kept in
-//!   the index.
+//!   value across one more page: a 4 KiB value then costs exactly one page to read when verification is disabled.
 //!
 //! Every structure is self-describing: a magic value, then a CRC32C covering
 //! everything after it. Every batch carries the
@@ -39,6 +38,8 @@
 //! record carries its LSN. Together these make an unsealed segment recoverable
 //! by a forward scan and a reused segment immune to stale data from its
 //! previous life.
+
+use std::ops::Range;
 
 use moat_common::{ChunkId, PAGE_SIZE, align_down, align_up, block_count};
 
@@ -714,29 +715,34 @@ pub struct Extent {
     pub len: u64,
 }
 
-/// Describes what to read to access a record, given the offsets the index
-/// keeps for it.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Describes the pages covering a value range and an optional record header.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RecordGeometry {
     /// The aligned range that must be read.
     pub extent: Extent,
     /// Offset of the record header relative to `extent.start`, if the header
     /// is within the extent.
     pub header_in_extent: Option<u64>,
-    /// Offset of the value relative to `extent.start`.
-    pub value_in_extent: u64,
+    /// The requested value range relative to `extent.start`.
+    pub data_in_extent: Range<usize>,
 }
 
 impl RecordGeometry {
-    /// Computes the pages to read for a record whose header is at
-    /// `header_off` and whose value is at `value_off`. With `with_header` the
-    /// extent covers the header as well (for inline and large records this
-    /// adds nothing or one adjacent page; for framed records it may span back
-    /// to the batch's header area).
-    pub fn new(header_off: u64, value_off: u64, value_len: u32, with_header: bool) -> Self {
-        let value_end = value_off + value_len as u64;
-        let mut start = align_down(value_off, PAGE_SIZE);
-        let mut end = align_up(value_end.max(value_off + 1), PAGE_SIZE);
+    /// Computes the pages covering `range` within the value. The caller clamps
+    /// it to `value_len` and expands it to checksum blocks when verifying.
+    /// `with_header` also includes the complete record metadata.
+    pub fn new(header_off: u64, value_off: u64, value_len: u32, range: Range<u64>, with_header: bool) -> Self {
+        let data_start = value_off + range.start;
+        let data_end = value_off + range.end;
+        // Empty ranges use the preceding value byte when possible, so a range
+        // at the end of a page-aligned value does not read past the record.
+        let anchor = if range.is_empty() && range.start > 0 {
+            data_start - 1
+        } else {
+            data_start
+        };
+        let mut start = align_down(anchor, PAGE_SIZE);
+        let mut end = align_up(data_end.max(anchor + 1), PAGE_SIZE);
         if with_header {
             let meta = record_meta_len(value_len) as u64;
             start = start.min(align_down(header_off, PAGE_SIZE));
@@ -748,7 +754,7 @@ impl RecordGeometry {
                 len: end - start,
             },
             header_in_extent: with_header.then(|| header_off - start),
-            value_in_extent: value_off - start,
+            data_in_extent: (data_start - start) as usize..(data_end - start) as usize,
         }
     }
 
@@ -881,21 +887,21 @@ mod tests {
     #[test]
     fn geometry() {
         // Large record: header page then value, read together.
-        let g = RecordGeometry::new(4096 + BATCH_HEADER_LEN as u64, 8192, 100_000, true);
+        let g = RecordGeometry::new(4096 + BATCH_HEADER_LEN as u64, 8192, 100_000, 0..100_000, true);
         assert_eq!(g.extent.start, 4096);
         assert_eq!(g.header_in_extent, Some(BATCH_HEADER_LEN as u64));
-        assert_eq!(g.value_in_extent, 4096);
+        assert_eq!(g.data_in_extent, 4096..104_096);
         assert_eq!(g.extent.len, align_up(4096 + 100_000, PAGE_SIZE));
 
         // Inline record in the middle of a page.
         let meta = record_meta_len(500) as u64;
-        let g = RecordGeometry::new(8192 + 1000, 8192 + 1000 + meta, 500, true);
+        let g = RecordGeometry::new(8192 + 1000, 8192 + 1000 + meta, 500, 0..500, true);
         assert_eq!(g.extent, Extent { start: 8192, len: 4096 });
         assert_eq!(g.header_in_extent, Some(1000));
-        assert_eq!(g.value_in_extent, 1000 + meta);
+        assert_eq!(g.data_in_extent, (1000 + meta) as usize..(1500 + meta) as usize);
 
         // Framed record read without its header: exactly the value's pages.
-        let g = RecordGeometry::new(64, 3 * 4096, 4096, false);
+        let g = RecordGeometry::new(64, 3 * 4096, 4096, 0..4096, false);
         assert_eq!(
             g.extent,
             Extent {
@@ -904,9 +910,9 @@ mod tests {
             }
         );
         assert_eq!(g.header_in_extent, None);
-        assert_eq!(g.value_in_extent, 0);
+        assert_eq!(g.data_in_extent, 0..4096);
         // ...and with the header: back to the batch's header area.
-        let g = RecordGeometry::new(64, 3 * 4096, 4096, true);
+        let g = RecordGeometry::new(64, 3 * 4096, 4096, 0..4096, true);
         assert_eq!(
             g.extent,
             Extent {
@@ -917,8 +923,45 @@ mod tests {
         assert_eq!(g.header_in_extent, Some(64));
 
         // An empty value still reads its header page.
-        let g = RecordGeometry::new(100, 100 + 64, 0, true);
+        let g = RecordGeometry::new(100, 100 + 64, 0, 0..0, true);
         assert_eq!(g.extent, Extent { start: 0, len: 4096 });
+    }
+
+    #[test]
+    fn range_geometry_avoids_unrequested_pages() {
+        let g = RecordGeometry::new(4160, 8192, 131072, 70000..70010, false);
+        assert_eq!(
+            g.extent,
+            Extent {
+                start: 77824,
+                len: 4096
+            }
+        );
+        assert_eq!(g.data_in_extent, 368..378);
+        assert_eq!(g.header_in_extent, None);
+
+        // A verified first block includes the header but not the second block.
+        let g = RecordGeometry::new(4160, 8192, 131072, 0..65536, true);
+        assert_eq!(
+            g.extent,
+            Extent {
+                start: 4096,
+                len: 69632
+            }
+        );
+        assert_eq!(g.data_in_extent, 4096..69632);
+        assert_eq!(g.header_in_extent, Some(64));
+
+        // Empty ranges at EOF must not cross into the next page.
+        let g = RecordGeometry::new(4160, 8192, 131072, 131072..131072, false);
+        assert_eq!(
+            g.extent,
+            Extent {
+                start: 135168,
+                len: 4096
+            }
+        );
+        assert_eq!(g.data_in_extent, 4096..4096);
     }
 
     #[test]

--- a/core/moat-engine/src/layout.rs
+++ b/core/moat-engine/src/layout.rs
@@ -70,7 +70,7 @@ pub const SEGMENT_HEADER_LEN: u64 = PAGE_SIZE;
 pub const BATCH_HEADER_LEN: usize = 64;
 /// Encoded length of a [`RecordHeader`], excluding the block checksums.
 pub const RECORD_HEADER_LEN: usize = 64;
-/// Encoded length of a [`FooterHeader`].
+/// Encoded length of the footer header.
 pub const FOOTER_HEADER_LEN: usize = 64;
 /// Encoded length of a [`FooterEntry`].
 pub const FOOTER_ENTRY_LEN: usize = 48;
@@ -540,15 +540,6 @@ impl BlockChecksums<'_> {
 // ---------------------------------------------------------------------------
 // Footer
 // ---------------------------------------------------------------------------
-
-/// Header of a sealed segment's footer.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct FooterHeader {
-    /// Sequence number of the segment incarnation.
-    pub seg_seq: u64,
-    /// Number of [`FooterEntry`] that follow.
-    pub entry_count: u32,
-}
 
 /// One record of a sealed segment, as listed in its footer. Carries exactly
 /// what the index needs, so recovery rebuilds the index without reading data.

--- a/core/moat-engine/src/lib.rs
+++ b/core/moat-engine/src/lib.rs
@@ -25,45 +25,61 @@
 //! most two active segments (hot for foreground writes, cold for records
 //! relocated by reclaim) in self-describing, checksummed *batches*. When a
 //! segment fills up it is sealed with a *footer* listing every record, so
-//! recovery reads footers instead of data. An in-memory sharded hash *index*
+//! recovery reads footers instead of data. A lock-free in-memory hash *index*
 //! maps every chunk to its newest record. Deletes append *tombstones*. Space is
 //! reclaimed one segment at a time by relocating what is still live and freeing
 //! the segment; the same mechanism implements cache eviction under a different
 //! policy. There is no separate write-ahead log and no embedded key-value
 //! store: the log is the only source of truth.
 //!
-//! # Threads
+//! # Queues, engines and pipelines
 //!
-//! [`open`] returns exactly one [`Writer`] and a cloneable [`Reader`]. All
-//! mutations (put, delete, flush, reclaim) go through the writer, which is
-//! meant to be driven by one thread per disk. Any number of threads may read
-//! concurrently, each through its own [`ReadRing`] created from a reader
-//! handle. Every thread that does I/O owns an I/O queue (io_uring on Linux)
-//! and a buffer pool of pre-registered, huge-page backed memory; values move
-//! between pool buffers and the device without copies.
+//! A worker thread owns one [`IoQueue`] (io_uring on Linux: one ring, one
+//! registered buffer pool, one fixed-file table) and drives any number of
+//! engines through it. An [`Engine`] is a disk's shared state; a [`Writer`] or
+//! a [`Reader`] is a pipeline of that disk attached to one queue. Exactly one
+//! writer exists per disk (all mutations, sealing and reclaim go through it);
+//! any number of readers may exist, one per worker in practice. No engine call
+//! blocks: every method does memory work, enqueues I/O and returns a ticket,
+//! or reports [`Error::Busy`] when the pool is out of buffers. Completions are
+//! observed only through `poll`. Values move between pool buffers and the
+//! device without copies.
 //!
 //! # Example
 //!
 //! ```
 //! use std::sync::Arc;
-//! use moat_common::ChunkId;
-//! use moat_engine::{FormatOptions, MemDevice, Options, PutOptions, PutOutcome, QueueOptions};
+//! use moat_common::{ChunkId, HugePages, PoolOptions};
+//! use moat_engine::{
+//!     FormatOptions, MemDevice, Options, PutOptions, PutOutcome, QueueOptions, blocking,
+//!     io::{CompletionOrder, SyncQueue},
+//! };
 //!
 //! let device = Arc::new(MemDevice::new(16 << 20));
 //! moat_engine::format(&*device, &FormatOptions { segment_size: 1 << 20, chunk_max: 128 << 10, ..Default::default() })?;
-//! let opened = moat_engine::open(device, Options::default())?;
-//! let (mut writer, reader) = (opened.writer, opened.reader);
-//! let mut ring = reader.ring(&QueueOptions::default())?;
+//! let (engine, _report) = moat_engine::open(device, Options::default())?;
+//!
+//! // The worker owns the queue; the engine's pipelines attach to it.
+//! let opts = QueueOptions {
+//!     pool: PoolOptions { bytes: 8 << 20, max_class: 1 << 20, huge_pages: HugePages::Disabled },
+//!     ..Default::default()
+//! };
+//! let mut q = SyncQueue::new(&opts, CompletionOrder::Fifo)?;
+//! let mut writer = engine.writer(&mut q)?;
+//! let mut reader = engine.reader(&mut q)?;
 //!
 //! let id = ChunkId::from_u128(42);
-//! assert!(matches!(writer.put(id, b"hello", PutOptions::default())?, PutOutcome::Written { .. }));
-//! writer.flush()?;
-//! assert_eq!(ring.get_sync(&id, None)?.as_deref(), Some(&b"hello"[..]));
-//! assert!(writer.delete(&id)?);
-//! assert!(ring.get_sync(&id, None)?.is_none());
+//! let PutOutcome::Written { ticket, .. } = writer.put(&mut q, id, b"hello", PutOptions::default())? else {
+//!     unreachable!()
+//! };
+//! blocking::wait(&mut q, &mut writer, ticket)?;
+//! assert_eq!(blocking::get(&mut q, &mut reader, &id, None)?.as_deref(), Some(&b"hello"[..]));
+//! writer.detach(&mut q);
+//! reader.detach(&mut q);
 //! # Ok::<(), moat_engine::Error>(())
 //! ```
 
+pub mod blocking;
 mod codec;
 mod device;
 mod engine;
@@ -81,9 +97,13 @@ pub mod uring;
 mod writer;
 
 pub use device::{Device, FileDevice, MemDevice};
-pub use engine::{Opened, RecoveryReport, format, open};
+pub use engine::{ChunkStat, Engine, RecoveryReport, Usage, format, open};
 pub use error::{Error, Result};
-pub use io::{IoQueue, QueueOptions};
+pub use index::{FLAG_ACCESSED, FLAG_EXPIRES, FLAG_FRAMED, FLAG_LARGE, IndexValue, Location, MAX_READERS};
+pub use io::{Descriptor, IoQueue, QueueOptions};
 pub use options::{Clock, FormatOptions, ManualClock, Options, SystemClock};
-pub use reader::{ChunkData, ChunkStat, ReadCompletion, ReadOutcome, ReadRing, Reader, Usage};
-pub use writer::{Completion, LargeValue, Lsn, PutOptions, PutOutcome, ReclaimPolicy, ReclaimReport, Ticket, Writer};
+pub use reader::{ChunkData, ReadCompletion, ReadOutcome, Reader};
+pub use writer::{
+    Completion, DeleteOutcome, LargeValue, Lsn, Outcome, PutOptions, PutOutcome, ReclaimPolicy, ReclaimReport, Ticket,
+    Writer,
+};

--- a/core/moat-engine/src/options.rs
+++ b/core/moat-engine/src/options.rs
@@ -26,7 +26,6 @@ use moat_common::{PAGE_SIZE, is_aligned};
 
 use crate::{
     error::{Error, Result},
-    io::QueueOptions,
     layout::{BATCH_HEADER_LEN, SEGMENT_HEADER_LEN, footer_len, large_batch_len},
 };
 
@@ -90,27 +89,25 @@ pub struct Options {
     /// Default: 1 MiB.
     pub batch_limit: usize,
     /// Read window used when scanning segments (recovery, reclaim). Grows
-    /// automatically to fit the largest possible batch. Default: 4 MiB.
+    /// automatically to fit the largest possible batch; reclaim shrinks it
+    /// to the queue pool's largest class. Default: 4 MiB.
     pub scan_window: usize,
-    /// Number of index shards (rounded up to a power of two). Default: 64.
-    pub index_shards: usize,
+    /// Initial number of index slots (rounded up to a power of two; 64 bytes
+    /// each). The table doubles as needed within `index_memory_budget`.
+    /// Default: 1 Mi slots (64 MiB).
+    pub index_capacity: usize,
+    /// Maximum bytes the index table may occupy. Once reached, puts of new
+    /// chunks fail with [`Error::IndexFull`](crate::Error::IndexFull).
+    /// Default: unlimited.
+    pub index_memory_budget: usize,
     /// Whether `flush` also flushes the device's volatile write cache. Leave
     /// off on devices with power-loss protection. Default: `false`.
     pub sync_on_flush: bool,
-    /// The writer's I/O queue: depth and buffer pool. The pool's maximum class
-    /// is raised automatically to fit the largest batch, the batch limit and
-    /// the scan window.
-    pub queue: QueueOptions,
-    /// Minimum writer pool capacity as a multiple of its largest required
-    /// buffer class. Larger values allow more large I/O operations to remain
-    /// in flight; smaller values reduce mapped and registered memory. The
-    /// configured pool size remains the lower bound. Default: 8.
-    pub writer_pool_capacity_multiplier: usize,
-    /// Always read and verify a record's header (key, LSN, kind) on `get`.
-    /// Framed single-block records are otherwise verified from the CRC in the
-    /// index alone, which costs one page per read; with this on they read
-    /// their batch's header area as well. Default: `false`.
-    pub verify_header_on_read: bool,
+    /// Verify the record header and every checksum block touched by each `get`.
+    /// Default: `false`; reads trust the index and do not scan the payload with
+    /// the CPU. Expiring records still read and validate their header for TTL.
+    /// Writing checksums and recovery/reclaim validation are unaffected.
+    pub verify_reads: bool,
 }
 
 impl Default for Options {
@@ -120,11 +117,10 @@ impl Default for Options {
             pack_threshold: 64 * 1024,
             batch_limit: 1024 * 1024,
             scan_window: 4 * 1024 * 1024,
-            index_shards: 64,
+            index_capacity: 1 << 20,
+            index_memory_budget: usize::MAX,
             sync_on_flush: false,
-            queue: QueueOptions::default(),
-            writer_pool_capacity_multiplier: 8,
-            verify_header_on_read: false,
+            verify_reads: false,
         }
     }
 }
@@ -135,11 +131,10 @@ impl std::fmt::Debug for Options {
             .field("pack_threshold", &self.pack_threshold)
             .field("batch_limit", &self.batch_limit)
             .field("scan_window", &self.scan_window)
-            .field("index_shards", &self.index_shards)
+            .field("index_capacity", &self.index_capacity)
+            .field("index_memory_budget", &self.index_memory_budget)
             .field("sync_on_flush", &self.sync_on_flush)
-            .field("queue", &self.queue)
-            .field("writer_pool_capacity_multiplier", &self.writer_pool_capacity_multiplier)
-            .field("verify_header_on_read", &self.verify_header_on_read)
+            .field("verify_reads", &self.verify_reads)
             .finish_non_exhaustive()
     }
 }
@@ -152,9 +147,9 @@ impl Options {
         if self.batch_limit < PAGE_SIZE as usize {
             return Err(Error::InvalidOption("batch_limit must be at least one page".into()));
         }
-        if self.writer_pool_capacity_multiplier == 0 {
+        if self.index_memory_budget < self.index_capacity.max(16).next_power_of_two() * crate::index::SLOT_BYTES {
             return Err(Error::InvalidOption(
-                "writer_pool_capacity_multiplier must be at least one".into(),
+                "index_memory_budget must hold the initial index capacity".into(),
             ));
         }
         Ok(())
@@ -166,13 +161,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn writer_pool_capacity_multiplier_must_be_positive() {
-        assert_eq!(Options::default().writer_pool_capacity_multiplier, 8);
+    fn index_budget_must_cover_initial_capacity() {
         let options = Options {
-            writer_pool_capacity_multiplier: 0,
+            index_capacity: 1024,
+            index_memory_budget: 1024,
             ..Default::default()
         };
         assert!(matches!(options.validate(), Err(Error::InvalidOption(_))));
+        assert!(Options::default().validate().is_ok());
     }
 }
 

--- a/core/moat-engine/src/reader.rs
+++ b/core/moat-engine/src/reader.rs
@@ -323,6 +323,9 @@ impl Reader {
 
 impl Drop for Reader {
     fn drop(&mut self) {
+        for pending in self.pending.iter().flatten() {
+            self.shared.segments.unpin(pending.value.loc.seg_no);
+        }
         // The slot is a `Copy`-free token; hand it back by value.
         let slot = std::mem::replace(&mut self.slot, ReaderSlot::detached());
         if !slot.is_detached() {

--- a/core/moat-engine/src/reader.rs
+++ b/core/moat-engine/src/reader.rs
@@ -12,149 +12,43 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Concurrent read access to an engine.
+//! Read pipelines.
 //!
-//! [`Reader`] is a cheap, cloneable handle to the shared state (index, segment
-//! table, device). Actual reads go through a [`ReadRing`], which a thread
-//! creates for itself: it owns an I/O queue and buffer pool, submits reads,
-//! and hands back verified values as [`ChunkData`], a view into the pool buffer
-//! the device wrote into. No byte of the value is copied by the engine; the
-//! buffer is released when the `ChunkData` is dropped.
+//! A [`Reader`] is a disk's read pipeline bound to one queue: it looks chunks
+//! up in the shared index, submits the reads, optionally verifies them and
+//! hands out [`ChunkData`], a view into the pool buffer the device wrote into.
+//! No byte of the value is copied by the engine; the buffer is released when
+//! the `ChunkData` is dropped. Every worker holds one reader per disk on its
+//! own queue, so a read is served on the thread that received the request.
+//!
+//! Nothing here blocks: a read the queue has no room for waits in the
+//! reader's ready queue and is pushed by the next [`Reader::poll`];
+//! [`Error::Busy`] is reported only when the pool has no buffer for it.
 
 use std::{
+    collections::VecDeque,
     io,
     ops::{Deref, Range},
     sync::Arc,
 };
 
-use moat_common::{CHECKSUM_BLOCK_SIZE, ChunkId, PooledBuf, crc32c, verify_blocks_with};
+use moat_common::{CHECKSUM_BLOCK_SIZE, ChunkId, PooledBuf, verify_blocks_with};
 
 use crate::{
+    engine::ChunkStat,
     error::{Error, Result},
-    index::IndexValue,
-    io::{IoCompletion, IoQueue, QueueOptions},
-    layout::{RecordGeometry, RecordHeader, RecordKind, SegmentState, large_batch_len},
+    index::{IndexValue, ReaderSlot},
+    io::{Descriptor, IoCompletion, IoQueue},
+    layout::{RecordGeometry, RecordHeader, RecordKind},
     shared::Shared,
-    writer::Lsn,
 };
 
-/// Metadata about a stored chunk.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct ChunkStat {
-    /// Value length in bytes.
-    pub len: u32,
-    /// LSN of the newest record.
-    pub lsn: Lsn,
-    /// Physical segment holding the record.
-    pub segment: u32,
-    /// Offset of the value within the segment.
-    pub value_offset: u32,
-    /// Whether the record is stored framed (header apart from the page
-    /// aligned value).
-    pub framed: bool,
-}
-
-/// Space usage of an engine.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct Usage {
-    /// Total number of segments.
-    pub segments: u32,
-    /// Segments not in use.
-    pub free_segments: u32,
-    /// Segments closed and eligible for reclaim.
-    pub sealed_segments: u32,
-    /// Bytes of records the index points at, across all segments.
-    pub live_bytes: u64,
-    /// Number of chunks in the index.
-    pub chunks: usize,
-}
-
-/// A handle to an engine's shared state. Cheap to clone; create a
-/// [`ReadRing`] per thread to read data.
-#[derive(Clone)]
-pub struct Reader {
-    shared: Arc<Shared>,
-}
-
-impl Reader {
-    pub(crate) fn new(shared: Arc<Shared>) -> Self {
-        Self { shared }
-    }
-
-    /// Opens a read ring for the calling thread.
-    ///
-    /// The pool's maximum class is raised to fit the largest record if needed.
-    pub fn ring(&self, opts: &QueueOptions) -> Result<ReadRing> {
-        let mut opts = *opts;
-        let largest = large_batch_len(self.shared.superblock.chunk_max) as usize;
-        opts.pool.max_class = opts.pool.max_class.max(largest.next_power_of_two());
-        let queue = self.shared.device.open_queue(&opts)?;
-        let depth = queue.depth();
-        Ok(ReadRing {
-            shared: self.shared.clone(),
-            queue,
-            pending: (0..depth).map(|_| None).collect(),
-            free_slots: (0..depth as u32).rev().collect(),
-            scratch: Vec::new(),
-        })
-    }
-
-    /// Returns metadata about a chunk without touching the disk.
-    ///
-    /// Expiry is not evaluated here; an expired chunk still reports its stat
-    /// until reclaim drops it.
-    pub fn stat(&self, id: &ChunkId) -> Option<ChunkStat> {
-        self.shared.index.get(id).map(|v| ChunkStat {
-            len: v.value_len,
-            lsn: v.lsn,
-            segment: v.loc.seg_no,
-            value_offset: v.value_off,
-            framed: v.is_framed(),
-        })
-    }
-
-    /// Whether a chunk exists in the index.
-    pub fn contains(&self, id: &ChunkId) -> bool {
-        self.shared.index.get(id).is_some()
-    }
-
-    /// Current space usage.
-    pub fn usage(&self) -> Usage {
-        let segments = &self.shared.segments;
-        let mut usage = Usage {
-            segments: segments.len(),
-            free_segments: 0,
-            sealed_segments: 0,
-            live_bytes: 0,
-            chunks: self.shared.index.len(),
-        };
-        for s in segments.iter() {
-            match segments.state(s) {
-                SegmentState::Free => usage.free_segments += 1,
-                SegmentState::Sealed => usage.sealed_segments += 1,
-                SegmentState::Active => {}
-            }
-            usage.live_bytes += segments.live_bytes(s);
-        }
-        usage
-    }
-
-    /// The segment size this device was formatted with.
-    pub fn segment_size(&self) -> u64 {
-        self.shared.superblock.segment_size
-    }
-
-    /// The largest value this device accepts.
-    pub fn chunk_max(&self) -> u32 {
-        self.shared.superblock.chunk_max
-    }
-}
-
-/// A verified value (or part of one) in the buffer the device read it into.
+/// A value (or part of one) in the buffer the device read it into.
+/// Verification is controlled by [`Options::verify_reads`](crate::Options::verify_reads).
 ///
 /// Dereferences to the requested bytes. Dropping it returns the buffer to the
-/// ring's pool; [`ChunkData::into_raw`] hands the buffer over for callers that
-/// DMA out of it directly.
+/// pool; [`ChunkData::into_raw`] hands the buffer over for callers that DMA
+/// out of it directly.
 pub struct ChunkData {
     buf: PooledBuf,
     range: Range<usize>,
@@ -188,19 +82,19 @@ impl std::fmt::Debug for ChunkData {
     }
 }
 
-/// Immediate result of [`ReadRing::get`].
+/// Immediate result of [`Reader::get`].
 #[derive(Debug, PartialEq, Eq)]
 pub enum ReadOutcome {
     /// The chunk is not in the index; nothing was submitted.
     Miss,
-    /// A read was submitted; its [`ReadCompletion`] carries the caller's token.
+    /// A read was accepted; its [`ReadCompletion`] carries the caller's token.
     Submitted,
 }
 
 /// A finished read.
 #[derive(Debug)]
 pub struct ReadCompletion {
-    /// The token passed to [`ReadRing::get`].
+    /// The token passed to [`Reader::get`].
     pub token: u64,
     /// The bytes, `None` if the chunk had expired, or an error.
     pub result: Result<Option<ChunkData>>,
@@ -210,38 +104,73 @@ struct PendingRead {
     id: ChunkId,
     value: IndexValue,
     geometry: RecordGeometry,
-    range: Range<u64>,
+    range: Range<usize>,
+    first_block: u32,
     user_token: u64,
 }
 
-/// A per-thread read pipeline.
-///
-/// Owns an I/O queue and its buffer pool. [`ReadRing::get`] looks a chunk up
-/// and submits the read; [`ReadRing::poll`] reaps, verifies and hands back
-/// [`ChunkData`] views into the pool buffers the device wrote into, so the
-/// engine copies no value bytes.
-pub struct ReadRing {
+/// A read waiting for queue room.
+struct ReadyRead {
+    slot: u32,
+    buf: PooledBuf,
+    len: usize,
+    offset: u64,
+}
+
+/// A disk's read pipeline on one queue: looks chunks up, submits reads through
+/// the caller's queue and hands back zero-copy views. Nothing blocks.
+pub struct Reader {
     shared: Arc<Shared>,
-    queue: Box<dyn IoQueue>,
-    /// In-flight reads indexed by the slot number used as the I/O token.
+    desc: Descriptor,
+    slot: ReaderSlot,
+    /// Reads accepted and not yet finished, indexed by the slot number used
+    /// as the I/O token.
     pending: Vec<Option<PendingRead>>,
     free_slots: Vec<u32>,
+    ready: VecDeque<ReadyRead>,
     scratch: Vec<IoCompletion>,
 }
 
-impl ReadRing {
+impl Reader {
+    pub(crate) fn new(shared: Arc<Shared>, desc: Descriptor, slot: ReaderSlot) -> Self {
+        Self {
+            shared,
+            desc,
+            slot,
+            pending: Vec::new(),
+            free_slots: Vec::new(),
+            ready: VecDeque::new(),
+            scratch: Vec::new(),
+        }
+    }
+
+    /// Returns metadata about a chunk without touching the disk.
+    ///
+    /// Expiry is not evaluated here; an expired chunk still reports its stat
+    /// until reclaim drops it.
+    pub fn stat(&self, id: &ChunkId) -> Option<ChunkStat> {
+        self.shared.index.get(&self.slot, id).map(|v| ChunkStat::from_value(&v))
+    }
+
+    /// Whether a chunk exists in the index.
+    pub fn contains(&self, id: &ChunkId) -> bool {
+        self.shared.index.get(&self.slot, id).is_some()
+    }
+
     /// Looks a chunk up and, if present, submits the read covering `range`
     /// (the whole value when `None`). A range past the end is clamped.
     ///
-    /// Fails with [`Error::Busy`] when no buffer or queue slot is free; poll
-    /// and retry.
-    pub fn get(&mut self, id: &ChunkId, range: Option<Range<u64>>, token: u64) -> Result<ReadOutcome> {
-        let Some(slot) = self.free_slots.pop() else {
-            return Err(Error::Busy);
-        };
+    /// Fails with [`Error::Busy`] when the pool has no buffer for the read;
+    /// poll and retry.
+    pub fn get(
+        &mut self,
+        q: &mut dyn IoQueue,
+        id: &ChunkId,
+        range: Option<Range<u64>>,
+        token: u64,
+    ) -> Result<ReadOutcome> {
         let shared = &*self.shared;
-        let Some(value) = shared.index.get_and_pin(id, &shared.segments) else {
-            self.free_slots.push(slot);
+        let Some(value) = shared.index.get_and_pin(&self.slot, id, &shared.segments) else {
             return Ok(ReadOutcome::Miss);
         };
         let total = value.value_len as u64;
@@ -252,52 +181,60 @@ impl ReadRing {
                 start..r.end.min(total).max(start)
             }
         };
-        // Framed single-block records are verified from the index CRC without
-        // their header; everything else (and any record with an expiry, or a
-        // strict configuration) reads the header too.
-        let with_header = !value.is_framed()
-            || value.expires()
-            || shared.options.verify_header_on_read
-            || value.value_len as usize > CHECKSUM_BLOCK_SIZE;
+        let verify = shared.options.verify_reads;
+        let mut covered = range.clone();
+        if verify && !range.is_empty() {
+            let block = CHECKSUM_BLOCK_SIZE as u64;
+            covered.start = range.start / block * block;
+            covered.end = (range.end.div_ceil(block) * block).min(total);
+        }
+        let first_block = (covered.start / CHECKSUM_BLOCK_SIZE as u64) as u32;
         let geometry = RecordGeometry::new(
             value.loc.offset as u64,
             value.value_off as u64,
             value.value_len,
-            with_header,
+            covered,
+            verify || value.expires(),
         );
-        let Some(buf) = self.queue.pool().alloc(geometry.extent.len as usize) else {
+        let range = (value.value_off as u64 + range.start - geometry.extent.start) as usize
+            ..(value.value_off as u64 + range.end - geometry.extent.start) as usize;
+        let len = geometry.extent.len as usize;
+        let Some(buf) = q.pool().alloc(len) else {
             shared.segments.unpin(value.loc.seg_no);
-            self.free_slots.push(slot);
             return Err(Error::Busy);
         };
         let offset = shared.geometry.segment_offset(value.loc.seg_no) + geometry.extent.start;
-        if let Err(e) = self.queue.read(buf, geometry.extent.len as usize, offset, slot as u64) {
-            shared.segments.unpin(value.loc.seg_no);
-            self.free_slots.push(slot);
-            return Err(Error::Io(e));
-        }
+        let slot = match self.free_slots.pop() {
+            Some(s) => s,
+            None => {
+                self.pending.push(None);
+                (self.pending.len() - 1) as u32
+            }
+        };
         self.pending[slot as usize] = Some(PendingRead {
             id: *id,
             value,
             geometry,
             range,
+            first_block,
             user_token: token,
         });
+        if let Err(buf) = q.read(self.desc, buf, len, offset, slot as u64) {
+            self.ready.push_back(ReadyRead { slot, buf, len, offset });
+        }
         Ok(ReadOutcome::Submitted)
     }
 
-    /// Pushes submitted reads to the device without waiting.
-    pub fn submit(&mut self) -> Result<()> {
-        self.queue.submit()?;
-        Ok(())
-    }
-
-    /// Reaps finished reads, verifies them, and appends the results to `out`.
-    /// With `wait` set and reads in flight, blocks until at least one
-    /// completes. Returns the number appended.
-    pub fn poll(&mut self, out: &mut Vec<ReadCompletion>, wait: bool) -> Result<usize> {
+    /// Finishes reads, appends them to `out`, and pushes reads that
+    /// were waiting for queue room. Never waits. Returns the number appended.
+    pub fn poll(&mut self, q: &mut dyn IoQueue, out: &mut Vec<ReadCompletion>) -> Result<usize> {
+        // A worker visits every disk, but often has requests on only a few.
+        // An idle reader cannot have completions in its private descriptor.
+        if self.in_flight() == 0 {
+            return Ok(0);
+        }
         self.scratch.clear();
-        self.queue.poll(&mut self.scratch, wait)?;
+        q.take(self.desc, &mut self.scratch);
         let mut n = 0;
         let mut finished = std::mem::take(&mut self.scratch);
         for done in finished.drain(..) {
@@ -308,14 +245,6 @@ impl ReadRing {
             self.free_slots.push(slot);
             let result = self.finish(&pending, done);
             self.shared.segments.unpin(pending.value.loc.seg_no);
-            if let Err(Error::Corrupt(_)) = &result
-                && let Some(old) = self.shared.index.remove_if_at(&pending.id, pending.value.loc)
-            {
-                self.shared.segments.sub_live(
-                    old.loc.seg_no,
-                    RecordGeometry::footprint(old.value_len, old.record_flags()),
-                );
-            }
             out.push(ReadCompletion {
                 token: pending.user_token,
                 result,
@@ -323,32 +252,32 @@ impl ReadRing {
             n += 1;
         }
         self.scratch = finished;
+        while q.vacant() > 0 {
+            let Some(r) = self.ready.pop_front() else {
+                break;
+            };
+            if let Err(buf) = q.read(self.desc, r.buf, r.len, r.offset, r.slot as u64) {
+                self.ready.push_front(ReadyRead { buf, ..r });
+                break;
+            }
+        }
         Ok(n)
     }
 
-    /// Reads a chunk synchronously: submits, waits, returns the value (or the
-    /// requested range of it). Convenience for tools and tests.
-    pub fn get_sync(&mut self, id: &ChunkId, range: Option<Range<u64>>) -> Result<Option<ChunkData>> {
-        const TOKEN: u64 = u64::MAX;
-        match self.get(id, range, TOKEN)? {
-            ReadOutcome::Miss => return Ok(None),
-            ReadOutcome::Submitted => {}
-        }
-        let mut out = Vec::with_capacity(1);
-        loop {
-            self.poll(&mut out, true)?;
-            if let Some(pos) = out.iter().position(|c| c.token == TOKEN) {
-                return out.swap_remove(pos).result;
-            }
-        }
-    }
-
-    /// Reads in flight.
+    /// Reads accepted and not yet finished (including those waiting for
+    /// queue room).
     pub fn in_flight(&self) -> usize {
         self.pending.len() - self.free_slots.len()
     }
 
-    /// Verifies a completed read and cuts the requested range out of it.
+    /// Closes the descriptor. Reads still in flight are abandoned (their
+    /// buffers return to the pool when they complete).
+    pub fn detach(self, q: &mut dyn IoQueue) {
+        q.detach(self.desc);
+        drop(self);
+    }
+
+    /// Applies optional verification and returns the requested range.
     fn finish(&self, pending: &PendingRead, done: IoCompletion) -> Result<Option<ChunkData>> {
         let id = &pending.id;
         let value = &pending.value;
@@ -364,47 +293,40 @@ impl ReadRing {
             Err(e) => return Err(Error::Io(e)),
         };
 
-        let range = &pending.range;
-        let value_at = geometry.value_in_extent as usize;
-        match geometry.header_in_extent {
-            Some(header_at) => {
-                let (header, checksums) = RecordHeader::decode(&buf[header_at as usize..])
-                    .ok_or_else(|| Error::corrupt(format!("chunk {id}: record header invalid")))?;
-                if header.key != *id || header.lsn != value.lsn || header.value_len != value.value_len {
-                    return Err(Error::corrupt(format!(
-                        "chunk {id}: record header does not match index"
-                    )));
-                }
-                if header.kind != RecordKind::Data {
-                    return Err(Error::corrupt(format!("chunk {id}: index points at a tombstone")));
-                }
-                if self.shared.is_expired(header.expire_at) {
-                    return Ok(None);
-                }
-                if !range.is_empty() {
-                    // Verify only the checksum blocks the range touches.
-                    let block = CHECKSUM_BLOCK_SIZE as u64;
-                    let first_block = range.start / block;
-                    let verify_end = (((range.end - 1) / block + 1) * block).min(value.value_len as u64);
-                    let covered = &buf[value_at + (first_block * block) as usize..value_at + verify_end as usize];
-                    if let Err(block) = verify_blocks_with(covered, first_block as u32, |i| checksums.get(i)) {
-                        return Err(Error::corrupt(format!("chunk {id}: checksum block {block} mismatch")));
-                    }
-                }
+        if let Some(header_at) = geometry.header_in_extent {
+            let (header, checksums) = RecordHeader::decode(&buf[header_at as usize..])
+                .ok_or_else(|| Error::corrupt(format!("chunk {id}: record header invalid")))?;
+            if header.key != *id || header.lsn != value.lsn || header.value_len != value.value_len {
+                return Err(Error::corrupt(format!(
+                    "chunk {id}: record header does not match index"
+                )));
             }
-            None => {
-                // Header-less read: the value is a single checksum block whose
-                // CRC the index carries. The pin protocol guarantees the
-                // location is current; the CRC guards against media errors.
-                let whole = &buf[value_at..value_at + value.value_len as usize];
-                if crc32c(whole) != value.crc {
-                    return Err(Error::corrupt(format!("chunk {id}: value checksum mismatch")));
+            if header.kind != RecordKind::Data {
+                return Err(Error::corrupt(format!("chunk {id}: index points at a tombstone")));
+            }
+            if self.shared.is_expired(header.expire_at) {
+                return Ok(None);
+            }
+            if self.shared.options.verify_reads {
+                let covered = &buf[geometry.data_in_extent.clone()];
+                if let Err(block) = verify_blocks_with(covered, pending.first_block, |i| checksums.get(i)) {
+                    return Err(Error::corrupt(format!("chunk {id}: checksum block {block} mismatch")));
                 }
             }
         }
         Ok(Some(ChunkData {
             buf,
-            range: value_at + range.start as usize..value_at + range.end as usize,
+            range: pending.range.clone(),
         }))
+    }
+}
+
+impl Drop for Reader {
+    fn drop(&mut self) {
+        // The slot is a `Copy`-free token; hand it back by value.
+        let slot = std::mem::replace(&mut self.slot, ReaderSlot::detached());
+        if !slot.is_detached() {
+            self.shared.index.unregister(slot);
+        }
     }
 }

--- a/core/moat-engine/src/scan.rs
+++ b/core/moat-engine/src/scan.rs
@@ -133,8 +133,8 @@ pub(crate) fn parse_batch<'a>(batch: &'a [u8], header: &BatchHeader, verify: boo
 pub(crate) enum BatchStep {
     /// A well-formed batch of `len` bytes starts here.
     Batch(BatchHeader, usize),
-    /// A well-formed batch header, but the batch extends past the window; the
-    /// caller must re-read from this position with a larger window.
+    /// The next header or batch extends past the window; the caller must
+    /// read another window starting at this position.
     NeedMore,
     /// Not a batch of this segment incarnation: the end of valid data.
     End,
@@ -146,8 +146,11 @@ pub(crate) enum BatchStep {
 /// scannable region of the segment; `max_batch` bounds the largest batch the
 /// engine could have written.
 pub(crate) fn next_batch(window: &[u8], rel: usize, seg_seq: u64, max_batch: u64, remaining: u64) -> BatchStep {
-    if remaining < BATCH_HEADER_LEN as u64 || rel + BATCH_HEADER_LEN > window.len() {
+    if remaining < BATCH_HEADER_LEN as u64 {
         return BatchStep::End;
+    }
+    if rel + BATCH_HEADER_LEN > window.len() {
+        return BatchStep::NeedMore;
     }
     let Some(header) = BatchHeader::decode(&window[rel..]) else {
         return BatchStep::End;
@@ -209,8 +212,8 @@ pub(crate) fn scan_batches_blocking(
                     rel += batch_len;
                 }
                 // The window always holds at least one maximal batch, so
-                // `NeedMore` here means the batch straddles the window end:
-                // continue from its start.
+                // `NeedMore` means the next batch straddles the window end
+                // or starts just beyond it: continue from its start.
                 BatchStep::NeedMore => break,
                 BatchStep::End => return Ok(cursor + rel as u64),
             }

--- a/core/moat-engine/src/segments.rs
+++ b/core/moat-engine/src/segments.rs
@@ -59,6 +59,8 @@ struct SegmentMeta {
     seq: AtomicU64,
     live_bytes: AtomicU64,
     pins: AtomicU32,
+    /// Sealed segments: offset where record data ends (and the footer starts).
+    data_end: AtomicU64,
 }
 
 /// Per-segment state visible to all threads.
@@ -79,6 +81,7 @@ impl SegmentTable {
                 seq: AtomicU64::new(0),
                 live_bytes: AtomicU64::new(0),
                 pins: AtomicU32::new(0),
+                data_end: AtomicU64::new(0),
             })
             .collect();
         Self { metas }
@@ -106,6 +109,19 @@ impl SegmentTable {
     /// Sequence number of the segment's current incarnation.
     pub fn seq(&self, seg_no: u32) -> u64 {
         self.meta(seg_no).seq.load(Ordering::Acquire)
+    }
+
+    /// Usage kind of the segment's current incarnation.
+    pub fn kind(&self, seg_no: u32) -> SegmentKind {
+        match self.meta(seg_no).kind.load(Ordering::Relaxed) {
+            1 => SegmentKind::Cold,
+            _ => SegmentKind::Hot,
+        }
+    }
+
+    /// Offset within a sealed segment where its record data ends.
+    pub fn data_end(&self, seg_no: u32) -> u64 {
+        self.meta(seg_no).data_end.load(Ordering::Acquire)
     }
 
     /// Bytes of records in the segment that the index still points at.
@@ -136,8 +152,11 @@ impl SegmentTable {
         m.state.store(state as u8, Ordering::Release);
     }
 
-    pub(crate) fn set_state(&self, seg_no: u32, state: SegmentState) {
-        self.meta(seg_no).state.store(state as u8, Ordering::Release);
+    /// Marks the segment sealed with its data ending at `data_end`.
+    pub(crate) fn set_sealed(&self, seg_no: u32, data_end: u64) {
+        let m = self.meta(seg_no);
+        m.data_end.store(data_end, Ordering::Release);
+        m.state.store(SegmentState::Sealed as u8, Ordering::Release);
     }
 
     pub(crate) fn add_live(&self, seg_no: u32, bytes: u64) {

--- a/core/moat-engine/src/shared.rs
+++ b/core/moat-engine/src/shared.rs
@@ -14,7 +14,10 @@
 
 //! State shared by the writer and all readers of one engine instance.
 
-use std::sync::Arc;
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, AtomicU64},
+};
 
 use moat_common::{AlignedBuf, PAGE_SIZE};
 
@@ -31,9 +34,17 @@ pub(crate) struct Shared {
     pub(crate) device: Arc<dyn Device>,
     pub(crate) superblock: Superblock,
     pub(crate) geometry: Geometry,
-    pub(crate) index: Index,
+    pub(crate) index: Arc<Index>,
     pub(crate) segments: SegmentTable,
     pub(crate) options: Options,
+    /// Whether a `Writer` currently exists for this engine.
+    pub(crate) writer_taken: AtomicBool,
+    /// Written only by the writer (and recovery): the LSN the next record
+    /// receives and the sequence number the next segment allocation receives,
+    /// so a writer re-created after `detach` continues where the previous one
+    /// stopped.
+    pub(crate) next_lsn: AtomicU64,
+    pub(crate) next_seq: AtomicU64,
 }
 
 impl Shared {
@@ -45,7 +56,8 @@ impl Shared {
         Ok(buf)
     }
 
-    /// Writes `data` at `offset` within segment `seg_no`.
+    /// Writes `data` at `offset` within segment `seg_no` (blocking; recovery
+    /// only).
     pub(crate) fn write_segment_bytes(&self, seg_no: u32, offset: u64, data: &[u8]) -> Result<()> {
         debug_assert!(offset.is_multiple_of(PAGE_SIZE) && (data.len() as u64).is_multiple_of(PAGE_SIZE));
         self.device
@@ -59,12 +71,33 @@ impl Shared {
         SegmentHeader::decode(&buf)
     }
 
+    /// Writes a segment header (blocking; recovery only).
     pub(crate) fn write_segment_header(&self, header: &SegmentHeader) -> Result<()> {
         let mut buf = AlignedBuf::zeroed(SEGMENT_HEADER_LEN as usize);
         header.encode(&mut buf);
         self.device
             .write_at(&buf, self.geometry.segment_offset(header.seg_no))?;
         Ok(())
+    }
+
+    /// A segment header for `seg_no` in `state`.
+    pub(crate) fn segment_header(
+        &self,
+        seg_no: u32,
+        state: crate::layout::SegmentState,
+        kind: crate::layout::SegmentKind,
+        seq: u64,
+    ) -> SegmentHeader {
+        SegmentHeader {
+            disk_uuid: self.superblock.disk_uuid,
+            seg_no,
+            state,
+            kind,
+            seq,
+            footer_offset: 0,
+            footer_len: 0,
+            record_count: 0,
+        }
     }
 
     pub(crate) fn now(&self) -> u64 {

--- a/core/moat-engine/src/uring.rs
+++ b/core/moat-engine/src/uring.rs
@@ -16,41 +16,75 @@
 //!
 //! One ring per queue (and therefore per thread). The queue's buffer pool
 //! arenas are registered as fixed buffers once, so every read and write is a
-//! `READ_FIXED`/`WRITE_FIXED` with no per-operation page pinning. SQPOLL is
-//! deliberately not used: a kernel polling thread per ring competes with the
-//! pinned application threads for cores; the application already batches
-//! submissions per poll cycle, which achieves the same syscall amortisation.
+//! `READ_FIXED`/`WRITE_FIXED` with no per-operation page pinning; attached
+//! devices live in a sparse fixed-file table, so operations name a slot instead
+//! of a file descriptor. The ring is created with `SINGLE_ISSUER` and
+//! `DEFER_TASKRUN` where the kernel supports them (completion work then runs
+//! only inside our own `io_uring_enter`, never as an interrupt on the pinned
+//! core) and falls back to a plain ring otherwise. SQPOLL is deliberately not
+//! used: a kernel polling thread per ring competes with the pinned application
+//! threads for cores; the application already batches submissions per poll
+//! cycle, which achieves the same syscall amortisation.
 
 use std::{
-    fs::File,
     io,
-    os::fd::{AsRawFd, OwnedFd},
+    os::fd::{AsRawFd, RawFd},
     sync::Arc,
 };
 
 use io_uring::{IoUring, opcode, types};
 use moat_common::{BufferPool, PooledBuf};
 
-use crate::io::{IoCompletion, IoQueue, QueueOptions};
+use crate::{
+    device::Device,
+    io::{Descriptor, Full, Inboxes, IoCompletion, IoQueue, QueueOptions},
+};
 
-/// An io_uring backed queue over one file descriptor.
+/// `IORING_ENTER_GETEVENTS`: with `DEFER_TASKRUN` completion work only runs
+/// when we enter with this flag, so a non-waiting reap must still set it.
+const ENTER_GETEVENTS: u32 = 1;
+
+struct Slot {
+    desc: Descriptor,
+    token: u64,
+    buf: Option<PooledBuf>,
+}
+
+/// An io_uring backed queue. See the [module docs](self).
 pub struct UringQueue {
     ring: IoUring,
-    fd: OwnedFd,
     pool: Arc<BufferPool>,
-    /// In-flight operations indexed by the slot number carried in `user_data`:
-    /// the caller's token and the buffer to hand back.
-    slots: Vec<Option<(u64, Option<PooledBuf>)>>,
+    inboxes: Inboxes,
+    /// In-flight operations indexed by the slot number carried in `user_data`.
+    slots: Vec<Option<Slot>>,
     free_slots: Vec<u32>,
-    unsubmitted: usize,
+    /// Entries accepted since the last submit. They are copied into the
+    /// submission ring in one go at submit time: opening the ring's view per
+    /// entry would read the kernel-written head and write the tail every
+    /// time, two cache-line transfers per operation.
+    staged: Vec<io_uring::squeue::Entry>,
+    /// Whether the ring runs with `DEFER_TASKRUN` (completions must be pulled
+    /// with `GETEVENTS`).
+    deferred: bool,
 }
 
 impl UringQueue {
-    /// Creates a ring of `opts.depth` entries over `file` and registers the
-    /// pool's arenas as fixed buffers.
-    pub fn new(file: File, opts: &QueueOptions) -> io::Result<Self> {
+    /// Creates a ring of `opts.depth` entries, a sparse file table of
+    /// `opts.descriptors` slots, and registers the pool's arenas as fixed
+    /// buffers. Must be called on the thread that will drive the queue.
+    pub fn new(opts: &QueueOptions) -> io::Result<Self> {
         let depth = opts.depth.clamp(1, 32 * 1024).next_power_of_two();
-        let ring = IoUring::builder().setup_cqsize(depth * 2).build(depth)?;
+        let (ring, deferred) = match IoUring::builder()
+            .setup_cqsize(depth * 2)
+            .setup_single_issuer()
+            .setup_defer_taskrun()
+            .build(depth)
+        {
+            Ok(ring) => (ring, true),
+            Err(_) => (IoUring::builder().setup_cqsize(depth * 2).build(depth)?, false),
+        };
+        let files = opts.descriptors.max(1);
+        ring.submitter().register_files_sparse(files)?;
         let pool = BufferPool::new(opts.pool)?;
         let iovecs: Vec<libc::iovec> = pool
             .arenas()
@@ -65,44 +99,51 @@ impl UringQueue {
         unsafe { ring.submitter().register_buffers(&iovecs)? };
         Ok(Self {
             ring,
-            fd: file.into(),
             pool,
+            inboxes: Inboxes::new(files),
             slots: (0..depth).map(|_| None).collect(),
             free_slots: (0..depth).rev().collect(),
-            unsubmitted: 0,
+            staged: Vec::with_capacity(depth as usize),
+            deferred,
         })
     }
 
-    /// Reserves a slot for an operation, or fails if the ring is full.
-    fn reserve(&mut self) -> io::Result<u32> {
-        self.free_slots
-            .pop()
-            .ok_or_else(|| io::Error::new(io::ErrorKind::WouldBlock, "ring full"))
+    /// Whether the ring was set up with `DEFER_TASKRUN`.
+    pub fn deferred_taskrun(&self) -> bool {
+        self.deferred
     }
 
     fn push(
         &mut self,
         entry: io_uring::squeue::Entry,
         slot: u32,
+        desc: Descriptor,
         token: u64,
         buf: Option<PooledBuf>,
-    ) -> io::Result<()> {
-        if self.ring.submission().is_full() {
-            self.submit()?;
-        }
-        // SAFETY: the buffer referenced by `entry` (if any) is stored in
-        // `slots` below and stays there until the CQE for `slot` is reaped, so
-        // the memory outlives the operation.
-        if let Err(e) = unsafe { self.ring.submission().push(&entry) } {
-            self.free_slots.push(slot);
-            return Err(io::Error::new(io::ErrorKind::WouldBlock, e.to_string()));
-        }
-        self.slots[slot as usize] = Some((token, buf));
-        self.unsubmitted += 1;
-        Ok(())
+    ) {
+        self.staged.push(entry);
+        self.slots[slot as usize] = Some(Slot { desc, token, buf });
     }
 
-    fn reap(&mut self, out: &mut Vec<IoCompletion>) -> usize {
+    /// Moves staged entries into the submission ring. The ring holds `depth`
+    /// entries and at most `depth` slots are ever reserved, and the kernel
+    /// consumes the ring at every submit, so it cannot be full here.
+    fn stage_to_ring(&mut self) {
+        if self.staged.is_empty() {
+            return;
+        }
+        let mut sq = self.ring.submission();
+        for entry in self.staged.drain(..) {
+            // SAFETY: the buffer referenced by `entry` (if any) is held in
+            // `slots` until the CQE for its slot is reaped, so the memory
+            // outlives the operation.
+            if let Err(e) = unsafe { sq.push(&entry) } {
+                unreachable!("submission queue full with a free slot: {e}");
+            }
+        }
+    }
+
+    fn reap(&mut self) -> usize {
         let mut n = 0;
         let mut cq = self.ring.completion();
         cq.sync();
@@ -114,12 +155,25 @@ impl UringQueue {
             } else {
                 Ok(res as usize)
             };
-            let (token, buf) = self.slots[slot as usize].take().expect("completion for a live slot");
+            let Slot { desc, token, buf } = self.slots[slot as usize].take().expect("completion for a live slot");
             self.free_slots.push(slot);
-            out.push(IoCompletion { token, result, buf });
+            self.inboxes.deliver(desc, IoCompletion { token, result, buf });
             n += 1;
         }
         n
+    }
+
+    fn enter(&mut self, want: u32) -> io::Result<()> {
+        self.stage_to_ring();
+        let to_submit = self.ring.submission().len() as u32;
+        // SAFETY: no extended arguments are passed; the kernel validates the
+        // ring fd and flags.
+        unsafe {
+            self.ring
+                .submitter()
+                .enter::<libc::sigset_t>(to_submit, want, ENTER_GETEVENTS, None)?;
+        }
+        Ok(())
     }
 }
 
@@ -128,61 +182,107 @@ impl IoQueue for UringQueue {
         &self.pool
     }
 
-    fn read(&mut self, mut buf: PooledBuf, len: usize, offset: u64, token: u64) -> io::Result<()> {
-        debug_assert!(len <= buf.capacity());
-        let slot = self.reserve()?;
-        let entry = opcode::ReadFixed::new(
-            types::Fd(self.fd.as_raw_fd()),
-            buf.as_mut_ptr(),
-            len as u32,
-            buf.arena_index(),
-        )
-        .offset(offset)
-        .build()
-        .user_data(slot as u64);
-        self.push(entry, slot, token, Some(buf))
+    fn attach(&mut self, device: &Arc<dyn Device>) -> io::Result<Descriptor> {
+        let fd = device
+            .fd()
+            .ok_or_else(|| io::Error::new(io::ErrorKind::Unsupported, "device has no file descriptor"))?;
+        let desc = self
+            .inboxes
+            .open()
+            .ok_or_else(|| io::Error::new(io::ErrorKind::OutOfMemory, "no free descriptor"))?;
+        if let Err(e) = self.ring.submitter().register_files_update(desc.0, &[fd.as_raw_fd()]) {
+            self.inboxes.close(desc);
+            return Err(e);
+        }
+        Ok(desc)
     }
 
-    fn write(&mut self, buf: PooledBuf, len: usize, offset: u64, token: u64) -> io::Result<()> {
-        debug_assert!(len <= buf.capacity());
-        let slot = self.reserve()?;
-        let entry = opcode::WriteFixed::new(
-            types::Fd(self.fd.as_raw_fd()),
-            buf.as_ptr(),
-            len as u32,
-            buf.arena_index(),
-        )
-        .offset(offset)
-        .build()
-        .user_data(slot as u64);
-        self.push(entry, slot, token, Some(buf))
+    fn detach(&mut self, desc: Descriptor) {
+        if !self.inboxes.is_open(desc) {
+            return;
+        }
+        self.inboxes.close(desc);
+        // Unregistering while operations are in flight is allowed: the kernel
+        // keeps its own reference for them.
+        let _ = self.ring.submitter().register_files_update(desc.0, &[-1 as RawFd]);
     }
 
-    fn fsync(&mut self, token: u64) -> io::Result<()> {
-        let slot = self.reserve()?;
-        let entry = opcode::Fsync::new(types::Fd(self.fd.as_raw_fd()))
+    fn read(
+        &mut self,
+        desc: Descriptor,
+        mut buf: PooledBuf,
+        len: usize,
+        offset: u64,
+        token: u64,
+    ) -> Result<(), PooledBuf> {
+        debug_assert!(len <= buf.capacity());
+        let Some(slot) = self.free_slots.pop() else {
+            return Err(buf);
+        };
+        let entry = opcode::ReadFixed::new(types::Fixed(desc.0), buf.as_mut_ptr(), len as u32, buf.arena_index())
+            .offset(offset)
+            .build()
+            .user_data(slot as u64);
+        self.push(entry, slot, desc, token, Some(buf));
+        Ok(())
+    }
+
+    fn write(
+        &mut self,
+        desc: Descriptor,
+        buf: PooledBuf,
+        len: usize,
+        offset: u64,
+        token: u64,
+    ) -> Result<(), PooledBuf> {
+        debug_assert!(len <= buf.capacity());
+        let Some(slot) = self.free_slots.pop() else {
+            return Err(buf);
+        };
+        let entry = opcode::WriteFixed::new(types::Fixed(desc.0), buf.as_ptr(), len as u32, buf.arena_index())
+            .offset(offset)
+            .build()
+            .user_data(slot as u64);
+        self.push(entry, slot, desc, token, Some(buf));
+        Ok(())
+    }
+
+    fn fsync(&mut self, desc: Descriptor, token: u64) -> Result<(), Full> {
+        let Some(slot) = self.free_slots.pop() else {
+            return Err(Full);
+        };
+        let entry = opcode::Fsync::new(types::Fixed(desc.0))
             .flags(types::FsyncFlags::DATASYNC)
             .build()
             .user_data(slot as u64);
-        self.push(entry, slot, token, None)
+        self.push(entry, slot, desc, token, None);
+        Ok(())
     }
 
     fn submit(&mut self) -> io::Result<()> {
-        if self.unsubmitted > 0 {
+        if !self.staged.is_empty() {
+            self.stage_to_ring();
             self.ring.submit()?;
-            self.unsubmitted = 0;
         }
         Ok(())
     }
 
-    fn poll(&mut self, out: &mut Vec<IoCompletion>, wait: bool) -> io::Result<usize> {
-        if wait && self.in_flight() > 0 {
-            self.ring.submit_and_wait(1)?;
-            self.unsubmitted = 0;
+    fn poll(&mut self, wait: bool) -> io::Result<usize> {
+        let in_flight = self.in_flight();
+        if wait && in_flight > 0 {
+            self.enter(1)?;
+        } else if self.deferred {
+            if in_flight > 0 || !self.staged.is_empty() {
+                self.enter(0)?;
+            }
         } else {
             self.submit()?;
         }
-        Ok(self.reap(out))
+        Ok(self.reap())
+    }
+
+    fn take(&mut self, desc: Descriptor, out: &mut Vec<IoCompletion>) -> usize {
+        self.inboxes.take(desc, out)
     }
 
     fn in_flight(&self) -> usize {
@@ -199,19 +299,13 @@ mod tests {
     use moat_common::{HugePages, PoolOptions};
 
     use super::*;
+    use crate::device::FileDevice;
 
     #[test]
-    fn fixed_buffer_write_then_read() {
+    fn fixed_buffer_write_then_read_on_two_devices() {
         let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("ring.img");
-        let file = std::fs::OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .open(&path)
-            .unwrap();
-        file.set_len(1 << 20).unwrap();
+        let a: Arc<dyn Device> = Arc::new(FileDevice::create(dir.path().join("a.img"), 1 << 20, false).unwrap());
+        let b: Arc<dyn Device> = Arc::new(FileDevice::create(dir.path().join("b.img"), 1 << 20, false).unwrap());
         let opts = QueueOptions {
             depth: 8,
             pool: PoolOptions {
@@ -219,44 +313,77 @@ mod tests {
                 max_class: 64 << 10,
                 huge_pages: HugePages::Disabled,
             },
-            force_sync: false,
+            descriptors: 4,
         };
-        let mut queue = UringQueue::new(file, &opts).unwrap();
+        let mut queue = UringQueue::new(&opts).unwrap();
         assert_eq!(queue.depth(), 8);
+        let da = queue.attach(&a).unwrap();
+        let db = queue.attach(&b).unwrap();
+        assert_ne!(da, db);
 
-        let mut buf = queue.pool().alloc(8192).unwrap();
-        buf[..8192]
-            .iter_mut()
-            .enumerate()
-            .for_each(|(i, b)| *b = (i % 251) as u8);
-        queue.write(buf, 8192, 16384, 1).unwrap();
-        let read_buf = queue.pool().alloc(8192).unwrap();
-        queue.read(read_buf, 8192, 16384, 2).unwrap();
-        assert_eq!(queue.in_flight(), 2);
-
-        let mut done = Vec::new();
-        while done.len() < 2 {
-            queue.poll(&mut done, true).unwrap();
+        for (desc, fill) in [(da, 1u8), (db, 2u8)] {
+            let mut buf = queue.pool().alloc(8192).unwrap();
+            buf[..8192].fill(fill);
+            queue.write(desc, buf, 8192, 16384, 1).unwrap();
         }
-        assert_eq!(queue.in_flight(), 0);
-        // Reads and writes on the same range are unordered within a ring, so
-        // only check what completed and that the buffer came back.
-        for c in done {
+        assert_eq!(queue.in_flight(), 2);
+        assert_eq!(queue.vacant(), 6);
+        let mut done = Vec::new();
+        while queue.in_flight() > 0 {
+            queue.poll(true).unwrap();
+        }
+        for desc in [da, db] {
+            assert_eq!(queue.take(desc, &mut done), 1);
+            let c = done.pop().unwrap();
             assert_eq!(c.result.unwrap(), 8192);
             assert!(c.buf.is_some());
         }
-        // A second read after everything completed sees the written bytes.
-        let read_buf = queue.pool().alloc(8192).unwrap();
-        queue.read(read_buf, 8192, 16384, 3).unwrap();
-        let mut done = Vec::new();
-        queue.poll(&mut done, true).unwrap();
-        let buf = done.pop().unwrap().buf.unwrap();
-        assert!(buf[..8192].iter().enumerate().all(|(i, &b)| b == (i % 251) as u8));
 
-        queue.fsync(4).unwrap();
-        let mut done = Vec::new();
-        queue.poll(&mut done, true).unwrap();
-        assert!(done[0].buf.is_none());
-        done[0].result.as_ref().unwrap();
+        // Each device reads back what was written to it, not to the other.
+        for (desc, fill) in [(da, 1u8), (db, 2u8)] {
+            let buf = queue.pool().alloc(8192).unwrap();
+            queue.read(desc, buf, 8192, 16384, 7).unwrap();
+            while queue.take(desc, &mut done) == 0 {
+                queue.poll(true).unwrap();
+            }
+            let c = done.pop().unwrap();
+            assert_eq!(c.token, 7);
+            assert!(c.buf.unwrap()[..8192].iter().all(|&x| x == fill));
+        }
+
+        queue.fsync(da, 4).unwrap();
+        while queue.take(da, &mut done) == 0 {
+            queue.poll(true).unwrap();
+        }
+        let c = done.pop().unwrap();
+        assert!(c.buf.is_none());
+        c.result.unwrap();
+
+        // A full ring rejects losslessly and hands the buffer back.
+        let mut held = Vec::new();
+        for i in 0..8 {
+            let buf = queue.pool().alloc(4096).unwrap();
+            queue.read(da, buf, 4096, 0, 100 + i).unwrap();
+        }
+        let buf = queue.pool().alloc(4096).unwrap();
+        let rejected = queue.read(da, buf, 4096, 0, 200).unwrap_err();
+        held.push(rejected);
+        assert_eq!(queue.vacant(), 0);
+        while queue.in_flight() > 0 {
+            queue.poll(true).unwrap();
+        }
+        assert_eq!(queue.take(da, &mut done), 8);
+
+        // Completions for a detached descriptor are discarded.
+        let buf = queue.pool().alloc(4096).unwrap();
+        queue.read(db, buf, 4096, 0, 300).unwrap();
+        queue.detach(db);
+        while queue.in_flight() > 0 {
+            queue.poll(true).unwrap();
+        }
+        done.clear();
+        assert_eq!(queue.take(db, &mut done), 0);
+        drop(held);
+        assert_eq!(queue.pool().in_use(), 0);
     }
 }

--- a/core/moat-engine/src/uring.rs
+++ b/core/moat-engine/src/uring.rs
@@ -121,6 +121,7 @@ impl UringQueue {
         token: u64,
         buf: Option<PooledBuf>,
     ) {
+        self.inboxes.start(desc);
         self.staged.push(entry);
         self.slots[slot as usize] = Some(Slot { desc, token, buf });
     }
@@ -145,7 +146,7 @@ impl UringQueue {
 
     fn reap(&mut self) -> usize {
         let mut n = 0;
-        let mut cq = self.ring.completion();
+        let (submitter, _, mut cq) = self.ring.split();
         cq.sync();
         for cqe in &mut cq {
             let slot = cqe.user_data() as u32;
@@ -157,7 +158,9 @@ impl UringQueue {
             };
             let Slot { desc, token, buf } = self.slots[slot as usize].take().expect("completion for a live slot");
             self.free_slots.push(slot);
-            self.inboxes.deliver(desc, IoCompletion { token, result, buf });
+            if self.inboxes.deliver(desc, IoCompletion { token, result, buf }) {
+                let _ = submitter.register_files_update(desc.0, &[-1 as RawFd]);
+            }
             n += 1;
         }
         n
@@ -198,13 +201,11 @@ impl IoQueue for UringQueue {
     }
 
     fn detach(&mut self, desc: Descriptor) {
-        if !self.inboxes.is_open(desc) {
-            return;
+        // Staged SQEs still refer to this fixed-file slot. Keep the binding
+        // until every accepted operation has completed, including staged ones.
+        if self.inboxes.close(desc) {
+            let _ = self.ring.submitter().register_files_update(desc.0, &[-1 as RawFd]);
         }
-        self.inboxes.close(desc);
-        // Unregistering while operations are in flight is allowed: the kernel
-        // keeps its own reference for them.
-        let _ = self.ring.submitter().register_files_update(desc.0, &[-1 as RawFd]);
     }
 
     fn read(
@@ -215,7 +216,7 @@ impl IoQueue for UringQueue {
         offset: u64,
         token: u64,
     ) -> Result<(), PooledBuf> {
-        debug_assert!(len <= buf.capacity());
+        assert!(len <= buf.capacity(), "I/O length exceeds buffer capacity");
         let Some(slot) = self.free_slots.pop() else {
             return Err(buf);
         };
@@ -235,7 +236,7 @@ impl IoQueue for UringQueue {
         offset: u64,
         token: u64,
     ) -> Result<(), PooledBuf> {
-        debug_assert!(len <= buf.capacity());
+        assert!(len <= buf.capacity(), "I/O length exceeds buffer capacity");
         let Some(slot) = self.free_slots.pop() else {
             return Err(buf);
         };
@@ -260,8 +261,8 @@ impl IoQueue for UringQueue {
     }
 
     fn submit(&mut self) -> io::Result<()> {
-        if !self.staged.is_empty() {
-            self.stage_to_ring();
+        self.stage_to_ring();
+        if !self.ring.submission().is_empty() {
             self.ring.submit()?;
         }
         Ok(())
@@ -272,7 +273,7 @@ impl IoQueue for UringQueue {
         if wait && in_flight > 0 {
             self.enter(1)?;
         } else if self.deferred {
-            if in_flight > 0 || !self.staged.is_empty() {
+            if in_flight > 0 {
                 self.enter(0)?;
             }
         } else {
@@ -300,6 +301,36 @@ mod tests {
 
     use super::*;
     use crate::device::FileDevice;
+
+    #[test]
+    fn oversized_io_is_rejected_before_reserving_a_slot() {
+        let dir = tempfile::tempdir().unwrap();
+        let device: Arc<dyn Device> = Arc::new(FileDevice::create(dir.path().join("disk.img"), 8192, false).unwrap());
+        let mut queue = UringQueue::new(&crate::io::tests::detach_options()).unwrap();
+        let desc = queue.attach(&device).unwrap();
+        for read in [true, false] {
+            let buf = queue.pool().alloc(4096).unwrap();
+            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                if read {
+                    queue.read(desc, buf, 8192, 0, 1)
+                } else {
+                    queue.write(desc, buf, 8192, 0, 1)
+                }
+            }));
+            assert!(result.is_err());
+            assert_eq!(queue.in_flight(), 0);
+            assert_eq!(queue.pool().in_use(), 0);
+        }
+    }
+
+    #[test]
+    fn detached_descriptors_keep_staged_writes_on_the_original_device() {
+        let dir = tempfile::tempdir().unwrap();
+        let a = Arc::new(FileDevice::create(dir.path().join("a.img"), 4096, false).unwrap());
+        let b = Arc::new(FileDevice::create(dir.path().join("b.img"), 4096, false).unwrap());
+        let mut queue = UringQueue::new(&crate::io::tests::detach_options()).unwrap();
+        crate::io::tests::check_detach(&mut queue, a, b);
+    }
 
     #[test]
     fn fixed_buffer_write_then_read_on_two_devices() {

--- a/core/moat-engine/src/writer.rs
+++ b/core/moat-engine/src/writer.rs
@@ -14,11 +14,20 @@
 
 //! The single writer of a disk.
 //!
-//! Exactly one [`Writer`] exists per open engine. It owns the log tail of the
-//! hot and cold active segments, assigns LSNs, performs every index mutation,
-//! seals segments, and runs reclaim. Because all of that happens on one thread,
-//! the engine needs no locking beyond the index shard mutexes that readers
-//! also take.
+//! Exactly one [`Writer`] exists per engine. It owns the log tail of the hot
+//! and cold active segments, assigns LSNs, performs every index mutation,
+//! seals segments, and runs reclaim. Because all of that happens on one
+//! thread, the engine needs no locking at all: the index is a single-writer
+//! structure, and everything else the writer touches is owned by it.
+//!
+//! # No call blocks
+//!
+//! Every method either does memory work and returns, enqueues I/O on the
+//! caller's [`IoQueue`] and returns a [`Ticket`], or reports
+//! [`Error::Busy`] (the pool is out of buffers; poll and retry). Completion is
+//! observed only through [`Writer::poll`], which also advances the state
+//! machines behind sealing, barriers and reclaim. A slow disk therefore never
+//! stalls the other disks that share its worker.
 //!
 //! # I/O pipeline
 //!
@@ -26,35 +35,48 @@
 //! staging batch (inline or framed, see [`crate::layout`]), large values into
 //! a buffer whose value area the caller may fill directly
 //! ([`Writer::prepare_large`]), so the only copy on the write path is the one
-//! the caller chooses to make. Batches are submitted to the writer's
-//! [`IoQueue`] and several stay in flight; completions are applied strictly in
-//! submission order, so acknowledged records always form a contiguous prefix of
-//! the log and a crash never leaves a hole in front of acknowledged data.
+//! the caller chooses to make. Closed batches wait in a *ready* queue until
+//! the I/O queue has room, then stay in flight; completions are applied
+//! strictly in submission order, so acknowledged records always form a
+//! contiguous prefix of the log and a crash never leaves a hole in front of
+//! acknowledged data. A segment header is written before any batch of the
+//! segment, a footer before the header that marks the segment sealed, and a
+//! segment returns to the free list only after its header says so on disk.
 //!
 //! A failed write truncates its segment at the failure offset: that batch and
-//! every later batch of the same segment are reported as failed, the segment is
-//! sealed with the records that did land, and writing continues on a fresh
+//! every later batch of the same segment are reported as failed, the segment
+//! is sealed with the records that did land, and writing continues on a fresh
 //! segment.
+//!
+//! # Reclaim and LSNs
+//!
+//! Relocated records keep their LSN. Reclaim is thereby a purely physical
+//! move: the set of `(key, lsn, kind, value)` records recovery sees is
+//! unchanged by it, so no ordering argument between reclaim and concurrent
+//! foreground writes is needed, and the LSN a client observed for a chunk
+//! stays valid across compaction. Whether a relocation takes effect in memory
+//! is decided when it is applied (the index must still point at the old
+//! location); a copy superseded meanwhile is dead data in the cold segment.
 
 use std::{
-    collections::{HashMap, HashSet, VecDeque},
+    collections::{HashMap, VecDeque},
     io,
-    sync::Arc,
-    thread,
+    sync::{Arc, atomic::Ordering},
 };
 
 use moat_common::{
-    ChunkId, PAGE_SIZE, PooledBuf, align_up, block_checksums, block_count, chunk_id::ChunkIdHashBuilder,
+    AlignedBuf, CHECKSUM_BLOCK_SIZE, ChunkId, PAGE_SIZE, PooledBuf, align_up, block_checksums, block_count,
+    chunk_id::ChunkIdHashBuilder, crc32c, verify_blocks_with,
 };
 
 use crate::{
     error::{Error, Result},
-    index::{IndexValue, InsertOutcome, Location, flags_from_record},
-    io::{IoCompletion, IoQueue},
+    index::{IndexValue, IndexWriter, InsertOutcome, Location, flags_from_record},
+    io::{Descriptor, IoCompletion, IoQueue},
     layout::{
         BATCH_HEADER_LEN, BatchHeader, BatchKind, FooterEntry, RECORD_ALIGN, RECORD_FLAG_EXPIRES, RECORD_FLAG_FRAMED,
-        RECORD_FLAG_LARGE, RecordGeometry, RecordHeader, RecordKind, SegmentHeader, SegmentKind, SegmentState,
-        encode_footer, footer_len, large_batch_len, large_value_offset, prefer_framed, record_meta_len,
+        RECORD_FLAG_LARGE, RecordGeometry, RecordHeader, RecordKind, SEGMENT_HEADER_LEN, SegmentHeader, SegmentKind,
+        SegmentState, encode_footer, footer_len, large_batch_len, large_value_offset, prefer_framed, record_meta_len,
     },
     scan::{BatchStep, max_batch_len, next_batch, parse_batch},
     shared::Shared,
@@ -63,10 +85,11 @@ use crate::{
 /// A per-disk write sequence number.
 pub type Lsn = u64;
 
-/// Identifies a submitted write until its [`Completion`] is delivered.
+/// Identifies an accepted operation until its [`Completion`] is delivered.
 pub type Ticket = u64;
 
-/// Tokens with this bit set are not batch writes (reclaim reads, fsync).
+/// Tokens with this bit set are auxiliary operations (headers, footers,
+/// fsync, reclaim reads), not batch writes.
 const AUX_TOKEN: u64 = 1 << 63;
 
 /// Options for a single `put`.
@@ -85,7 +108,7 @@ pub struct PutOptions {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PutOutcome {
     /// The record was accepted. It is durable and visible once the
-    /// [`Completion`] for `ticket` reports success (or after [`Writer::flush`]).
+    /// [`Completion`] for `ticket` reports success.
     Written {
         /// Identifies the eventual completion.
         ticket: Ticket,
@@ -96,15 +119,50 @@ pub enum PutOutcome {
     Exists,
 }
 
-/// The outcome of a write accepted earlier.
+/// Result of a `delete`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeleteOutcome {
+    /// A tombstone was appended. The chunk is invisible to this writer at
+    /// once and to readers (and after a crash) once the completion for
+    /// `ticket` reports success.
+    Deleted {
+        /// Identifies the eventual completion.
+        ticket: Ticket,
+        /// The tombstone's LSN.
+        lsn: Lsn,
+    },
+    /// The chunk is neither indexed nor pending; nothing was written.
+    Missing,
+}
+
+/// What a completed ticket did.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Outcome {
+    /// A record is on disk and indexed.
+    Put {
+        /// The record's LSN.
+        lsn: Lsn,
+    },
+    /// A tombstone is on disk.
+    Delete {
+        /// The tombstone's LSN.
+        lsn: Lsn,
+    },
+    /// Every write accepted before the barrier is durable.
+    Flush,
+    /// As `Flush`, and both active segments are sealed.
+    Seal,
+    /// A reclaim pass finished.
+    Reclaim(ReclaimReport),
+}
+
+/// The outcome of an operation accepted earlier.
 #[derive(Debug)]
 pub struct Completion {
-    /// The ticket returned by `put`.
+    /// The ticket the operation returned.
     pub ticket: Ticket,
-    /// The record's LSN.
-    pub lsn: Lsn,
-    /// `Ok` once the record is on disk and indexed.
-    pub result: Result<()>,
+    /// What happened.
+    pub result: Result<Outcome>,
 }
 
 /// How reclaim decides what to keep when it processes a segment.
@@ -139,6 +197,8 @@ pub struct ReclaimReport {
     pub tombstones_dropped: u64,
     /// Value bytes copied.
     pub bytes_relocated: u64,
+    /// Data records whose value failed its checksums (counted in `dropped`).
+    pub corrupt: u64,
 }
 
 /// A pool buffer laid out as a large batch, with the value area exposed for
@@ -177,6 +237,10 @@ impl LargeValue {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Segments under construction
+// ---------------------------------------------------------------------------
+
 struct Active {
     seg_no: u32,
     seq: u64,
@@ -185,14 +249,23 @@ struct Active {
     tail: u64,
     /// Footer entries of every record applied so far.
     footer: Vec<FooterEntry>,
-    /// A write into this segment failed; it must be sealed at `tail` and
+    /// A write into this segment failed; it is truncated at `tail` and
     /// abandoned.
     broken: bool,
+    /// The header write that opened the segment has completed; batches may
+    /// go to the device.
+    opened: bool,
+    /// Batches closed for this segment and not yet applied, and the records
+    /// they hold: the footer must have room for them too.
+    unapplied: u32,
+    unapplied_records: usize,
 }
 
 impl Active {
     fn fits(&self, batch_len: u64, new_records: usize, segment_size: u64) -> bool {
-        !self.broken && self.tail + batch_len + footer_len(self.footer.len() + new_records) <= segment_size
+        !self.broken
+            && self.tail + batch_len + footer_len(self.footer.len() + self.unapplied_records + new_records)
+                <= segment_size
     }
 }
 
@@ -204,8 +277,8 @@ enum Apply {
     /// A record relocated by reclaim: only applies if the index still points
     /// at the old location.
     Relocate(Location),
-    /// No index change (tombstones; the index was updated at delete time).
-    None,
+    /// A tombstone: the index was updated at delete time.
+    Tombstone,
 }
 
 struct PendingRecord {
@@ -235,7 +308,6 @@ struct Pending {
     header_len: usize,
     header_pos: usize,
     records: Vec<PendingRecord>,
-    keys: HashSet<ChunkId, ChunkIdHashBuilder>,
     first_lsn: Lsn,
 }
 
@@ -248,7 +320,6 @@ impl Pending {
             header_len: 0,
             header_pos: BATCH_HEADER_LEN,
             records: Vec::new(),
-            keys: HashSet::default(),
             first_lsn: 0,
         }
     }
@@ -323,7 +394,6 @@ impl Pending {
         if self.kind == BatchKind::Framed {
             self.header_pos = hdr_pos + meta;
         }
-        self.keys.insert(hdr.key);
         self.records.push(PendingRecord {
             offset_in_batch: hdr_pos as u32,
             value_in_batch: value_pos as u32,
@@ -373,58 +443,186 @@ fn footer_entry(hdr: &RecordHeader, checksums: &[u32]) -> FooterEntry {
     }
 }
 
-struct InFlight {
-    token: u64,
-    slot: usize,
+/// An encoded batch with its position fixed, waiting for the queue or in
+/// flight.
+struct Batch {
+    /// Close sequence number; barriers are expressed in terms of it.
+    id: u64,
     seg_no: u32,
     offset: u64,
-    batch_len: u64,
+    batch_len: usize,
     records: Vec<PendingRecord>,
+    /// The encoded bytes while the batch waits for the queue; `None` once the
+    /// queue holds them.
+    buf: Option<PooledBuf>,
+}
+
+struct InFlight {
+    batch: Batch,
+    token: u64,
     /// Set when the completion arrives; applied once every earlier batch has
     /// been applied.
     result: Option<io::Result<usize>>,
 }
 
-/// The single writer of an engine.
+// ---------------------------------------------------------------------------
+// Auxiliary operations and state machines
+// ---------------------------------------------------------------------------
+
+/// What an auxiliary I/O was for.
+#[derive(Debug, Clone, Copy)]
+enum Aux {
+    /// The header that opens a fresh active segment.
+    OpenHeader { seg_no: u32 },
+    /// One piece of a footer.
+    Footer { seg_no: u32 },
+    /// The header that marks a segment sealed.
+    SealHeader { seg_no: u32 },
+    /// A barrier's `fdatasync`.
+    Fsync { ticket: Ticket },
+    /// A reclaim window read.
+    ReclaimRead,
+    /// The header that returns a reclaimed segment to the free list.
+    FreeHeader { seg_no: u32 },
+}
+
+/// An auxiliary operation the queue had no room for yet.
+struct AuxOp {
+    aux: Aux,
+    buf: PooledBuf,
+    len: usize,
+    offset: u64,
+    read: bool,
+}
+
+enum SealStage {
+    /// Waiting for the segment's batches to be applied.
+    Draining,
+    /// Footer pieces being written.
+    Footer {
+        encoded: AlignedBuf,
+        written: usize,
+        outstanding: u32,
+    },
+    /// The sealed header write is in flight.
+    Header,
+}
+
+struct Sealing {
+    seg: Active,
+    stage: SealStage,
+}
+
+enum Fsync {
+    NotNeeded,
+    /// Batches are applied; the fsync has yet to be enqueued.
+    Pending,
+    Issued,
+    Done,
+}
+
+struct Barrier {
+    ticket: Ticket,
+    /// Complete once no batch with an id below this is unapplied.
+    until: u64,
+    /// Segments that must leave `sealing` (for `seal`).
+    seal: Option<Vec<u32>>,
+    fsync: Fsync,
+    error: Option<String>,
+}
+
+enum ReclaimStage {
+    /// Issue the next window read (or finish when the cursor reached the end).
+    Read,
+    /// A window read is in flight.
+    Reading,
+    /// A window is being processed; resume at batch `rel`, record `rec`.
+    Process {
+        buf: PooledBuf,
+        len: usize,
+        rel: usize,
+        rec: usize,
+    },
+    /// Every record is processed; waiting for the batches that carry the
+    /// relocations and the foreground writes the decisions relied on.
+    Drain,
+    /// Waiting for readers to release the victim.
+    Pins,
+    /// The free header write is in flight.
+    Freeing,
+}
+
+struct ReclaimJob {
+    ticket: Ticket,
+    seg_no: u32,
+    seq: u64,
+    kind: SegmentKind,
+    policy: ReclaimPolicy,
+    is_oldest: bool,
+    end: u64,
+    cursor: u64,
+    window: usize,
+    report: ReclaimReport,
+    stage: ReclaimStage,
+    drain_until: u64,
+    /// A relocation write failed; the victim must be kept.
+    failed: bool,
+}
+
+/// A data record appended but not yet applied.
+struct Unapplied {
+    count: u32,
+    max_lsn: Lsn,
+}
+
+/// A tombstone that still has to suppress older puts of its key.
+struct Tombstone {
+    lsn: Lsn,
+    /// The tombstone itself is on disk; the entry only lingers while puts of
+    /// the key with a lower LSN are unapplied.
+    applied: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Writer
+// ---------------------------------------------------------------------------
+
+/// The single writer of an engine: owns the log tails, assigns LSNs, performs
+/// every index mutation, seals segments and runs reclaim, all without blocking.
 ///
-/// Exactly one writer exists per open engine. It owns the log tail of the hot
-/// and cold active segments, assigns LSNs, performs every index mutation, seals
-/// segments and runs reclaim. It is `Send` but not `Sync`: drive it from one
-/// thread per disk.
-///
-/// # Durability and acknowledgement
-///
-/// `put` only enqueues. Values shorter than
-/// [`Options::pack_threshold`](crate::Options::pack_threshold) accumulate in a
-/// packed batch that is submitted once it reaches
-/// [`Options::batch_limit`](crate::Options::batch_limit); larger values are
-/// submitted immediately. A record is durable and visible to readers when its
-/// [`Completion`] arrives through [`Writer::poll`] with `Ok`, or after
-/// [`Writer::flush`] returns. Operations that need a consistent view
-/// (`delete`, `reclaim`, `seal_active`, `close`) flush internally.
+/// It is `Send` but not `Sync`: drive it from one thread, the one that owns
+/// the queue it was attached to.
 pub struct Writer {
     shared: Arc<Shared>,
-    queue: Box<dyn IoQueue>,
+    index: IndexWriter,
+    desc: Descriptor,
     active: [Option<Active>; 2],
     /// Pending packed batches per segment kind: `[inline, framed]`.
     pending: [[Pending; 2]; 2],
+    /// Closed batches waiting for queue room, per segment kind.
+    ready: [VecDeque<Batch>; 2],
     inflight: VecDeque<InFlight>,
-    /// Completed auxiliary operations (reclaim reads, fsync).
-    aux_done: HashMap<u64, IoCompletion>,
+    aux: HashMap<u64, Aux>,
+    aux_ready: VecDeque<AuxOp>,
+    sealing: Vec<Sealing>,
+    barriers: VecDeque<Barrier>,
+    reclaim: Option<ReclaimJob>,
     completions: Vec<Completion>,
     scratch: Vec<IoCompletion>,
-    /// Keys of records submitted but not yet applied, with multiplicity.
-    inflight_keys: HashMap<ChunkId, u32, ChunkIdHashBuilder>,
+    /// Data records appended but not yet applied, per key.
+    unapplied: HashMap<ChunkId, Unapplied, ChunkIdHashBuilder>,
+    /// Tombstones that still outrank unapplied puts of their key.
+    deleted: HashMap<ChunkId, Tombstone, ChunkIdHashBuilder>,
     free: VecDeque<u32>,
-    /// Batch write tokens are consecutive, so a completion is located in
-    /// `inflight` by subtracting the front token.
+    /// Batch write tokens are consecutive in submission order, so a
+    /// completion is located in `inflight` by subtracting the front token.
     next_batch_token: u64,
+    next_batch_id: u64,
     next_aux_token: u64,
     next_ticket: Ticket,
     next_seq: u64,
     next_lsn: Lsn,
     max_batch: u64,
-    relocation_failures: u64,
 }
 
 fn slot(kind: SegmentKind) -> usize {
@@ -443,8 +641,8 @@ fn batch_slot(kind: BatchKind) -> usize {
 
 /// Chooses how a small (below the pack threshold) value is stored.
 fn small_batch_kind(value_len: u32, expire_at: u64) -> BatchKind {
-    // Framed records are verified from the index CRC without reading their
-    // header, which is where the expiry lives; expiring values stay inline.
+    // Expiring records always read their header for TTL; keep it adjacent to
+    // the value so those reads do not span a separate framed header area.
     if expire_at == 0 && prefer_framed(value_len) {
         BatchKind::Framed
     } else {
@@ -475,82 +673,118 @@ fn header(kind: RecordKind, flags: u8, value_len: u32, lsn: Lsn, key: ChunkId, e
     }
 }
 
+fn io_error(msg: impl Into<String>) -> Error {
+    Error::Io(io::Error::other(msg.into()))
+}
+
 impl Writer {
-    pub(crate) fn new(
-        shared: Arc<Shared>,
-        queue: Box<dyn IoQueue>,
-        free: VecDeque<u32>,
-        next_seq: u64,
-        next_lsn: Lsn,
-    ) -> Self {
+    pub(crate) fn new(shared: Arc<Shared>, desc: Descriptor) -> Self {
         let max_batch = max_batch_len(&shared);
+        let segments = &shared.segments;
+        let free: VecDeque<u32> = segments
+            .iter()
+            .filter(|&s| segments.state(s) == SegmentState::Free)
+            .collect();
+        let next_seq = shared.next_seq.load(Ordering::Acquire);
+        let next_lsn = shared.next_lsn.load(Ordering::Acquire);
         Self {
+            index: IndexWriter::new(shared.index.clone()),
             shared,
-            queue,
+            desc,
             active: [None, None],
             pending: [
                 [Pending::new(BatchKind::Inline), Pending::new(BatchKind::Framed)],
                 [Pending::new(BatchKind::Inline), Pending::new(BatchKind::Framed)],
             ],
+            ready: [VecDeque::new(), VecDeque::new()],
             inflight: VecDeque::new(),
-            aux_done: HashMap::new(),
+            aux: HashMap::new(),
+            aux_ready: VecDeque::new(),
+            sealing: Vec::new(),
+            barriers: VecDeque::new(),
+            reclaim: None,
             completions: Vec::new(),
             scratch: Vec::new(),
-            inflight_keys: HashMap::default(),
+            unapplied: HashMap::default(),
+            deleted: HashMap::default(),
             free,
             next_batch_token: 0,
+            next_batch_id: 1,
             next_aux_token: 0,
             next_ticket: 1,
             next_seq,
             next_lsn,
             max_batch,
-            relocation_failures: 0,
         }
     }
 
-    // -- public API ----------------------------------------------------------
+    // -- data ---------------------------------------------------------------
+
+    /// Hints the index location of an upcoming put or delete.
+    ///
+    /// Call this while processing an earlier request to overlap a cold index
+    /// lookup with useful work. It does not reserve a slot, perform I/O, or
+    /// change the result of any operation. Unsupported targets ignore it.
+    #[inline]
+    pub fn prefetch(&self, id: &ChunkId) {
+        self.index.prefetch(id);
+    }
 
     /// Appends a chunk, copying `value` into the log buffers.
     ///
     /// For values at or above the pack threshold, [`Writer::prepare_large`]
     /// followed by [`Writer::put_large`] avoids this copy.
-    pub fn put(&mut self, id: ChunkId, value: &[u8], opts: PutOptions) -> Result<PutOutcome> {
+    pub fn put(&mut self, q: &mut dyn IoQueue, id: ChunkId, value: &[u8], opts: PutOptions) -> Result<PutOutcome> {
         self.check_len(value.len() as u64)?;
         if self.exists(&id, opts) {
             return Ok(PutOutcome::Exists);
         }
-        let checksums = block_checksums(value);
+        self.check_index_room(&id)?;
+        // Small puts need at most one checksum; avoid a heap allocation for
+        // every packed record. Encoding consumes the slice before returning.
+        let single;
+        let multiple;
+        let checksums: &[u32] = if value.len() <= CHECKSUM_BLOCK_SIZE {
+            single = [crc32c(value)];
+            &single[..usize::from(!value.is_empty())]
+        } else {
+            multiple = block_checksums(value);
+            &multiple
+        };
         let len = value.len() as u32;
         if value.len() >= self.shared.options.pack_threshold as usize {
-            let mut large = self.prepare_large(len)?;
+            let mut large = self.prepare_large(q, len)?;
             large.value_mut().copy_from_slice(value);
+            self.ensure_room(q, SegmentKind::Hot, large_batch_len(len), 1)?;
             let (ticket, lsn) = self.next_ids();
             let flags = record_flags(BatchKind::Large, opts.expire_at);
             let hdr = header(RecordKind::Data, flags, len, lsn, id, opts.expire_at);
             self.write_large(
+                q,
                 SegmentKind::Hot,
                 &hdr,
-                &checksums,
+                checksums,
                 large.buf,
                 Apply::Insert,
                 Some(ticket),
-            )?;
+            );
             Ok(PutOutcome::Written { ticket, lsn })
         } else {
             let batch = small_batch_kind(len, opts.expire_at);
-            self.reserve_small(SegmentKind::Hot, batch, value.len())?;
+            self.reserve_small(q, SegmentKind::Hot, batch, value.len())?;
             let (ticket, lsn) = self.next_ids();
             let flags = record_flags(batch, opts.expire_at);
             let hdr = header(RecordKind::Data, flags, len, lsn, id, opts.expire_at);
             self.append_small(
+                q,
                 SegmentKind::Hot,
                 batch,
                 &hdr,
-                &checksums,
+                checksums,
                 value,
                 Apply::Insert,
                 Some(ticket),
-            )?;
+            );
             Ok(PutOutcome::Written { ticket, lsn })
         }
     }
@@ -558,7 +792,7 @@ impl Writer {
     /// Allocates a buffer for a value of `value_len` bytes laid out as a large
     /// batch, so the value can be produced in place and written without a
     /// copy. `value_len` must be at least the pack threshold.
-    pub fn prepare_large(&mut self, value_len: u32) -> Result<LargeValue> {
+    pub fn prepare_large(&mut self, q: &mut dyn IoQueue, value_len: u32) -> Result<LargeValue> {
         let max = self.shared.superblock.chunk_max;
         if value_len > max {
             return Err(Error::ValueTooLarge {
@@ -572,7 +806,7 @@ impl Writer {
                 self.shared.options.pack_threshold
             )));
         }
-        let buf = self.alloc(large_batch_len(value_len) as usize)?;
+        let buf = q.pool().alloc(large_batch_len(value_len) as usize).ok_or(Error::Busy)?;
         Ok(LargeValue {
             buf,
             value_len,
@@ -586,6 +820,7 @@ impl Writer {
     /// already has them (end-to-end integrity); they are computed otherwise.
     pub fn put_large(
         &mut self,
+        q: &mut dyn IoQueue,
         id: ChunkId,
         value: LargeValue,
         checksums: Option<&[u32]>,
@@ -595,149 +830,171 @@ impl Writer {
         if self.exists(&id, opts) {
             return Ok(PutOutcome::Exists);
         }
+        self.check_index_room(&id)?;
         let expected = block_count(value.len() as u64) as usize;
+        let computed;
         let checksums = match checksums {
-            Some(c) if c.len() == expected => c.to_vec(),
+            Some(c) if c.len() == expected => c,
             Some(c) => {
                 return Err(Error::InvalidOption(format!(
                     "expected {expected} block checksums, got {}",
                     c.len()
                 )));
             }
-            None => block_checksums(value.value()),
+            None => {
+                computed = block_checksums(value.value());
+                &computed
+            }
         };
+        self.ensure_room(q, SegmentKind::Hot, large_batch_len(value.len()), 1)?;
         let (ticket, lsn) = self.next_ids();
         let flags = record_flags(BatchKind::Large, opts.expire_at);
         let hdr = header(RecordKind::Data, flags, value.len(), lsn, id, opts.expire_at);
         self.write_large(
+            q,
             SegmentKind::Hot,
             &hdr,
-            &checksums,
+            checksums,
             value.buf,
             Apply::Insert,
             Some(ticket),
-        )?;
+        );
         Ok(PutOutcome::Written { ticket, lsn })
     }
 
-    /// Deletes a chunk. Returns whether it existed.
+    /// Deletes a chunk by appending a tombstone.
     ///
-    /// The deletion is durable when this returns: the index entry is removed
-    /// and a tombstone has been written so recovery cannot resurrect the
-    /// chunk.
-    pub fn delete(&mut self, id: &ChunkId) -> Result<bool> {
-        // Pending and in-flight puts of this key must be applied with their
-        // (older) LSNs before the tombstone takes a newer one.
-        self.flush_pending(SegmentKind::Hot)?;
-        self.wait_inflight()?;
-        let Some(old) = self.shared.index.remove(id) else {
-            return Ok(false);
-        };
-        self.shared.segments.sub_live(
-            old.loc.seg_no,
-            RecordGeometry::footprint(old.value_len, old.record_flags()),
-        );
-        self.reserve_small(SegmentKind::Hot, BatchKind::Inline, 0)?;
-        let lsn = self.take_lsn();
+    /// The chunk disappears from this writer's view at once (a subsequent put
+    /// of the id is not `Exists`) and from readers' when the completion
+    /// reports success, at which point the deletion also survives a crash.
+    pub fn delete(&mut self, q: &mut dyn IoQueue, id: &ChunkId) -> Result<DeleteOutcome> {
+        if !self.exists(id, PutOptions::default()) {
+            return Ok(DeleteOutcome::Missing);
+        }
+        self.reserve_small(q, SegmentKind::Hot, BatchKind::Inline, 0)?;
+        if let Some(old) = self.index.remove(id) {
+            self.shared.segments.sub_live(
+                old.loc.seg_no,
+                RecordGeometry::footprint(old.value_len, old.record_flags()),
+            );
+        }
+        let (ticket, lsn) = self.next_ids();
+        self.deleted.insert(*id, Tombstone { lsn, applied: false });
         let hdr = header(RecordKind::Tombstone, 0, 0, lsn, *id, 0);
-        self.append_small(SegmentKind::Hot, BatchKind::Inline, &hdr, &[], &[], Apply::None, None)?;
-        self.flush_pending(SegmentKind::Hot)?;
-        self.wait_inflight()?;
-        Ok(true)
+        self.append_small(
+            q,
+            SegmentKind::Hot,
+            BatchKind::Inline,
+            &hdr,
+            &[],
+            &[],
+            Apply::Tombstone,
+            Some(ticket),
+        );
+        Ok(DeleteOutcome::Deleted { ticket, lsn })
     }
 
-    /// Pushes queued I/O to the device without waiting for anything.
-    pub fn submit(&mut self) -> Result<()> {
-        self.queue.submit()?;
-        Ok(())
+    // -- control ------------------------------------------------------------
+
+    /// Barrier: its completion reports [`Outcome::Flush`] once every write
+    /// accepted before it is durable (including an `fdatasync` when
+    /// [`Options::sync_on_flush`](crate::Options::sync_on_flush) is set), or
+    /// the first error among those writes.
+    pub fn flush(&mut self, q: &mut dyn IoQueue) -> Result<Ticket> {
+        self.close_all_pending(q)?;
+        let ticket = self.next_ticket();
+        self.barriers.push_back(Barrier {
+            ticket,
+            until: self.next_batch_id,
+            seal: None,
+            fsync: if self.shared.options.sync_on_flush {
+                Fsync::Pending
+            } else {
+                Fsync::NotNeeded
+            },
+            error: None,
+        });
+        self.push_ready(q);
+        Ok(ticket)
     }
 
-    /// Reaps I/O completions, applies them in order, and appends the resulting
-    /// [`Completion`]s to `out`. With `wait` set and writes in flight, blocks
-    /// until at least one completes. Returns the number appended.
-    pub fn poll(&mut self, out: &mut Vec<Completion>, wait: bool) -> Result<usize> {
-        self.poll_io(wait)?;
-        let n = self.completions.len();
-        out.append(&mut self.completions);
-        Ok(n)
-    }
-
-    /// Writes every pending batch and waits for all in-flight writes.
+    /// `flush`, then seal both active segments so the next open needs no
+    /// scan. The completion reports [`Outcome::Seal`].
     ///
-    /// Afterwards every previous put is durable and visible. Completions
-    /// produced meanwhile are discarded (use [`Writer::poll`] to observe them);
-    /// the first failure, if any, is returned.
-    pub fn flush(&mut self) -> Result<()> {
-        self.flush_pending(SegmentKind::Hot)?;
-        self.flush_pending(SegmentKind::Cold)?;
-        self.wait_inflight()?;
-        if self.shared.options.sync_on_flush {
-            let token = self.next_aux_token();
-            self.queue.fsync(token)?;
-            let done = self.wait_aux(token)?;
-            done.result?;
-        }
-        let first_err = self.completions.drain(..).find_map(|c| c.result.err());
-        match first_err {
-            Some(e) => Err(e),
-            None => Ok(()),
-        }
-    }
-
-    /// Flushes and seals both active segments.
-    ///
-    /// Sealed segments are described by a footer (fast recovery) and become
-    /// eligible for reclaim. The writer allocates fresh segments on the next
-    /// write, so sealing a nearly empty segment wastes its remaining space;
-    /// callers normally leave sealing to the writer and use this only before
-    /// shutdown or when reclaim must be able to reach recent data.
-    pub fn seal_active(&mut self) -> Result<()> {
-        self.flush()?;
-        for kind in [SegmentKind::Hot, SegmentKind::Cold] {
-            if let Some(active) = self.active[slot(kind)].take() {
-                self.seal(active)?;
+    /// The writer allocates fresh segments on the next write, so sealing a
+    /// nearly empty segment wastes its remaining space; callers normally leave
+    /// sealing to the writer and use this before shutdown or when reclaim must
+    /// be able to reach recent data.
+    pub fn seal(&mut self, q: &mut dyn IoQueue) -> Result<Ticket> {
+        self.close_all_pending(q)?;
+        let mut sealed = Vec::new();
+        for k in 0..2 {
+            if let Some(active) = self.active[k].take() {
+                sealed.push(active.seg_no);
+                self.park(active);
             }
         }
-        Ok(())
+        let ticket = self.next_ticket();
+        self.barriers.push_back(Barrier {
+            ticket,
+            until: self.next_batch_id,
+            seal: Some(sealed),
+            fsync: if self.shared.options.sync_on_flush {
+                Fsync::Pending
+            } else {
+                Fsync::NotNeeded
+            },
+            error: None,
+        });
+        self.push_ready(q);
+        Ok(ticket)
     }
 
-    /// Flushes and seals the active segments so the next open needs no scan.
+    /// Starts one reclaim pass under `policy`; the completion reports
+    /// [`Outcome::Reclaim`]. `None` if there is no sealed segment to reclaim,
+    /// [`Error::Busy`] while a previous pass is still running.
     ///
-    /// Dropping a writer without closing is safe; recovery scans whatever was
-    /// left active.
-    pub fn close(mut self) -> Result<()> {
-        self.seal_active()
-    }
-
-    /// Number of free segments.
-    pub fn free_segments(&self) -> u32 {
-        self.free.len() as u32
-    }
-
-    /// The LSN the next record will receive.
-    pub fn next_lsn(&self) -> Lsn {
-        self.next_lsn
-    }
-
-    /// Batches submitted but not yet applied.
-    pub fn in_flight(&self) -> usize {
-        self.inflight.len()
-    }
-
-    /// Runs one reclaim pass under `policy`.
-    ///
-    /// Picks a victim among the sealed segments, relocates what the policy
-    /// keeps, and frees the segment. Returns `None` if there is no sealed
-    /// segment to reclaim.
-    ///
-    /// Relocation needs a free segment for the cold log; callers should reclaim
-    /// before the free list is exhausted (keeping at least two free segments is
-    /// enough).
-    pub fn reclaim(&mut self, policy: ReclaimPolicy) -> Result<Option<ReclaimReport>> {
-        let Some(victim) = self.pick_victim(policy) else {
+    /// Relocation needs a free segment for the cold log; callers should
+    /// reclaim before the free list is exhausted (keeping at least two free
+    /// segments is enough).
+    pub fn reclaim(&mut self, q: &mut dyn IoQueue, policy: ReclaimPolicy) -> Result<Option<Ticket>> {
+        if self.reclaim.is_some() {
+            return Err(Error::Busy);
+        }
+        let Some(seg_no) = self.pick_victim(policy) else {
             return Ok(None);
         };
-        self.reclaim_segment(victim, policy).map(Some)
+        let (seq, kind, end) = {
+            let segments = &self.shared.segments;
+            (segments.seq(seg_no), segments.kind(seg_no), segments.data_end(seg_no))
+        };
+        let is_oldest = self.oldest_live_seq() == Some(seq);
+        // The window is a performance knob; it is bounded by the pool's
+        // largest class but never below the largest batch.
+        let window = align_up(self.shared.options.scan_window as u64, PAGE_SIZE)
+            .min(q.pool().max_class() as u64)
+            .max(self.max_batch) as usize;
+        let ticket = self.next_ticket();
+        self.reclaim = Some(ReclaimJob {
+            ticket,
+            seg_no,
+            seq,
+            kind,
+            policy,
+            is_oldest,
+            end,
+            cursor: self.shared.geometry.data_start(),
+            window,
+            report: ReclaimReport {
+                seg_no,
+                ..Default::default()
+            },
+            stage: ReclaimStage::Read,
+            drain_until: 0,
+            failed: false,
+        });
+        self.advance_reclaim(q);
+        Ok(Some(ticket))
     }
 
     /// Chooses the segment [`Writer::reclaim`] would process next.
@@ -752,6 +1009,87 @@ impl Writer {
             })
     }
 
+    // -- progress -----------------------------------------------------------
+
+    /// Applies completions that arrived for this writer, advances the sealing,
+    /// barrier and reclaim state machines, submits whatever became ready
+    /// (including any partially filled pending batch), and appends the
+    /// resulting [`Completion`]s to `out`. Never waits. Returns the number
+    /// appended.
+    pub fn poll(&mut self, q: &mut dyn IoQueue, out: &mut Vec<Completion>) -> Result<usize> {
+        self.scratch.clear();
+        q.take(self.desc, &mut self.scratch);
+        let mut finished = std::mem::take(&mut self.scratch);
+        for done in finished.drain(..) {
+            if done.token & AUX_TOKEN != 0 {
+                if let Some(aux) = self.aux.remove(&done.token) {
+                    self.finish_aux(aux, done);
+                }
+            } else if let Some(front) = self.inflight.front() {
+                let index = (done.token - front.token) as usize;
+                // The buffer returns to the pool when `done` is dropped here.
+                self.inflight[index].result = Some(done.result);
+            }
+        }
+        self.scratch = finished;
+        while self.inflight.front().is_some_and(|f| f.result.is_some()) {
+            let mut front = self.inflight.pop_front().expect("front exists");
+            let result = front.result.take().expect("checked");
+            self.apply_batch(front.batch, result);
+        }
+
+        self.advance_sealing(q);
+        self.advance_barriers(q);
+        self.advance_reclaim(q);
+        self.index.gc();
+
+        // Close whatever accumulated during this iteration; a packing window
+        // is one worker iteration. A batch that cannot be placed yet stays
+        // pending until the next poll.
+        let _ = self.close_all_pending(q);
+        self.push_ready(q);
+
+        let n = self.completions.len();
+        out.append(&mut self.completions);
+        Ok(n)
+    }
+
+    /// Batches and auxiliary operations accepted but not yet completed.
+    pub fn in_flight(&self) -> usize {
+        self.inflight.len()
+            + self.ready.iter().map(VecDeque::len).sum::<usize>()
+            + self.aux.len()
+            + self.aux_ready.len()
+    }
+
+    /// Whether nothing is pending: no unwritten records, no I/O in flight, no
+    /// sealing, barrier or reclaim in progress. Safe to `detach` when true.
+    pub fn is_idle(&self) -> bool {
+        self.in_flight() == 0
+            && self.pending.iter().all(|p| p.iter().all(Pending::is_empty))
+            && self.sealing.is_empty()
+            && self.barriers.is_empty()
+            && self.reclaim.is_none()
+    }
+
+    /// Number of free segments.
+    pub fn free_segments(&self) -> u32 {
+        self.free.len() as u32
+    }
+
+    /// The LSN the next record will receive.
+    pub fn next_lsn(&self) -> Lsn {
+        self.next_lsn
+    }
+
+    /// Closes the descriptor. Call after `seal` has completed and
+    /// [`Writer::is_idle`] is true; otherwise in-flight batches are abandoned
+    /// (recovery handles that, but the segment is scanned on next open).
+    pub fn detach(self, q: &mut dyn IoQueue) {
+        q.detach(self.desc);
+        drop(self);
+    }
+
     // -- helpers -------------------------------------------------------------
 
     fn check_len(&self, len: u64) -> Result<()> {
@@ -762,17 +1100,34 @@ impl Writer {
         Ok(())
     }
 
+    /// A put of a key the index does not hold needs an index slot.
+    fn check_index_room(&self, id: &ChunkId) -> Result<()> {
+        if self.index.is_full() && self.index.get(id).is_none() {
+            return Err(Error::IndexFull);
+        }
+        Ok(())
+    }
+
     fn exists(&self, id: &ChunkId, opts: PutOptions) -> bool {
-        !opts.overwrite
-            && (self.shared.index.get(id).is_some()
-                || self.pending[slot(SegmentKind::Hot)].iter().any(|p| p.keys.contains(id))
-                || self.inflight_keys.contains_key(id))
+        if opts.overwrite {
+            return false;
+        }
+        if self.index.get(id).is_some() {
+            return true;
+        }
+        let deleted_at = self.deleted.get(id).map_or(0, |t| t.lsn);
+        self.unapplied.get(id).is_some_and(|u| u.max_lsn > deleted_at)
     }
 
     fn next_ids(&mut self) -> (Ticket, Lsn) {
+        let ticket = self.next_ticket();
+        (ticket, self.take_lsn())
+    }
+
+    fn next_ticket(&mut self) -> Ticket {
         let ticket = self.next_ticket;
         self.next_ticket += 1;
-        (ticket, self.take_lsn())
+        ticket
     }
 
     fn take_lsn(&mut self) -> Lsn {
@@ -787,35 +1142,55 @@ impl Writer {
         t | AUX_TOKEN
     }
 
-    /// Allocates from the queue's pool, waiting for in-flight I/O to return
-    /// buffers if necessary. Fails with [`Error::Busy`] only when nothing is
-    /// in flight to wait for.
-    fn alloc(&mut self, len: usize) -> Result<PooledBuf> {
-        loop {
-            if let Some(buf) = self.queue.pool().alloc(len) {
-                return Ok(buf);
-            }
-            if self.queue.in_flight() == 0 {
-                return Err(Error::Busy);
-            }
-            self.poll_io(true)?;
+    fn complete(&mut self, ticket: Ticket, result: Result<Outcome>) {
+        self.completions.push(Completion { ticket, result });
+    }
+
+    /// The segment record for `seg_no`, whether active or being sealed.
+    fn segment_mut(&mut self, seg_no: u32) -> Option<&mut Active> {
+        if let Some(a) = self.active.iter_mut().flatten().find(|a| a.seg_no == seg_no) {
+            return Some(a);
         }
+        self.sealing.iter_mut().map(|s| &mut s.seg).find(|s| s.seg_no == seg_no)
+    }
+
+    fn segment(&self, seg_no: u32) -> Option<&Active> {
+        if let Some(a) = self.active.iter().flatten().find(|a| a.seg_no == seg_no) {
+            return Some(a);
+        }
+        self.sealing.iter().map(|s| &s.seg).find(|s| s.seg_no == seg_no)
+    }
+
+    /// The lowest id among batches not yet applied, if any.
+    fn oldest_unapplied(&self) -> Option<u64> {
+        self.ready
+            .iter()
+            .filter_map(|r| r.front().map(|b| b.id))
+            .chain(self.inflight.iter().map(|f| f.batch.id))
+            .min()
     }
 
     // -- append path ---------------------------------------------------------
 
     /// Makes sure the pending batch of `(kind, batch)` can take a record with a
-    /// value of `value_len` bytes, flushing it and allocating a fresh staging
-    /// buffer as needed.
-    fn reserve_small(&mut self, kind: SegmentKind, batch: BatchKind, value_len: usize) -> Result<()> {
+    /// value of `value_len` bytes, closing it when full and attaching a fresh
+    /// staging buffer. A pending batch is placed in a segment only when it is
+    /// closed, so building one needs no segment room.
+    fn reserve_small(
+        &mut self,
+        q: &mut dyn IoQueue,
+        kind: SegmentKind,
+        batch: BatchKind,
+        value_len: usize,
+    ) -> Result<()> {
         let (k, b) = (slot(kind), batch_slot(batch));
         let meta = record_meta_len(value_len as u32);
         let limit = self.shared.options.batch_limit;
         if self.pending[k][b].buf.is_some() && !self.pending[k][b].fits(meta, value_len) {
-            self.flush_pending_kind(kind, batch)?;
+            self.close_pending(q, k, b)?;
         }
         if self.pending[k][b].buf.is_none() {
-            let buf = self.alloc(limit)?;
+            let buf = q.pool().alloc(limit).ok_or(Error::Busy)?;
             self.pending[k][b].attach(buf);
         }
         debug_assert!(self.pending[k][b].fits(meta, value_len));
@@ -825,6 +1200,7 @@ impl Writer {
     #[allow(clippy::too_many_arguments)]
     fn append_small(
         &mut self,
+        q: &mut dyn IoQueue,
         kind: SegmentKind,
         batch: BatchKind,
         hdr: &RecordHeader,
@@ -832,24 +1208,43 @@ impl Writer {
         value: &[u8],
         apply: Apply,
         ticket: Option<Ticket>,
-    ) -> Result<()> {
+    ) {
         let (k, b) = (slot(kind), batch_slot(batch));
+        self.track(hdr, apply);
         self.pending[k][b].append(hdr, checksums, value, apply, ticket);
         if self.pending[k][b].len >= self.shared.options.batch_limit {
-            self.flush_pending_kind(kind, batch)?;
+            // A batch that cannot be placed now (no free segment, no buffer
+            // for a segment header) stays pending and is retried by `poll`.
+            if self.close_pending(q, k, b).is_ok() {
+                self.push_ready(q);
+            }
         }
-        Ok(())
     }
 
+    fn track(&mut self, hdr: &RecordHeader, apply: Apply) {
+        if matches!(apply, Apply::Insert) {
+            let u = self
+                .unapplied
+                .entry(hdr.key)
+                .or_insert(Unapplied { count: 0, max_lsn: 0 });
+            u.count += 1;
+            u.max_lsn = u.max_lsn.max(hdr.lsn);
+        }
+    }
+
+    /// Encodes a large batch and queues it. The caller has reserved room with
+    /// `ensure_room`.
+    #[allow(clippy::too_many_arguments)]
     fn write_large(
         &mut self,
+        q: &mut dyn IoQueue,
         kind: SegmentKind,
         hdr: &RecordHeader,
         checksums: &[u32],
         mut buf: PooledBuf,
         apply: Apply,
         ticket: Option<Ticket>,
-    ) -> Result<()> {
+    ) {
         let batch_len = large_batch_len(hdr.value_len) as usize;
         let value_off = large_value_offset(hdr.value_len) as usize;
         let meta = hdr.meta_len();
@@ -859,9 +1254,10 @@ impl Writer {
         buf[BATCH_HEADER_LEN + meta..value_off].fill(0);
         buf[value_off + hdr.value_len as usize..batch_len].fill(0);
 
-        let active = self.ensure_room(kind, batch_len as u64, 1)?;
+        let active = self.active[slot(kind)].as_ref().expect("room ensured");
+        let (seg_no, seq) = (active.seg_no, active.seq);
         BatchHeader {
-            seg_seq: active.seq,
+            seg_seq: seq,
             batch_len: batch_len as u32,
             record_count: 1,
             first_lsn: hdr.lsn,
@@ -869,6 +1265,7 @@ impl Writer {
             header_len: 0,
         }
         .encode(&mut buf[..BATCH_HEADER_LEN]);
+        self.track(hdr, apply);
         let record = PendingRecord {
             offset_in_batch: BATCH_HEADER_LEN as u32,
             value_in_batch: value_off as u32,
@@ -876,232 +1273,457 @@ impl Writer {
             apply,
             ticket,
         };
-        self.submit_batch(kind, buf, batch_len, vec![record])
+        self.enqueue_batch(slot(kind), seg_no, buf, batch_len, vec![record]);
+        self.push_ready(q);
     }
 
-    /// Flushes both pending packed batches of `kind`.
-    fn flush_pending(&mut self, kind: SegmentKind) -> Result<()> {
-        self.flush_pending_kind(kind, BatchKind::Inline)?;
-        self.flush_pending_kind(kind, BatchKind::Framed)
+    /// Closes every non-empty pending batch. A batch that cannot be placed
+    /// (no free segment, no buffer for a segment header) stays pending; the
+    /// first such error is returned after the others were tried.
+    fn close_all_pending(&mut self, q: &mut dyn IoQueue) -> Result<()> {
+        let mut first = Ok(());
+        for k in 0..2 {
+            for b in 0..2 {
+                if let Err(e) = self.close_pending(q, k, b)
+                    && first.is_ok()
+                {
+                    first = Err(e);
+                }
+            }
+        }
+        first
     }
 
-    fn flush_pending_kind(&mut self, kind: SegmentKind, batch: BatchKind) -> Result<()> {
-        let (k, b) = (slot(kind), batch_slot(batch));
+    /// Closes the pending batch `(k, b)` into the ready queue at the tail of
+    /// the active segment of its kind.
+    fn close_pending(&mut self, q: &mut dyn IoQueue, k: usize, b: usize) -> Result<()> {
         if self.pending[k][b].is_empty() {
             return Ok(());
         }
+        let kind = if k == 0 { SegmentKind::Hot } else { SegmentKind::Cold };
         let n = self.pending[k][b].records.len();
         let batch_len = align_up(self.pending[k][b].len as u64, PAGE_SIZE);
-        let seq = self.ensure_room(kind, batch_len, n)?.seq;
-
-        let mut pending = std::mem::replace(&mut self.pending[k][b], Pending::new(batch));
+        self.ensure_room(q, kind, batch_len, n)?;
+        let active = self.active[k].as_ref().expect("room ensured");
+        let (seg_no, seq) = (active.seg_no, active.seq);
+        let batch_kind = self.pending[k][b].kind;
+        let mut pending = std::mem::replace(&mut self.pending[k][b], Pending::new(batch_kind));
         let batch_len = pending.finish(seq);
         let buf = pending.buf.take().expect("non-empty pending has a buffer");
-        self.submit_batch(kind, buf, batch_len, pending.records)
+        self.enqueue_batch(k, seg_no, buf, batch_len, pending.records);
+        Ok(())
     }
 
-    /// Submits a fully encoded batch at the tail of the active segment of
-    /// `kind` (which the caller has already sized with `ensure_room`).
-    fn submit_batch(
-        &mut self,
-        kind: SegmentKind,
-        buf: PooledBuf,
-        batch_len: usize,
-        records: Vec<PendingRecord>,
-    ) -> Result<()> {
-        let k = slot(kind);
-        let active = self.active[k]
-            .as_mut()
-            .expect("ensure_room allocated an active segment");
-        let (seg_no, offset) = (active.seg_no, active.tail);
-        active.tail += batch_len as u64;
-
-        while self.queue.in_flight() >= self.queue.depth() {
-            self.poll_io(true)?;
-        }
-        let token = self.next_batch_token;
-        self.next_batch_token += 1;
-        let device_offset = self.shared.geometry.segment_offset(seg_no) + offset;
-        self.queue.write(buf, batch_len, device_offset, token)?;
-        for rec in &records {
-            *self.inflight_keys.entry(rec.entry.key).or_insert(0) += 1;
-        }
-        self.inflight.push_back(InFlight {
-            token,
-            slot: k,
+    /// Fixes a fully encoded batch at the tail of `seg_no` and appends it to
+    /// the ready queue of kind `k`.
+    fn enqueue_batch(&mut self, k: usize, seg_no: u32, buf: PooledBuf, batch_len: usize, records: Vec<PendingRecord>) {
+        let seg = self.segment_mut(seg_no).expect("segment exists");
+        let offset = seg.tail;
+        seg.tail += batch_len as u64;
+        seg.unapplied += 1;
+        seg.unapplied_records += records.len();
+        let id = self.next_batch_id;
+        self.next_batch_id += 1;
+        self.ready[k].push_back(Batch {
+            id,
             seg_no,
             offset,
-            batch_len: batch_len as u64,
+            batch_len,
             records,
-            result: None,
+            buf: Some(buf),
         });
-        Ok(())
+    }
+
+    /// Pushes deferred auxiliary operations and ready batches (foreground
+    /// first) while the queue has room.
+    fn push_ready(&mut self, q: &mut dyn IoQueue) {
+        // Auxiliary operations first: segment headers gate the batches behind
+        // them, footers and free headers gate reclaim.
+        while q.vacant() > 0 {
+            let Some(op) = self.aux_ready.pop_front() else {
+                break;
+            };
+            if let Some(op) = self.try_enqueue_aux(q, op) {
+                self.aux_ready.push_front(op);
+                break;
+            }
+        }
+        for k in 0..2 {
+            while let Some(front) = self.ready[k].front() {
+                let seg_no = front.seg_no;
+                let seg = self.segment(seg_no).expect("ready batch for a known segment");
+                if seg.broken {
+                    // Everything from the failure onwards in this segment is
+                    // lost; nothing beyond the truncated tail is written.
+                    let batch = self.ready[k].pop_front().expect("front exists");
+                    let seg = self.segment_mut(seg_no).expect("known segment");
+                    seg.unapplied -= 1;
+                    seg.unapplied_records -= batch.records.len();
+                    self.fail_batch(batch, "write after a failed write in the same segment");
+                    continue;
+                }
+                if !seg.opened || q.vacant() == 0 {
+                    break;
+                }
+                let mut batch = self.ready[k].pop_front().expect("front exists");
+                let buf = batch.buf.take().expect("ready batch holds its buffer");
+                let token = self.next_batch_token;
+                let device_offset = self.shared.geometry.segment_offset(batch.seg_no) + batch.offset;
+                match q.write(self.desc, buf, batch.batch_len, device_offset, token) {
+                    Ok(()) => {
+                        self.next_batch_token += 1;
+                        self.inflight.push_back(InFlight {
+                            batch,
+                            token,
+                            result: None,
+                        });
+                    }
+                    Err(buf) => {
+                        batch.buf = Some(buf);
+                        self.ready[k].push_front(batch);
+                        break;
+                    }
+                }
+            }
+        }
     }
 
     // -- completion path -----------------------------------------------------
 
-    /// Reaps completions and applies every write whose turn has come.
-    fn poll_io(&mut self, wait: bool) -> Result<()> {
-        self.scratch.clear();
-        self.queue.poll(&mut self.scratch, wait)?;
-        for done in self.scratch.drain(..) {
-            if done.token & AUX_TOKEN != 0 {
-                self.aux_done.insert(done.token, done);
-            } else {
-                let front = self.inflight.front().expect("completion for an in-flight batch").token;
-                let index = (done.token - front) as usize;
-                // The buffer returns to the pool when `done` is dropped here.
-                self.inflight[index].result = Some(done.result);
-            }
-        }
-        while self.inflight.front().is_some_and(|f| f.result.is_some()) {
-            let mut batch = self.inflight.pop_front().expect("front exists");
-            let result = batch.result.take().expect("checked");
-            self.apply_batch(batch, result);
-        }
-        Ok(())
-    }
-
-    fn apply_batch(&mut self, batch: InFlight, result: io::Result<usize>) {
-        for rec in &batch.records {
-            if let Some(n) = self.inflight_keys.get_mut(&rec.entry.key) {
-                *n -= 1;
-                if *n == 0 {
-                    self.inflight_keys.remove(&rec.entry.key);
-                }
-            }
-        }
-        let active = self.active[batch.slot]
-            .as_mut()
-            .expect("active segment outlives its in-flight batches");
-        debug_assert_eq!(active.seg_no, batch.seg_no);
+    fn apply_batch(&mut self, batch: Batch, result: io::Result<usize>) {
         let failure = match result {
-            Ok(n) if n as u64 == batch.batch_len => None,
+            Ok(n) if n == batch.batch_len => None,
             Ok(n) => Some(format!("short write: {n} of {} bytes", batch.batch_len)),
             Err(e) => Some(e.to_string()),
         };
-        if failure.is_none() && !active.broken {
-            for rec in batch.records {
-                let mut entry = rec.entry;
-                entry.offset = (batch.offset + rec.offset_in_batch as u64) as u32;
-                entry.value_off = (batch.offset + rec.value_in_batch as u64) as u32;
-                active.footer.push(entry);
-                // A relocation that no longer applies was superseded by a
-                // foreground write meanwhile; that is not a failure.
-                apply_record(&self.shared, batch.seg_no, &entry, rec.apply);
+        let seg_no = batch.seg_no;
+        let broken = {
+            let seg = self.segment_mut(seg_no).expect("segment outlives its batches");
+            seg.unapplied -= 1;
+            seg.unapplied_records -= batch.records.len();
+            seg.broken
+        };
+        if failure.is_none() && !broken {
+            let entries: Vec<FooterEntry> = batch
+                .records
+                .iter()
+                .map(|rec| FooterEntry {
+                    offset: (batch.offset + rec.offset_in_batch as u64) as u32,
+                    value_off: (batch.offset + rec.value_in_batch as u64) as u32,
+                    ..rec.entry
+                })
+                .collect();
+            self.segment_mut(seg_no)
+                .expect("segment outlives its batches")
+                .footer
+                .extend_from_slice(&entries);
+            for (rec, entry) in batch.records.into_iter().zip(entries) {
+                let result = self.apply_record(seg_no, &entry, rec.apply);
                 if let Some(ticket) = rec.ticket {
-                    self.completions.push(Completion {
-                        ticket,
-                        lsn: entry.lsn,
-                        result: Ok(()),
-                    });
+                    let outcome = match rec.apply {
+                        Apply::Tombstone => Outcome::Delete { lsn: entry.lsn },
+                        _ => Outcome::Put { lsn: entry.lsn },
+                    };
+                    self.complete(ticket, result.map(|()| outcome));
                 }
             }
             return;
         }
-
         // Everything from the first failure onwards in this segment is lost;
         // truncate the segment there and abandon it.
-        if !active.broken {
-            active.broken = true;
-            active.tail = batch.offset;
+        let seg = self.segment_mut(seg_no).expect("segment outlives its batches");
+        if !seg.broken {
+            seg.broken = true;
+            seg.tail = batch.offset;
         }
         let message = failure.unwrap_or_else(|| "write after a failed write in the same segment".to_string());
+        self.fail_batch(batch, &message);
+    }
+
+    fn fail_batch(&mut self, batch: Batch, message: &str) {
         for rec in batch.records {
-            if matches!(rec.apply, Apply::Relocate(_)) {
-                self.relocation_failures += 1;
+            self.untrack(&rec.entry, rec.apply);
+            if matches!(rec.apply, Apply::Relocate(_))
+                && let Some(job) = &mut self.reclaim
+            {
+                job.failed = true;
             }
             if let Some(ticket) = rec.ticket {
-                self.completions.push(Completion {
-                    ticket,
-                    lsn: rec.entry.lsn,
-                    result: Err(Error::Io(io::Error::other(message.clone()))),
-                });
+                self.complete(ticket, Err(io_error(message)));
             }
+        }
+        for b in &mut self.barriers {
+            b.error.get_or_insert_with(|| message.to_string());
         }
     }
 
-    fn wait_inflight(&mut self) -> Result<()> {
-        while !self.inflight.is_empty() {
-            self.poll_io(true)?;
+    fn untrack(&mut self, entry: &FooterEntry, apply: Apply) {
+        match apply {
+            Apply::Insert => {
+                if let Some(u) = self.unapplied.get_mut(&entry.key) {
+                    u.count -= 1;
+                    if u.count == 0 {
+                        self.unapplied.remove(&entry.key);
+                        // No put of the key is unapplied any more; an applied
+                        // tombstone has nothing left to suppress.
+                        if self.deleted.get(&entry.key).is_some_and(|t| t.applied) {
+                            self.deleted.remove(&entry.key);
+                        }
+                    }
+                }
+            }
+            Apply::Tombstone => {
+                if let Some(t) = self.deleted.get_mut(&entry.key)
+                    && t.lsn == entry.lsn
+                {
+                    if self.unapplied.contains_key(&entry.key) {
+                        t.applied = true;
+                    } else {
+                        self.deleted.remove(&entry.key);
+                    }
+                }
+            }
+            Apply::Relocate(_) => {}
         }
+    }
+
+    /// Updates the index and live-byte accounting for a record now on disk.
+    fn apply_record(&mut self, seg_no: u32, entry: &FooterEntry, apply: Apply) -> Result<()> {
+        let footprint = RecordGeometry::footprint(entry.value_len, entry.flags);
+        let value = IndexValue {
+            loc: Location {
+                seg_no,
+                offset: entry.offset,
+            },
+            value_off: entry.value_off,
+            value_len: entry.value_len,
+            flags: flags_from_record(entry.flags),
+            lsn: entry.lsn,
+        };
+        let segments = &self.shared.segments;
+        let mut result = Ok(());
+        match apply {
+            Apply::Insert => {
+                // A tombstone appended after this record (and not yet applied)
+                // supersedes it: the record is on disk but never indexed.
+                let superseded = self.deleted.get(&entry.key).is_some_and(|t| t.lsn > entry.lsn);
+                if !superseded {
+                    match self.index.insert_if_newer(entry.key, value) {
+                        InsertOutcome::Inserted => segments.add_live(seg_no, footprint),
+                        InsertOutcome::Replaced(old) => {
+                            segments.sub_live(
+                                old.loc.seg_no,
+                                RecordGeometry::footprint(old.value_len, old.record_flags()),
+                            );
+                            segments.add_live(seg_no, footprint);
+                        }
+                        // An even newer version was applied first.
+                        InsertOutcome::Rejected => {}
+                        // The budget was checked at put time; a rebuild that
+                        // failed meanwhile leaves the record unindexed.
+                        InsertOutcome::Full => result = Err(Error::IndexFull),
+                    }
+                }
+            }
+            Apply::Relocate(from) => {
+                // A relocation that no longer applies was superseded by a
+                // foreground write meanwhile; that is not a failure.
+                if self.index.replace_if_at(&entry.key, from, value) {
+                    segments.add_live(seg_no, footprint);
+                }
+            }
+            Apply::Tombstone => {}
+        }
+        self.untrack(entry, apply);
+        result
+    }
+
+    // -- auxiliary I/O --------------------------------------------------------
+
+    /// Enqueues an auxiliary operation now, or defers it until the queue has
+    /// room.
+    fn enqueue_aux(&mut self, q: &mut dyn IoQueue, op: AuxOp) {
+        if let Some(op) = self.try_enqueue_aux(q, op) {
+            self.aux_ready.push_back(op);
+        }
+    }
+
+    fn try_enqueue_aux(&mut self, q: &mut dyn IoQueue, op: AuxOp) -> Option<AuxOp> {
+        let token = self.next_aux_token();
+        let AuxOp {
+            aux,
+            buf,
+            len,
+            offset,
+            read,
+        } = op;
+        let outcome = if read {
+            q.read(self.desc, buf, len, offset, token)
+        } else {
+            q.write(self.desc, buf, len, offset, token)
+        };
+        match outcome {
+            Ok(()) => {
+                self.aux.insert(token, aux);
+                None
+            }
+            Err(buf) => Some(AuxOp {
+                aux,
+                buf,
+                len,
+                offset,
+                read,
+            }),
+        }
+    }
+
+    /// Encodes `header` into a pool buffer and queues it as `aux`.
+    fn write_header(&mut self, q: &mut dyn IoQueue, header: &SegmentHeader, aux: Aux) -> Result<()> {
+        let mut buf = q.pool().alloc(SEGMENT_HEADER_LEN as usize).ok_or(Error::Busy)?;
+        header.encode(&mut buf[..SEGMENT_HEADER_LEN as usize]);
+        let offset = self.shared.geometry.segment_offset(header.seg_no);
+        self.enqueue_aux(
+            q,
+            AuxOp {
+                aux,
+                buf,
+                len: SEGMENT_HEADER_LEN as usize,
+                offset,
+                read: false,
+            },
+        );
         Ok(())
     }
 
-    /// Waits for the auxiliary operation `token`.
-    fn wait_aux(&mut self, token: u64) -> Result<IoCompletion> {
-        loop {
-            if let Some(done) = self.aux_done.remove(&token) {
-                return Ok(done);
+    fn finish_aux(&mut self, aux: Aux, done: IoCompletion) {
+        let failure = match &done.result {
+            Ok(_) => None,
+            Err(e) => Some(e.to_string()),
+        };
+        match aux {
+            Aux::OpenHeader { seg_no } => {
+                if let Some(seg) = self.segment_mut(seg_no) {
+                    seg.opened = true;
+                    // A segment whose header may not be on disk is not
+                    // recoverable: abandon it; its batches fail at push time.
+                    if failure.is_some() {
+                        seg.broken = true;
+                    }
+                }
             }
-            self.poll_io(true)?;
-        }
-    }
-
-    /// Reads `len` bytes at `offset` within `seg_no` through the queue,
-    /// applying write completions while waiting.
-    fn read_blocking(&mut self, seg_no: u32, offset: u64, len: usize) -> Result<PooledBuf> {
-        let buf = self.alloc(len)?;
-        let token = self.next_aux_token();
-        while self.queue.in_flight() >= self.queue.depth() {
-            self.poll_io(true)?;
-        }
-        self.queue
-            .read(buf, len, self.shared.geometry.segment_offset(seg_no) + offset, token)?;
-        let done = self.wait_aux(token)?;
-        match done.result {
-            Ok(n) if n == len => Ok(done.buf.expect("read returns its buffer")),
-            Ok(n) => Err(Error::Io(io::Error::other(format!("short read: {n} of {len} bytes")))),
-            Err(e) => Err(Error::Io(e)),
+            Aux::Footer { seg_no } => {
+                if let Some(s) = self.sealing.iter_mut().find(|s| s.seg.seg_no == seg_no)
+                    && let SealStage::Footer { outstanding, .. } = &mut s.stage
+                {
+                    *outstanding -= 1;
+                }
+                // A failed footer piece is not fatal: recovery falls back to a
+                // scan when the footer does not validate.
+            }
+            Aux::SealHeader { seg_no } => {
+                if let Some(pos) = self.sealing.iter().position(|s| s.seg.seg_no == seg_no) {
+                    let sealing = self.sealing.swap_remove(pos);
+                    // Even if the header write failed the data is intact; the
+                    // in-memory state moves on and recovery scans the segment.
+                    self.shared.segments.set_sealed(seg_no, sealing.seg.tail);
+                }
+            }
+            Aux::Fsync { ticket } => {
+                if let Some(b) = self.barriers.iter_mut().find(|b| b.ticket == ticket) {
+                    b.fsync = Fsync::Done;
+                    if let Some(e) = failure {
+                        b.error.get_or_insert(e);
+                    }
+                }
+            }
+            Aux::ReclaimRead => {
+                let Some(job) = &mut self.reclaim else {
+                    return;
+                };
+                match (done.result, done.buf) {
+                    (Ok(n), Some(buf)) => {
+                        job.stage = ReclaimStage::Process {
+                            buf,
+                            len: n,
+                            rel: 0,
+                            rec: 0,
+                        };
+                    }
+                    (Err(e), _) => {
+                        let ticket = job.ticket;
+                        self.reclaim = None;
+                        self.complete(ticket, Err(Error::Io(e)));
+                    }
+                    (Ok(_), None) => unreachable!("reads return their buffer"),
+                }
+            }
+            Aux::FreeHeader { seg_no } => {
+                let Some(job) = self.reclaim.take() else {
+                    return;
+                };
+                debug_assert_eq!(job.seg_no, seg_no);
+                match failure {
+                    None => {
+                        let segments = &self.shared.segments;
+                        segments.set(seg_no, SegmentState::Free, job.kind, job.seq);
+                        segments.reset_live(seg_no);
+                        self.free.push_back(seg_no);
+                        self.complete(job.ticket, Ok(Outcome::Reclaim(job.report)));
+                    }
+                    Some(e) => self.complete(job.ticket, Err(io_error(e))),
+                }
+            }
         }
     }
 
     // -- segment lifecycle ---------------------------------------------------
 
-    /// Returns the active segment of `kind` with room for a batch of
-    /// `batch_len` bytes and `new_records` footer entries, sealing and
-    /// allocating as needed.
-    fn ensure_room(&mut self, kind: SegmentKind, batch_len: u64, new_records: usize) -> Result<&mut Active> {
+    /// Makes sure the active segment of `kind` has room for a batch of
+    /// `batch_len` bytes and `new_records` footer entries, parking the current
+    /// one for sealing and allocating a fresh one as needed.
+    fn ensure_room(
+        &mut self,
+        q: &mut dyn IoQueue,
+        kind: SegmentKind,
+        batch_len: u64,
+        new_records: usize,
+    ) -> Result<()> {
         let k = slot(kind);
         let segment_size = self.shared.superblock.segment_size;
         let fits = self.active[k]
             .as_ref()
             .is_some_and(|a| a.fits(batch_len, new_records, segment_size));
-        if !fits {
-            if self.active[k].is_some() {
-                // The footer must describe every record of the segment, so all
-                // of its batches have to be applied first.
-                self.wait_inflight()?;
-                let active = self.active[k].take().expect("checked");
-                self.seal(active)?;
-            }
-            let active = self.allocate(kind)?;
-            if !active.fits(batch_len, new_records, segment_size) {
-                // Only reachable if format validation was bypassed.
-                return Err(Error::ValueTooLarge {
-                    len: batch_len,
-                    max: segment_size,
-                });
-            }
-            self.active[k] = Some(active);
+        if fits {
+            return Ok(());
         }
-        Ok(self.active[k].as_mut().expect("just ensured"))
+        // Allocate first so a failure leaves the current segment in place.
+        let fresh = self.allocate(q, kind)?;
+        if !fresh.fits(batch_len, new_records, segment_size) {
+            // Only reachable if format validation was bypassed; the header
+            // write is already queued, so the segment is parked, not reused.
+            self.park(fresh);
+            return Err(Error::ValueTooLarge {
+                len: batch_len,
+                max: segment_size,
+            });
+        }
+        if let Some(old) = self.active[k].replace(fresh) {
+            self.park(old);
+        }
+        Ok(())
     }
 
-    fn allocate(&mut self, kind: SegmentKind) -> Result<Active> {
+    /// Takes a free segment, queues its header write and returns it as
+    /// active (batches wait until the header has landed).
+    fn allocate(&mut self, q: &mut dyn IoQueue, kind: SegmentKind) -> Result<Active> {
         let seg_no = self.free.pop_front().ok_or(Error::NoSpace)?;
         let seq = self.next_seq;
+        let header = self.shared.segment_header(seg_no, SegmentState::Active, kind, seq);
+        if let Err(e) = self.write_header(q, &header, Aux::OpenHeader { seg_no }) {
+            self.free.push_front(seg_no);
+            return Err(e);
+        }
         self.next_seq += 1;
-        self.shared.write_segment_header(&SegmentHeader {
-            disk_uuid: self.shared.superblock.disk_uuid,
-            seg_no,
-            state: SegmentState::Active,
-            kind,
-            seq,
-            footer_offset: 0,
-            footer_len: 0,
-            record_count: 0,
-        })?;
         self.shared.segments.set(seg_no, SegmentState::Active, kind, seq);
         Ok(Active {
             seg_no,
@@ -1110,18 +1732,162 @@ impl Writer {
             tail: self.shared.geometry.data_start(),
             footer: Vec::new(),
             broken: false,
+            opened: false,
+            unapplied: 0,
+            unapplied_records: 0,
         })
     }
 
-    fn seal(&self, active: Active) -> Result<()> {
-        seal_segment(
-            &self.shared,
-            active.seg_no,
-            active.seq,
-            active.kind,
-            active.tail,
-            &active.footer,
-        )
+    /// Hands a segment that is no longer written to the sealing state
+    /// machine.
+    fn park(&mut self, seg: Active) {
+        self.sealing.push(Sealing {
+            seg,
+            stage: SealStage::Draining,
+        });
+    }
+
+    fn advance_sealing(&mut self, q: &mut dyn IoQueue) {
+        for i in 0..self.sealing.len() {
+            self.advance_one_sealing(q, i);
+        }
+    }
+
+    fn advance_one_sealing(&mut self, q: &mut dyn IoQueue, i: usize) {
+        // The stage is taken out while it is worked on so the queue and the
+        // pool can be used without holding a borrow into `sealing`.
+        loop {
+            let stage = std::mem::replace(&mut self.sealing[i].stage, SealStage::Header);
+            match stage {
+                SealStage::Draining => {
+                    let seg = &self.sealing[i].seg;
+                    if seg.unapplied > 0 {
+                        self.sealing[i].stage = SealStage::Draining;
+                        return;
+                    }
+                    let len = footer_len(seg.footer.len()) as usize;
+                    let mut encoded = AlignedBuf::zeroed(len);
+                    encode_footer(seg.seq, &seg.footer, &mut encoded);
+                    self.sealing[i].stage = SealStage::Footer {
+                        encoded,
+                        written: 0,
+                        outstanding: 0,
+                    };
+                }
+                SealStage::Footer {
+                    encoded,
+                    mut written,
+                    mut outstanding,
+                } => {
+                    let seg = &self.sealing[i].seg;
+                    let (seg_no, tail, kind, seq, count) = (seg.seg_no, seg.tail, seg.kind, seg.seq, seg.footer.len());
+                    let base = self.shared.geometry.segment_offset(seg_no);
+                    let max = q.pool().max_class();
+                    while written < encoded.len() {
+                        let piece = (encoded.len() - written).min(max);
+                        let Some(mut buf) = q.pool().alloc(piece) else {
+                            self.sealing[i].stage = SealStage::Footer {
+                                encoded,
+                                written,
+                                outstanding,
+                            };
+                            return;
+                        };
+                        buf[..piece].copy_from_slice(&encoded[written..written + piece]);
+                        let op = AuxOp {
+                            aux: Aux::Footer { seg_no },
+                            buf,
+                            len: piece,
+                            offset: base + tail + written as u64,
+                            read: false,
+                        };
+                        written += piece;
+                        // A deferred piece is still outstanding.
+                        outstanding += 1;
+                        self.enqueue_aux(q, op);
+                    }
+                    if outstanding > 0 {
+                        self.sealing[i].stage = SealStage::Footer {
+                            encoded,
+                            written,
+                            outstanding,
+                        };
+                        return;
+                    }
+                    let header = SegmentHeader {
+                        footer_offset: tail,
+                        footer_len: encoded.len() as u64,
+                        record_count: count as u64,
+                        ..self.shared.segment_header(seg_no, SegmentState::Sealed, kind, seq)
+                    };
+                    match self.write_header(q, &header, Aux::SealHeader { seg_no }) {
+                        Ok(()) => {
+                            self.sealing[i].stage = SealStage::Header;
+                        }
+                        Err(_) => {
+                            self.sealing[i].stage = SealStage::Footer {
+                                encoded,
+                                written,
+                                outstanding,
+                            };
+                        }
+                    }
+                    return;
+                }
+                SealStage::Header => {
+                    self.sealing[i].stage = SealStage::Header;
+                    return;
+                }
+            }
+        }
+    }
+
+    fn advance_barriers(&mut self, q: &mut dyn IoQueue) {
+        let oldest = self.oldest_unapplied();
+        let mut i = 0;
+        while i < self.barriers.len() {
+            let ticket = self.barriers[i].ticket;
+            let until = self.barriers[i].until;
+            let applied = oldest.is_none_or(|o| o >= until);
+            if !applied {
+                i += 1;
+                continue;
+            }
+            if matches!(self.barriers[i].fsync, Fsync::Pending) {
+                let token = self.next_aux_token();
+                match q.fsync(self.desc, token) {
+                    Ok(()) => {
+                        self.aux.insert(token, Aux::Fsync { ticket });
+                        self.barriers[i].fsync = Fsync::Issued;
+                    }
+                    Err(_) => {
+                        i += 1;
+                        continue;
+                    }
+                }
+            }
+            if matches!(self.barriers[i].fsync, Fsync::Issued) {
+                i += 1;
+                continue;
+            }
+            if let Some(segs) = &self.barriers[i].seal
+                && segs.iter().any(|s| self.sealing.iter().any(|x| x.seg.seg_no == *s))
+            {
+                i += 1;
+                continue;
+            }
+            let b = self.barriers.remove(i).expect("index in range");
+            let outcome = if b.seal.is_some() {
+                Outcome::Seal
+            } else {
+                Outcome::Flush
+            };
+            let result = match b.error {
+                Some(e) => Err(io_error(e)),
+                None => Ok(outcome),
+            };
+            self.complete(b.ticket, result);
+        }
     }
 
     // -- reclaim -------------------------------------------------------------
@@ -1135,167 +1901,276 @@ impl Writer {
             .min()
     }
 
-    fn reclaim_segment(&mut self, seg_no: u32, policy: ReclaimPolicy) -> Result<ReclaimReport> {
-        // Liveness is judged against the index, which must reflect every
-        // accepted foreground write.
-        self.flush_pending(SegmentKind::Hot)?;
-        self.wait_inflight()?;
-
-        let shared = self.shared.clone();
-        let seg_header = shared.read_segment_header(seg_no)?;
-        if seg_header.state != SegmentState::Sealed {
-            return Err(Error::InvalidOption(format!("segment {seg_no} is not sealed")));
+    fn set_reclaim_stage(&mut self, stage: ReclaimStage) {
+        if let Some(job) = &mut self.reclaim {
+            job.stage = stage;
         }
-        let is_oldest = self.oldest_live_seq() == Some(seg_header.seq);
-        let failures_before = self.relocation_failures;
-        let mut report = ReclaimReport {
-            seg_no,
-            ..Default::default()
-        };
+    }
 
-        let window = align_up(shared.options.scan_window as u64, PAGE_SIZE).max(self.max_batch) as usize;
-        let end = seg_header.footer_offset;
-        let mut cursor = shared.geometry.data_start();
-        'scan: while cursor < end {
-            let len = (end - cursor).min(window as u64) as usize;
-            let buf = self.read_blocking(seg_no, cursor, len)?;
-            let mut rel = 0usize;
-            loop {
-                match next_batch(
-                    &buf[..len],
-                    rel,
-                    seg_header.seq,
-                    self.max_batch,
-                    end - cursor - rel as u64,
-                ) {
-                    BatchStep::Batch(batch, batch_len) => {
-                        let batch_off = cursor + rel as u64;
-                        // A corrupt batch aborts the pass without freeing
-                        // anything: live records behind it could be lost.
-                        for rec in parse_batch(&buf[rel..rel + batch_len], &batch, true)? {
-                            let loc = Location {
-                                seg_no,
-                                offset: (batch_off + rec.offset_in_batch as u64) as u32,
-                            };
-                            report.records += 1;
-                            // Reclaim is off the hot path; copying the checksum
-                            // array out keeps the re-encoding API simple.
-                            let checksums = rec.checksums.to_vec();
-                            self.reclaim_record(
-                                &rec.header,
-                                &checksums,
-                                rec.value,
-                                loc,
-                                policy,
-                                is_oldest,
-                                &mut report,
-                            )?;
+    fn finish_reclaim(&mut self, result: Result<Outcome>) {
+        if let Some(job) = self.reclaim.take() {
+            self.complete(job.ticket, result);
+        }
+    }
+
+    fn advance_reclaim(&mut self, q: &mut dyn IoQueue) {
+        loop {
+            // The stage is taken out while it is worked on; every arm puts a
+            // stage back before returning or looping.
+            let Some(stage) = self
+                .reclaim
+                .as_mut()
+                .map(|j| std::mem::replace(&mut j.stage, ReclaimStage::Reading))
+            else {
+                return;
+            };
+            match stage {
+                ReclaimStage::Read => {
+                    let (seg_no, cursor, end, window) = {
+                        let j = self.reclaim.as_ref().expect("job exists");
+                        (j.seg_no, j.cursor, j.end, j.window)
+                    };
+                    if cursor >= end {
+                        // Every record is processed. The batches carrying the
+                        // relocations, and the foreground writes whose
+                        // existence justified dropping records (a pending
+                        // tombstone, a newer version), must be durable before
+                        // the victim disappears.
+                        if let Err(e) = self.close_all_pending(q) {
+                            match e {
+                                Error::Busy => {
+                                    self.set_reclaim_stage(ReclaimStage::Read);
+                                    return;
+                                }
+                                e => {
+                                    self.finish_reclaim(Err(e));
+                                    return;
+                                }
+                            }
                         }
-                        rel += batch_len;
+                        let until = self.next_batch_id;
+                        let job = self.reclaim.as_mut().expect("job exists");
+                        job.drain_until = until;
+                        job.stage = ReclaimStage::Drain;
+                        continue;
                     }
-                    BatchStep::NeedMore => break,
-                    BatchStep::End => break 'scan,
+                    let len = (end - cursor).min(window as u64) as usize;
+                    let Some(buf) = q.pool().alloc(len) else {
+                        self.set_reclaim_stage(ReclaimStage::Read);
+                        return;
+                    };
+                    let offset = self.shared.geometry.segment_offset(seg_no) + cursor;
+                    self.set_reclaim_stage(ReclaimStage::Reading);
+                    self.enqueue_aux(
+                        q,
+                        AuxOp {
+                            aux: Aux::ReclaimRead,
+                            buf,
+                            len,
+                            offset,
+                            read: true,
+                        },
+                    );
+                    return;
+                }
+                ReclaimStage::Reading => {
+                    self.set_reclaim_stage(ReclaimStage::Reading);
+                    return;
+                }
+                ReclaimStage::Process { buf, len, rel, rec } => match self.process_window(q, buf, len, rel, rec) {
+                    Ok(None) => self.set_reclaim_stage(ReclaimStage::Read),
+                    Ok(Some(stage)) => {
+                        self.set_reclaim_stage(stage);
+                        return;
+                    }
+                    Err(e) => {
+                        self.finish_reclaim(Err(e));
+                        return;
+                    }
+                },
+                ReclaimStage::Drain => {
+                    let (until, failed, seg_no) = {
+                        let j = self.reclaim.as_ref().expect("job exists");
+                        (j.drain_until, j.failed, j.seg_no)
+                    };
+                    if !self.oldest_unapplied().is_none_or(|o| o >= until) {
+                        self.set_reclaim_stage(ReclaimStage::Drain);
+                        return;
+                    }
+                    if failed {
+                        self.finish_reclaim(Err(io_error(format!(
+                            "segment {seg_no}: relocation writes failed; segment kept"
+                        ))));
+                        return;
+                    }
+                    self.set_reclaim_stage(ReclaimStage::Pins);
+                }
+                ReclaimStage::Pins => {
+                    // Readers that looked the victim up before its entries
+                    // were removed hold a pin; the removals are ordered before
+                    // this check.
+                    std::sync::atomic::fence(Ordering::SeqCst);
+                    let (seg_no, kind, seq) = {
+                        let j = self.reclaim.as_ref().expect("job exists");
+                        (j.seg_no, j.kind, j.seq)
+                    };
+                    if self.shared.segments.pins(seg_no) > 0 {
+                        self.set_reclaim_stage(ReclaimStage::Pins);
+                        return;
+                    }
+                    let header = self.shared.segment_header(seg_no, SegmentState::Free, kind, seq);
+                    match self.write_header(q, &header, Aux::FreeHeader { seg_no }) {
+                        Ok(()) => self.set_reclaim_stage(ReclaimStage::Freeing),
+                        Err(_) => self.set_reclaim_stage(ReclaimStage::Pins),
+                    }
+                    return;
+                }
+                ReclaimStage::Freeing => {
+                    self.set_reclaim_stage(ReclaimStage::Freeing);
+                    return;
                 }
             }
-            if rel == 0 {
-                return Err(Error::corrupt(format!(
-                    "segment {seg_no}: batch at {cursor} larger than the scan window"
-                )));
+        }
+    }
+
+    /// Processes the window `buf[..len]` from batch offset `rel`, record
+    /// `rec`. Returns the stage to park in when the pool runs dry mid-window,
+    /// or `None` when the window is consumed and the cursor advanced.
+    fn process_window(
+        &mut self,
+        q: &mut dyn IoQueue,
+        buf: PooledBuf,
+        len: usize,
+        mut rel: usize,
+        mut rec: usize,
+    ) -> Result<Option<ReclaimStage>> {
+        let (seg_no, seq, cursor, end, policy, is_oldest) = {
+            let job = self.reclaim.as_ref().expect("job exists");
+            (job.seg_no, job.seq, job.cursor, job.end, job.policy, job.is_oldest)
+        };
+        loop {
+            match next_batch(&buf[..len], rel, seq, self.max_batch, end - cursor - rel as u64) {
+                BatchStep::Batch(batch, batch_len) => {
+                    let batch_off = cursor + rel as u64;
+                    // A structurally corrupt batch aborts the pass without
+                    // freeing anything: live records behind it could be lost.
+                    // Value checksums are checked per record below, so one
+                    // rotten value only drops that record.
+                    let records = parse_batch(&buf[rel..rel + batch_len], &batch, false)?;
+                    for (i, r) in records.iter().enumerate().skip(rec) {
+                        let loc = Location {
+                            seg_no,
+                            offset: (batch_off + r.offset_in_batch as u64) as u32,
+                        };
+                        // Reclaim is off the hot path; copying the checksum
+                        // array out keeps the re-encoding API simple.
+                        let checksums = r.checksums.to_vec();
+                        match self.reclaim_record(q, &r.header, &checksums, r.value, loc, policy, is_oldest) {
+                            Ok(()) => self.reclaim.as_mut().expect("job exists").report.records += 1,
+                            Err(Error::Busy) => {
+                                return Ok(Some(ReclaimStage::Process { buf, len, rel, rec: i }));
+                            }
+                            Err(e) => return Err(e),
+                        }
+                    }
+                    rel += batch_len;
+                    rec = 0;
+                }
+                BatchStep::NeedMore => break,
+                BatchStep::End => {
+                    let job = self.reclaim.as_mut().expect("job exists");
+                    job.cursor = job.end;
+                    return Ok(None);
+                }
             }
-            cursor += rel as u64;
         }
-
-        // Relocated records must be applied to the index before the victim
-        // disappears from it, and every relocation must have succeeded.
-        self.flush_pending(SegmentKind::Cold)?;
-        self.wait_inflight()?;
-        if self.relocation_failures != failures_before {
-            return Err(Error::Io(io::Error::other(format!(
-                "segment {seg_no}: relocation writes failed; segment kept"
-            ))));
+        if rel == 0 {
+            return Err(Error::corrupt(format!(
+                "segment {seg_no}: batch at {cursor} larger than the scan window"
+            )));
         }
-
-        // Readers that looked the victim up before its entries were removed
-        // hold a pin; wait for them to finish.
-        while shared.segments.pins(seg_no) > 0 {
-            thread::yield_now();
-        }
-        shared.write_segment_header(&SegmentHeader {
-            disk_uuid: shared.superblock.disk_uuid,
-            seg_no,
-            state: SegmentState::Free,
-            kind: seg_header.kind,
-            seq: seg_header.seq,
-            footer_offset: 0,
-            footer_len: 0,
-            record_count: 0,
-        })?;
-        shared
-            .segments
-            .set(seg_no, SegmentState::Free, seg_header.kind, seg_header.seq);
-        shared.segments.reset_live(seg_no);
-        self.free.push_back(seg_no);
-        Ok(report)
+        let job = self.reclaim.as_mut().expect("job exists");
+        job.cursor += rel as u64;
+        Ok(None)
     }
 
     #[allow(clippy::too_many_arguments)]
     fn reclaim_record(
         &mut self,
+        q: &mut dyn IoQueue,
         hdr: &RecordHeader,
         checksums: &[u32],
         value: &[u8],
         loc: Location,
         policy: ReclaimPolicy,
         is_oldest: bool,
-        report: &mut ReclaimReport,
     ) -> Result<()> {
-        let shared = self.shared.clone();
         match hdr.kind {
             RecordKind::Data => {
-                let Some(current) = shared.index.get(&hdr.key).filter(|v| v.loc == loc) else {
-                    report.dropped += 1;
+                let Some(current) = self.index.get(&hdr.key).filter(|v| v.loc == loc) else {
+                    self.reclaim.as_mut().expect("job exists").report.dropped += 1;
                     return Ok(());
                 };
-                let keep = !shared.is_expired(hdr.expire_at)
+                // A value that fails its checksums can never be read again;
+                // it is dropped rather than copied forward.
+                let intact = verify_blocks_with(value, 0, |b| checksums.get(b as usize).copied()).is_ok();
+                let keep = intact
+                    && !self.shared.is_expired(hdr.expire_at)
                     && match policy {
                         ReclaimPolicy::Storage => true,
                         ReclaimPolicy::Cache { reinsert_accessed } => reinsert_accessed && current.is_accessed(),
                     };
                 if !keep {
-                    shared.index.remove_if_at(&hdr.key, loc);
+                    // Decided before any I/O, so a `Busy` retry cannot repeat it.
+                    self.index.remove_if_at(&hdr.key, loc);
+                    let report = &mut self.reclaim.as_mut().expect("job exists").report;
                     report.dropped += 1;
+                    if !intact {
+                        report.corrupt += 1;
+                    }
                     return Ok(());
                 }
+                // Relocated records keep their LSN (see the module docs).
                 let apply = Apply::Relocate(loc);
                 if hdr.is_large() {
-                    let mut large = self.prepare_large(hdr.value_len)?;
+                    let mut large = self.prepare_large(q, hdr.value_len)?;
+                    self.ensure_room(q, SegmentKind::Cold, large_batch_len(hdr.value_len), 1)?;
                     large.value_mut().copy_from_slice(value);
-                    let lsn = self.take_lsn();
                     let flags = record_flags(BatchKind::Large, hdr.expire_at);
-                    let new = header(RecordKind::Data, flags, hdr.value_len, lsn, hdr.key, hdr.expire_at);
-                    self.write_large(SegmentKind::Cold, &new, checksums, large.buf, apply, None)?;
+                    let new = header(RecordKind::Data, flags, hdr.value_len, hdr.lsn, hdr.key, hdr.expire_at);
+                    self.write_large(q, SegmentKind::Cold, &new, checksums, large.buf, apply, None);
                 } else {
                     let batch = small_batch_kind(hdr.value_len, hdr.expire_at);
-                    self.reserve_small(SegmentKind::Cold, batch, value.len())?;
-                    let lsn = self.take_lsn();
+                    self.reserve_small(q, SegmentKind::Cold, batch, value.len())?;
                     let flags = record_flags(batch, hdr.expire_at);
-                    let new = header(RecordKind::Data, flags, hdr.value_len, lsn, hdr.key, hdr.expire_at);
-                    self.append_small(SegmentKind::Cold, batch, &new, checksums, value, apply, None)?;
+                    let new = header(RecordKind::Data, flags, hdr.value_len, hdr.lsn, hdr.key, hdr.expire_at);
+                    self.append_small(q, SegmentKind::Cold, batch, &new, checksums, value, apply, None);
                 }
+                let report = &mut self.reclaim.as_mut().expect("job exists").report;
                 report.relocated += 1;
                 report.bytes_relocated += value.len() as u64;
             }
             RecordKind::Tombstone => {
                 // A live newer version supersedes the tombstone; and if this is
-                // the oldest segment, no older data can exist.
-                if shared.index.get(&hdr.key).is_some() || is_oldest {
-                    report.tombstones_dropped += 1;
+                // the oldest segment, no older data can exist. Otherwise it is
+                // carried forward with its LSN, so a put of the key that is
+                // still pending keeps outranking it.
+                if self.index.get(&hdr.key).is_some() || is_oldest {
+                    self.reclaim.as_mut().expect("job exists").report.tombstones_dropped += 1;
                 } else {
-                    self.reserve_small(SegmentKind::Cold, BatchKind::Inline, 0)?;
-                    let lsn = self.take_lsn();
-                    let new = header(RecordKind::Tombstone, 0, 0, lsn, hdr.key, 0);
-                    self.append_small(SegmentKind::Cold, BatchKind::Inline, &new, &[], &[], Apply::None, None)?;
-                    report.tombstones_relocated += 1;
+                    self.reserve_small(q, SegmentKind::Cold, BatchKind::Inline, 0)?;
+                    let new = header(RecordKind::Tombstone, 0, 0, hdr.lsn, hdr.key, 0);
+                    self.append_small(
+                        q,
+                        SegmentKind::Cold,
+                        BatchKind::Inline,
+                        &new,
+                        &[],
+                        &[],
+                        Apply::Tombstone,
+                        None,
+                    );
+                    self.reclaim.as_mut().expect("job exists").report.tombstones_relocated += 1;
                 }
             }
         }
@@ -1303,74 +2178,12 @@ impl Writer {
     }
 }
 
-/// Updates the index and live-byte accounting for a record now on disk.
-/// Returns whether the index now points at it.
-fn apply_record(shared: &Shared, seg_no: u32, entry: &FooterEntry, apply: Apply) -> bool {
-    let footprint = RecordGeometry::footprint(entry.value_len, entry.flags);
-    let value = IndexValue {
-        loc: Location {
-            seg_no,
-            offset: entry.offset,
-        },
-        value_off: entry.value_off,
-        value_len: entry.value_len,
-        flags: flags_from_record(entry.flags),
-        crc: entry.crc,
-        lsn: entry.lsn,
-    };
-    let segments = &shared.segments;
-    match apply {
-        Apply::Insert => match shared.index.insert_if_newer(entry.key, value) {
-            InsertOutcome::Inserted => {
-                segments.add_live(seg_no, footprint);
-                true
-            }
-            InsertOutcome::Replaced(old) => {
-                segments.sub_live(
-                    old.loc.seg_no,
-                    RecordGeometry::footprint(old.value_len, old.record_flags()),
-                );
-                segments.add_live(seg_no, footprint);
-                true
-            }
-            InsertOutcome::Rejected => false,
-        },
-        Apply::Relocate(from) => {
-            let moved = shared.index.replace_if_at(&entry.key, from, value);
-            if moved {
-                segments.add_live(seg_no, footprint);
-            }
-            moved
-        }
-        Apply::None => false,
+impl Drop for Writer {
+    fn drop(&mut self) {
+        self.shared.next_lsn.store(self.next_lsn, Ordering::Release);
+        self.shared.next_seq.store(self.next_seq, Ordering::Release);
+        self.shared.writer_taken.store(false, Ordering::Release);
     }
-}
-
-/// Writes a footer at `tail` and marks the segment sealed.
-pub(crate) fn seal_segment(
-    shared: &Shared,
-    seg_no: u32,
-    seq: u64,
-    kind: SegmentKind,
-    tail: u64,
-    footer: &[FooterEntry],
-) -> Result<()> {
-    let len = footer_len(footer.len());
-    let mut buf = moat_common::AlignedBuf::zeroed(len as usize);
-    encode_footer(seq, footer, &mut buf);
-    shared.write_segment_bytes(seg_no, tail, &buf)?;
-    shared.write_segment_header(&SegmentHeader {
-        disk_uuid: shared.superblock.disk_uuid,
-        seg_no,
-        state: SegmentState::Sealed,
-        kind,
-        seq,
-        footer_offset: tail,
-        footer_len: len,
-        record_count: footer.len() as u64,
-    })?;
-    shared.segments.set_state(seg_no, SegmentState::Sealed);
-    Ok(())
 }
 
 #[cfg(test)]
@@ -1384,48 +2197,5 @@ mod tests {
         assert_eq!(small_batch_kind(40942, 0), BatchKind::Framed);
         assert_eq!(small_batch_kind(40942, 5), BatchKind::Inline);
         assert_eq!(small_batch_kind(5000, 0), BatchKind::Inline);
-    }
-}
-
-#[cfg(test)]
-mod framed_tests {
-    use std::sync::Arc;
-
-    use moat_common::{HugePages, PoolOptions};
-
-    use crate::{FormatOptions, MemDevice, Options, PutOptions, QueueOptions, format, open};
-
-    #[test]
-    fn near_page_multiple_value_is_framed_and_page_aligned() {
-        let device = Arc::new(MemDevice::new(8 << 20));
-        format(
-            &*device,
-            &FormatOptions {
-                segment_size: 1 << 20,
-                chunk_max: 128 << 10,
-                disk_uuid: [1; 16],
-            },
-        )
-        .unwrap();
-        let opts = Options {
-            queue: QueueOptions {
-                depth: 8,
-                pool: PoolOptions {
-                    bytes: 8 << 20,
-                    max_class: 1 << 20,
-                    huge_pages: HugePages::Disabled,
-                },
-                force_sync: true,
-            },
-            ..Default::default()
-        };
-        let opened = open(device, opts).unwrap();
-        let mut writer = opened.writer;
-        let id = moat_common::ChunkId::from_u128(7);
-        writer.put(id, &vec![0xabu8; 40942], PutOptions::default()).unwrap();
-        writer.flush().unwrap();
-        let v = writer.shared.index.get(&id).unwrap();
-        assert!(v.is_framed(), "flags {:#x}", v.flags);
-        assert_eq!(v.value_off % 4096, 0, "value offset {}", v.value_off);
     }
 }

--- a/core/moat-engine/src/writer.rs
+++ b/core/moat-engine/src/writer.rs
@@ -282,12 +282,7 @@ enum Apply {
 }
 
 struct PendingRecord {
-    /// Offset of the record header from the start of the batch.
-    offset_in_batch: u32,
-    /// Offset of the value from the start of the batch.
-    value_in_batch: u32,
-    /// Footer entry with segment-relative offsets left at zero until the batch
-    /// position is known.
+    /// Offsets are batch-relative until `enqueue_batch` fixes the position.
     entry: FooterEntry,
     apply: Apply,
     ticket: Option<Ticket>,
@@ -395,9 +390,7 @@ impl Pending {
             self.header_pos = hdr_pos + meta;
         }
         self.records.push(PendingRecord {
-            offset_in_batch: hdr_pos as u32,
-            value_in_batch: value_pos as u32,
-            entry: footer_entry(hdr, checksums),
+            entry: footer_entry(hdr, checksums, hdr_pos, value_pos),
             apply,
             ticket,
         });
@@ -430,11 +423,11 @@ impl Pending {
 }
 
 /// The footer entry for a record, with segment offsets still unresolved.
-fn footer_entry(hdr: &RecordHeader, checksums: &[u32]) -> FooterEntry {
+fn footer_entry(hdr: &RecordHeader, checksums: &[u32], offset: usize, value_off: usize) -> FooterEntry {
     FooterEntry {
         key: hdr.key,
-        offset: 0,
-        value_off: 0,
+        offset: offset as u32,
+        value_off: value_off as u32,
         value_len: hdr.value_len,
         lsn: hdr.lsn,
         crc: checksums.first().copied().unwrap_or(0),
@@ -602,7 +595,7 @@ pub struct Writer {
     /// Closed batches waiting for queue room, per segment kind.
     ready: [VecDeque<Batch>; 2],
     inflight: VecDeque<InFlight>,
-    aux: HashMap<u64, Aux>,
+    aux: HashMap<u64, (Aux, usize)>,
     aux_ready: VecDeque<AuxOp>,
     sealing: Vec<Sealing>,
     barriers: VecDeque<Barrier>,
@@ -793,13 +786,7 @@ impl Writer {
     /// batch, so the value can be produced in place and written without a
     /// copy. `value_len` must be at least the pack threshold.
     pub fn prepare_large(&mut self, q: &mut dyn IoQueue, value_len: u32) -> Result<LargeValue> {
-        let max = self.shared.superblock.chunk_max;
-        if value_len > max {
-            return Err(Error::ValueTooLarge {
-                len: value_len as u64,
-                max: max as u64,
-            });
-        }
+        self.check_len(value_len as u64)?;
         if value_len < self.shared.options.pack_threshold {
             return Err(Error::InvalidOption(format!(
                 "large values must be at least {} bytes",
@@ -902,20 +889,7 @@ impl Writer {
     /// the first error among those writes.
     pub fn flush(&mut self, q: &mut dyn IoQueue) -> Result<Ticket> {
         self.close_all_pending(q)?;
-        let ticket = self.next_ticket();
-        self.barriers.push_back(Barrier {
-            ticket,
-            until: self.next_batch_id,
-            seal: None,
-            fsync: if self.shared.options.sync_on_flush {
-                Fsync::Pending
-            } else {
-                Fsync::NotNeeded
-            },
-            error: None,
-        });
-        self.push_ready(q);
-        Ok(ticket)
+        Ok(self.enqueue_barrier(q, None))
     }
 
     /// `flush`, then seal both active segments so the next open needs no
@@ -934,11 +908,15 @@ impl Writer {
                 self.park(active);
             }
         }
+        Ok(self.enqueue_barrier(q, Some(sealed)))
+    }
+
+    fn enqueue_barrier(&mut self, q: &mut dyn IoQueue, seal: Option<Vec<u32>>) -> Ticket {
         let ticket = self.next_ticket();
         self.barriers.push_back(Barrier {
             ticket,
             until: self.next_batch_id,
-            seal: Some(sealed),
+            seal,
             fsync: if self.shared.options.sync_on_flush {
                 Fsync::Pending
             } else {
@@ -947,7 +925,7 @@ impl Writer {
             error: None,
         });
         self.push_ready(q);
-        Ok(ticket)
+        ticket
     }
 
     /// Starts one reclaim pass under `policy`; the completion reports
@@ -1022,8 +1000,8 @@ impl Writer {
         let mut finished = std::mem::take(&mut self.scratch);
         for done in finished.drain(..) {
             if done.token & AUX_TOKEN != 0 {
-                if let Some(aux) = self.aux.remove(&done.token) {
-                    self.finish_aux(aux, done);
+                if let Some((aux, len)) = self.aux.remove(&done.token) {
+                    self.finish_aux(aux, len, done);
                 }
             } else if let Some(front) = self.inflight.front() {
                 let index = (done.token - front.token) as usize;
@@ -1267,9 +1245,7 @@ impl Writer {
         .encode(&mut buf[..BATCH_HEADER_LEN]);
         self.track(hdr, apply);
         let record = PendingRecord {
-            offset_in_batch: BATCH_HEADER_LEN as u32,
-            value_in_batch: value_off as u32,
-            entry: footer_entry(hdr, checksums),
+            entry: footer_entry(hdr, checksums, BATCH_HEADER_LEN, value_off),
             apply,
             ticket,
         };
@@ -1316,9 +1292,20 @@ impl Writer {
 
     /// Fixes a fully encoded batch at the tail of `seg_no` and appends it to
     /// the ready queue of kind `k`.
-    fn enqueue_batch(&mut self, k: usize, seg_no: u32, buf: PooledBuf, batch_len: usize, records: Vec<PendingRecord>) {
+    fn enqueue_batch(
+        &mut self,
+        k: usize,
+        seg_no: u32,
+        buf: PooledBuf,
+        batch_len: usize,
+        mut records: Vec<PendingRecord>,
+    ) {
         let seg = self.segment_mut(seg_no).expect("segment exists");
         let offset = seg.tail;
+        for rec in &mut records {
+            rec.entry.offset += offset as u32;
+            rec.entry.value_off += offset as u32;
+        }
         seg.tail += batch_len as u64;
         seg.unapplied += 1;
         seg.unapplied_records += records.len();
@@ -1404,20 +1391,12 @@ impl Writer {
             seg.broken
         };
         if failure.is_none() && !broken {
-            let entries: Vec<FooterEntry> = batch
-                .records
-                .iter()
-                .map(|rec| FooterEntry {
-                    offset: (batch.offset + rec.offset_in_batch as u64) as u32,
-                    value_off: (batch.offset + rec.value_in_batch as u64) as u32,
-                    ..rec.entry
-                })
-                .collect();
             self.segment_mut(seg_no)
                 .expect("segment outlives its batches")
                 .footer
-                .extend_from_slice(&entries);
-            for (rec, entry) in batch.records.into_iter().zip(entries) {
+                .extend(batch.records.iter().map(|rec| rec.entry));
+            for rec in batch.records {
+                let entry = rec.entry;
                 let result = self.apply_record(seg_no, &entry, rec.apply);
                 if let Some(ticket) = rec.ticket {
                     let outcome = match rec.apply {
@@ -1564,7 +1543,7 @@ impl Writer {
         };
         match outcome {
             Ok(()) => {
-                self.aux.insert(token, aux);
+                self.aux.insert(token, (aux, len));
                 None
             }
             Err(buf) => Some(AuxOp {
@@ -1595,7 +1574,12 @@ impl Writer {
         Ok(())
     }
 
-    fn finish_aux(&mut self, aux: Aux, done: IoCompletion) {
+    fn finish_aux(&mut self, aux: Aux, len: usize, mut done: IoCompletion) {
+        if let Ok(n) = done.result
+            && n != len
+        {
+            done.result = Err(io::Error::other(format!("short I/O: {n} of {len} bytes")));
+        }
         let failure = match &done.result {
             Ok(_) => None,
             Err(e) => Some(e.to_string()),
@@ -1857,7 +1841,7 @@ impl Writer {
                 let token = self.next_aux_token();
                 match q.fsync(self.desc, token) {
                     Ok(()) => {
-                        self.aux.insert(token, Aux::Fsync { ticket });
+                        self.aux.insert(token, (Aux::Fsync { ticket }, 0));
                         self.barriers[i].fsync = Fsync::Issued;
                     }
                     Err(_) => {
@@ -2190,6 +2174,75 @@ impl Drop for Writer {
 mod tests {
     use super::*;
     use crate::layout::prefer_framed;
+
+    #[test]
+    fn short_auxiliary_io_fails_without_reclaiming_live_data() {
+        use crate::{
+            FormatOptions, MemDevice, Options, QueueOptions, blocking,
+            io::{CompletionOrder, SyncQueue},
+        };
+        use moat_common::{HugePages, PoolOptions};
+
+        for reclaim in [false, true] {
+            let device = Arc::new(MemDevice::new(5 << 20));
+            crate::format(
+                &*device,
+                &FormatOptions {
+                    segment_size: 1 << 20,
+                    chunk_max: 64 << 10,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+            let (engine, _) = crate::open(
+                device,
+                Options {
+                    index_capacity: 64,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+            let mut queue = SyncQueue::new(
+                &QueueOptions {
+                    pool: PoolOptions {
+                        bytes: 2 << 20,
+                        max_class: 1 << 20,
+                        huge_pages: HugePages::Disabled,
+                    },
+                    ..Default::default()
+                },
+                CompletionOrder::Fifo,
+            )
+            .unwrap();
+            let mut writer = engine.writer(&mut queue).unwrap();
+            let key = ChunkId::from_u128(1);
+            writer.put(&mut queue, key, b"value", PutOptions::default()).unwrap();
+            let ticket = if reclaim {
+                blocking::seal(&mut queue, &mut writer).unwrap();
+                writer.reclaim(&mut queue, ReclaimPolicy::Storage).unwrap().unwrap()
+            } else {
+                writer.flush(&mut queue).unwrap()
+            };
+            queue.poll(false).unwrap();
+            let mut done = Vec::new();
+            assert_eq!(queue.take(writer.desc, &mut done), 1);
+            let mut completion = done.pop().unwrap();
+            completion.result = Ok(0);
+            let (aux, len) = writer.aux.remove(&completion.token).unwrap();
+            writer.finish_aux(aux, len, completion);
+            assert!(blocking::wait(&mut queue, &mut writer, ticket).is_err());
+            if reclaim {
+                assert_eq!(engine.usage().sealed_segments, 1);
+                let mut reader = engine.reader(&mut queue).unwrap();
+                assert_eq!(
+                    &*blocking::get(&mut queue, &mut reader, &key, None).unwrap().unwrap(),
+                    b"value"
+                );
+            } else {
+                assert!(!engine.contains(&key));
+            }
+        }
+    }
 
     #[test]
     fn framing_decision_for_near_page_multiples() {

--- a/core/moat-engine/tests/engine.rs
+++ b/core/moat-engine/tests/engine.rs
@@ -1808,3 +1808,47 @@ fn scan_window_boundary_footer_recovery() {
 fn scan_window_boundary_reclaim() {
     check_scan_window_boundary("reclaim");
 }
+
+#[test]
+fn dropping_a_reader_releases_pins_for_submitted_and_queued_reads() {
+    for detach in [false, true] {
+        let device = new_device(4);
+        let (engine, mut q, mut writer, reader) = setup(&device);
+        put(&mut q, &mut writer, id(1), b"value", PutOptions::default());
+        seal(&mut q, &mut writer);
+        reader.detach(&mut q);
+        let mut read_queue = SyncQueue::new(
+            &QueueOptions {
+                depth: 1,
+                ..queue_options()
+            },
+            CompletionOrder::Fifo,
+        )
+        .unwrap();
+        let mut reader = engine.reader(&mut read_queue).unwrap();
+        // One read is accepted by the queue; the other waits in the reader.
+        reader.get(&mut read_queue, &id(1), None, 1).unwrap();
+        reader.get(&mut read_queue, &id(1), None, 2).unwrap();
+        if detach {
+            reader.detach(&mut read_queue);
+        } else {
+            drop(reader);
+        }
+        let ticket = writer.reclaim(&mut q, ReclaimPolicy::Storage).unwrap().unwrap();
+        let mut done = Vec::new();
+        let mut reclaimed = false;
+        for _ in 0..100 {
+            q.poll(false).unwrap();
+            writer.poll(&mut q, &mut done).unwrap();
+            if let Some(c) = done.iter().find(|c| c.ticket == ticket) {
+                assert!(matches!(c.result, Ok(Outcome::Reclaim(_))));
+                reclaimed = true;
+                break;
+            }
+        }
+        assert!(reclaimed, "abandoned reads must not keep reclaim pinned");
+        read_queue.poll(false).unwrap();
+        let mut reader = engine.reader(&mut q).unwrap();
+        assert_eq!(read(&mut q, &mut reader, &id(1)).unwrap(), b"value");
+    }
+}

--- a/core/moat-engine/tests/engine.rs
+++ b/core/moat-engine/tests/engine.rs
@@ -15,14 +15,17 @@
 //! End-to-end tests of the engine on an in-memory device.
 //!
 //! Segments are kept tiny (1 MiB) so that a handful of writes exercises
-//! rollover, sealing, reclaim and recovery.
+//! rollover, sealing, reclaim and recovery. Everything runs through the
+//! blocking `SyncQueue`, optionally with reversed completion order to
+//! exercise out-of-order completion handling.
 
 use std::{collections::HashMap, sync::Arc};
 
 use moat_common::{ChunkId, HugePages, PoolOptions};
 use moat_engine::{
-    Error, FormatOptions, ManualClock, MemDevice, Opened, Options, PutOptions, PutOutcome, QueueOptions, ReadRing,
-    Reader, ReclaimPolicy,
+    DeleteOutcome, Engine, Error, FormatOptions, IoQueue, ManualClock, MemDevice, Options, Outcome, PutOptions,
+    PutOutcome, QueueOptions, Reader, ReclaimPolicy, Writer, blocking,
+    io::{CompletionOrder, SyncQueue},
 };
 
 const SEGMENT: u64 = 1 << 20;
@@ -47,46 +50,19 @@ fn queue_options() -> QueueOptions {
             max_class: 1 << 20,
             huge_pages: HugePages::Disabled,
         },
-        force_sync: false,
+        descriptors: 8,
     }
 }
 
 fn options() -> Options {
     Options {
-        queue: queue_options(),
+        index_capacity: 1024,
         ..Default::default()
     }
 }
 
-/// Keep the registered pools used by the file-backed test below the
-/// locked-memory limit of standard hosted CI runners. The 128 KiB class still
-/// accommodates the test format's 64 KiB maximum chunk plus its metadata.
-fn file_queue_options() -> QueueOptions {
-    QueueOptions {
-        depth: 64,
-        pool: PoolOptions {
-            bytes: 1 << 20,
-            max_class: 128 << 10,
-            huge_pages: HugePages::Disabled,
-        },
-        force_sync: false,
-    }
-}
-
-fn file_options() -> Options {
-    Options {
-        batch_limit: 128 << 10,
-        scan_window: 128 << 10,
-        queue: file_queue_options(),
-        ..Default::default()
-    }
-}
-
-fn file_format_options() -> FormatOptions {
-    FormatOptions {
-        chunk_max: FILE_CHUNK_MAX,
-        ..format_options()
-    }
+fn queue() -> SyncQueue {
+    SyncQueue::new(&queue_options(), CompletionOrder::Fifo).unwrap()
 }
 
 fn new_device(segments: u64) -> Arc<MemDevice> {
@@ -95,16 +71,21 @@ fn new_device(segments: u64) -> Arc<MemDevice> {
     device
 }
 
-fn open(device: &Arc<MemDevice>) -> Opened {
-    moat_engine::open(device.clone(), options()).unwrap()
+fn open(device: &Arc<MemDevice>) -> Engine {
+    moat_engine::open(device.clone(), options()).unwrap().0
 }
 
-fn open_with(device: &Arc<MemDevice>, options: Options) -> Opened {
-    moat_engine::open(device.clone(), options).unwrap()
+fn open_with(device: &Arc<MemDevice>, options: Options) -> Engine {
+    moat_engine::open(device.clone(), options).unwrap().0
 }
 
-fn open_ring(reader: &Reader) -> ReadRing {
-    reader.ring(&queue_options()).unwrap()
+/// Opens the engine and attaches a writer and a reader to a fresh queue.
+fn setup(device: &Arc<MemDevice>) -> (Engine, SyncQueue, Writer, Reader) {
+    let engine = open(device);
+    let mut q = queue();
+    let writer = engine.writer(&mut q).unwrap();
+    let reader = engine.reader(&mut q).unwrap();
+    (engine, q, writer, reader)
 }
 
 fn id(n: u128) -> ChunkId {
@@ -112,8 +93,61 @@ fn id(n: u128) -> ChunkId {
 }
 
 /// Reads a whole chunk into an owned vector for comparisons.
-fn read(ring: &mut ReadRing, id: &ChunkId) -> Option<Vec<u8>> {
-    ring.get_sync(id, None).unwrap().map(|d| d.to_vec())
+fn read(q: &mut dyn IoQueue, reader: &mut Reader, id: &ChunkId) -> Option<Vec<u8>> {
+    blocking::get(q, reader, id, None).unwrap().map(|d| d.to_vec())
+}
+
+fn flush(q: &mut dyn IoQueue, writer: &mut Writer) {
+    blocking::flush(q, writer).unwrap();
+}
+
+/// `put` with the back-pressure loop a worker would run: on `Busy` (the pool is
+/// out of buffers because completions have not been reaped) poll and retry.
+fn put(q: &mut dyn IoQueue, writer: &mut Writer, id: ChunkId, value: &[u8], opts: PutOptions) -> PutOutcome {
+    let mut done = Vec::new();
+    loop {
+        match writer.put(q, id, value, opts) {
+            Ok(outcome) => return outcome,
+            Err(Error::Busy) => {
+                q.poll(true).unwrap();
+                writer.poll(q, &mut done).unwrap();
+                for c in done.drain(..) {
+                    c.result.unwrap();
+                }
+            }
+            Err(e) => panic!("put failed: {e}"),
+        }
+    }
+}
+
+fn seal(q: &mut dyn IoQueue, writer: &mut Writer) {
+    blocking::seal(q, writer).unwrap();
+}
+
+fn reclaim(q: &mut dyn IoQueue, writer: &mut Writer, policy: ReclaimPolicy) -> Option<moat_engine::ReclaimReport> {
+    blocking::reclaim(q, writer, policy).unwrap()
+}
+
+fn delete(q: &mut dyn IoQueue, writer: &mut Writer, id: &ChunkId) -> bool {
+    match writer.delete(q, id).unwrap() {
+        DeleteOutcome::Deleted { ticket, .. } => {
+            assert!(matches!(
+                blocking::wait(q, writer, ticket).unwrap(),
+                Outcome::Delete { .. }
+            ));
+            true
+        }
+        DeleteOutcome::Missing => false,
+    }
+}
+
+/// Seals and detaches the writer cleanly, as a shutdown would.
+fn close(q: &mut dyn IoQueue, writer: Writer) {
+    let mut writer = writer;
+    seal(q, &mut writer);
+    blocking::drain(q, &mut writer).unwrap();
+    assert!(writer.is_idle());
+    writer.detach(q);
 }
 
 /// A deterministic value for `(key, version)` whose every byte can be checked.
@@ -165,8 +199,7 @@ fn random_len(rng: &mut XorShift) -> usize {
 #[test]
 fn put_get_roundtrip_across_sizes() {
     let device = new_device(16);
-    let Opened { mut writer, reader, .. } = open(&device);
-    let mut ring = open_ring(&reader);
+    let (engine, mut q, mut writer, mut reader) = setup(&device);
 
     let sizes = [
         0usize,
@@ -184,55 +217,75 @@ fn put_get_roundtrip_across_sizes() {
     for (i, &len) in sizes.iter().enumerate() {
         let value = value_for(i as u128, 0, len);
         assert!(matches!(
-            writer.put(id(i as u128), &value, PutOptions::default()).unwrap(),
+            writer
+                .put(&mut q, id(i as u128), &value, PutOptions::default())
+                .unwrap(),
             PutOutcome::Written { .. }
         ));
     }
-    writer.flush().unwrap();
+    flush(&mut q, &mut writer);
 
     for (i, &len) in sizes.iter().enumerate() {
-        let got = read(&mut ring, &id(i as u128)).expect("present");
+        let got = read(&mut q, &mut reader, &id(i as u128)).expect("present");
         assert_eq!(got, value_for(i as u128, 0, len), "size {len}");
         assert_eq!(reader.stat(&id(i as u128)).unwrap().len as usize, len);
+        assert_eq!(engine.stat(&id(i as u128)).unwrap().len as usize, len);
     }
-    assert!(read(&mut ring, &id(999)).is_none());
+    assert!(read(&mut q, &mut reader, &id(999)).is_none());
     assert!(reader.stat(&id(999)).is_none());
 
     let too_big = vec![0u8; CHUNK_MAX as usize + 1];
     assert!(matches!(
-        writer.put(id(1000), &too_big, PutOptions::default()),
+        writer.put(&mut q, id(1000), &too_big, PutOptions::default()),
         Err(Error::ValueTooLarge { .. })
     ));
+    // A second writer is refused until the first detaches.
+    assert!(matches!(engine.writer(&mut q), Err(Error::Busy)));
+    close(&mut q, writer);
+    let writer = engine.writer(&mut q).unwrap();
+    writer.detach(&mut q);
 }
 
 #[test]
 fn zero_copy_large_put() {
     let device = new_device(4);
-    let Opened { mut writer, reader, .. } = open(&device);
-    let mut ring = open_ring(&reader);
+    let (_engine, mut q, mut writer, mut reader) = setup(&device);
     let value = value_for(3, 0, 100_000);
 
-    let mut large = writer.prepare_large(value.len() as u32).unwrap();
+    let mut large = writer.prepare_large(&mut q, value.len() as u32).unwrap();
     large.value_mut().copy_from_slice(&value);
     let sums = moat_common::block_checksums(&value);
     let outcome = writer
-        .put_large(id(3), large, Some(&sums), PutOptions::default())
+        .put_large(&mut q, id(3), large, Some(&sums), PutOptions::default())
         .unwrap();
     assert!(matches!(outcome, PutOutcome::Written { .. }));
-    writer.flush().unwrap();
-    assert_eq!(read(&mut ring, &id(3)).unwrap(), value);
+    flush(&mut q, &mut writer);
+    assert_eq!(read(&mut q, &mut reader, &id(3)).unwrap(), value);
 
     // Wrong checksum count is rejected before anything is written.
-    let large = writer.prepare_large(value.len() as u32).unwrap();
+    let large = writer.prepare_large(&mut q, value.len() as u32).unwrap();
     assert!(matches!(
-        writer.put_large(id(4), large, Some(&sums[..1]), PutOptions::default()),
+        writer.put_large(&mut q, id(4), large, Some(&sums[..1]), PutOptions::default()),
         Err(Error::InvalidOption(_))
     ));
+    // The producer may also leave checksum computation to the writer.
+    let mut large = writer.prepare_large(&mut q, value.len() as u32).unwrap();
+    large.value_mut().copy_from_slice(&value);
+    writer
+        .put_large(&mut q, id(5), large, None, PutOptions::default())
+        .unwrap();
+    flush(&mut q, &mut writer);
+    assert_eq!(read(&mut q, &mut reader, &id(5)).unwrap(), value);
     // Values below the pack threshold are not large.
-    assert!(matches!(writer.prepare_large(100), Err(Error::InvalidOption(_))));
+    assert!(matches!(
+        writer.prepare_large(&mut q, 100),
+        Err(Error::InvalidOption(_))
+    ));
 
     // The returned data is a view into a pool buffer, usable without copying.
-    let data = ring.get_sync(&id(3), Some(10..20)).unwrap().unwrap();
+    let data = blocking::get(&mut q, &mut reader, &id(3), Some(10..20))
+        .unwrap()
+        .unwrap();
     assert_eq!(&*data, &value[10..20]);
     let (buf, range) = data.into_raw();
     assert_eq!(&buf[range], &value[10..20]);
@@ -241,50 +294,46 @@ fn zero_copy_large_put() {
 #[test]
 fn async_tickets_and_completions() {
     let device = new_device(8);
-    let Opened { mut writer, reader, .. } = open(&device);
-    let mut ring = open_ring(&reader);
+    let (_engine, mut q, mut writer, mut reader) = setup(&device);
     let mut tickets = HashMap::new();
     for i in 0..40u128 {
         let v = value_for(i, 0, if i % 4 == 0 { 70_000 } else { 3_000 });
-        if let PutOutcome::Written { ticket, lsn } = writer.put(id(i), &v, PutOptions::default()).unwrap() {
+        if let PutOutcome::Written { ticket, lsn } = writer.put(&mut q, id(i), &v, PutOptions::default()).unwrap() {
             tickets.insert(ticket, (i, lsn));
         }
     }
     // Small records are still pending: not visible yet.
     assert!(reader.stat(&id(1)).is_none());
+    // Without a flush, every ticket still completes through polling: the
+    // pending batch is closed at the end of a poll.
     let mut done = Vec::new();
-    writer.submit().unwrap();
-    // Nothing forces the pending batch out but a flush or filling it up; use
-    // seal_active's flush and then drain completions through poll.
-    writer.flush().unwrap();
-    // flush discarded completions; write another set and observe them via poll.
-    let mut tickets2 = HashMap::new();
-    for i in 100..110u128 {
-        let v = value_for(i, 0, 70_000);
-        if let PutOutcome::Written { ticket, lsn } = writer.put(id(i), &v, PutOptions::default()).unwrap() {
-            tickets2.insert(ticket, (i, lsn));
-        }
-    }
-    while !tickets2.is_empty() {
-        writer.poll(&mut done, true).unwrap();
+    while !tickets.is_empty() {
+        q.poll(true).unwrap();
+        writer.poll(&mut q, &mut done).unwrap();
         for c in done.drain(..) {
-            let (i, lsn) = tickets2.remove(&c.ticket).expect("known ticket");
-            assert_eq!(c.lsn, lsn);
-            c.result.unwrap();
+            let (i, lsn) = tickets.remove(&c.ticket).expect("known ticket");
+            assert_eq!(c.result.unwrap(), Outcome::Put { lsn });
             assert_eq!(reader.stat(&id(i)).unwrap().lsn, lsn);
         }
     }
-    for (_, (i, _)) in tickets {
-        assert!(read(&mut ring, &id(i)).is_some());
+    for i in 0..40u128 {
+        assert!(read(&mut q, &mut reader, &id(i)).is_some());
     }
+    // A barrier completes after everything before it, with its own outcome.
+    let t = writer.flush(&mut q).unwrap();
+    assert_eq!(blocking::wait(&mut q, &mut writer, t).unwrap(), Outcome::Flush);
+    let t = writer.seal(&mut q).unwrap();
+    assert_eq!(blocking::wait(&mut q, &mut writer, t).unwrap(), Outcome::Seal);
+    assert!(writer.is_idle());
 }
 
 #[test]
 fn out_of_order_completions_are_applied_in_order() {
     let device = new_device(12);
-    device.set_reverse_completions(true);
-    let Opened { mut writer, reader, .. } = open(&device);
-    let mut ring = open_ring(&reader);
+    let engine = open(&device);
+    let mut q = SyncQueue::new(&queue_options(), CompletionOrder::Reverse).unwrap();
+    let mut writer = engine.writer(&mut q).unwrap();
+    let mut reader = engine.reader(&mut q).unwrap();
     let overwrite = PutOptions {
         overwrite: true,
         ..Default::default()
@@ -297,35 +346,34 @@ fn out_of_order_completions_are_applied_in_order() {
     for round in 0..30u32 {
         for k in 0..12u128 {
             let v = value_for(k, round, random_len(&mut rng));
-            writer.put(id(k), &v, overwrite).unwrap();
+            put(&mut q, &mut writer, id(k), &v, overwrite);
             expected.insert(k, v);
         }
     }
-    writer.flush().unwrap();
+    flush(&mut q, &mut writer);
     for (k, v) in &expected {
-        assert_eq!(read(&mut ring, &id(*k)).unwrap(), *v, "key {k}");
+        assert_eq!(read(&mut q, &mut reader, &id(*k)).unwrap(), *v, "key {k}");
     }
     drop(writer);
-    let Opened { reader, .. } = open(&device);
-    let mut ring = open_ring(&reader);
+    drop(reader);
+    let (_engine, mut q, _writer, mut reader) = setup(&device);
     for (k, v) in &expected {
-        assert_eq!(read(&mut ring, &id(*k)).unwrap(), *v, "key {k} after reopen");
+        assert_eq!(read(&mut q, &mut reader, &id(*k)).unwrap(), *v, "key {k} after reopen");
     }
 }
 
 #[test]
 fn write_failure_truncates_segment_and_continues() {
     let device = new_device(8);
-    let Opened { mut writer, reader, .. } = open(&device);
-    let mut ring = open_ring(&reader);
+    let (engine, mut q, mut writer, mut reader) = setup(&device);
     let mut ok_keys = Vec::new();
     for i in 0..3u128 {
         writer
-            .put(id(i), &value_for(i, 0, 70_000), PutOptions::default())
+            .put(&mut q, id(i), &value_for(i, 0, 70_000), PutOptions::default())
             .unwrap();
         ok_keys.push(i);
     }
-    writer.flush().unwrap();
+    flush(&mut q, &mut writer);
 
     // The hot segment is segment 0 at device offset SEGMENT; fail every write
     // into its second half.
@@ -333,7 +381,7 @@ fn write_failure_truncates_segment_and_continues() {
     let mut outcomes = HashMap::new();
     for i in 10..30u128 {
         if let PutOutcome::Written { ticket, .. } = writer
-            .put(id(i), &value_for(i, 0, 70_000), PutOptions::default())
+            .put(&mut q, id(i), &value_for(i, 0, 70_000), PutOptions::default())
             .unwrap()
         {
             outcomes.insert(ticket, i);
@@ -342,13 +390,14 @@ fn write_failure_truncates_segment_and_continues() {
     let mut done = Vec::new();
     let (mut succeeded, mut failed) = (Vec::new(), Vec::new());
     while !outcomes.is_empty() {
-        writer.poll(&mut done, true).unwrap();
+        q.poll(true).unwrap();
+        writer.poll(&mut q, &mut done).unwrap();
         for c in done.drain(..) {
             let i = outcomes.remove(&c.ticket).unwrap();
             match c.result {
-                Ok(()) => succeeded.push(i),
+                Ok(Outcome::Put { .. }) => succeeded.push(i),
                 Err(Error::Io(_)) => failed.push(i),
-                Err(e) => panic!("unexpected {e}"),
+                other => panic!("unexpected {other:?}"),
             }
         }
     }
@@ -358,155 +407,238 @@ fn write_failure_truncates_segment_and_continues() {
     // Writing continues on a fresh segment.
     for i in 100..105u128 {
         writer
-            .put(id(i), &value_for(i, 0, 70_000), PutOptions::default())
+            .put(&mut q, id(i), &value_for(i, 0, 70_000), PutOptions::default())
             .unwrap();
     }
-    writer.flush().unwrap();
+    flush(&mut q, &mut writer);
 
-    let check = |ring: &mut ReadRing, reader: &Reader| {
+    let check = |q: &mut dyn IoQueue, reader: &mut Reader, engine: &Engine| {
         for i in ok_keys.iter().chain(succeeded.iter()).copied().chain(100..105u128) {
-            assert_eq!(read(ring, &id(i)).unwrap(), value_for(i, 0, 70_000), "key {i}");
+            assert_eq!(read(q, reader, &id(i)).unwrap(), value_for(i, 0, 70_000), "key {i}");
         }
         for i in &failed {
-            assert!(!reader.contains(&id(*i)), "failed key {i} must not be indexed");
+            assert!(!engine.contains(&id(*i)), "failed key {i} must not be indexed");
         }
     };
-    check(&mut ring, &reader);
+    check(&mut q, &mut reader, &engine);
     drop(writer);
-    let Opened { reader, report, .. } = open(&device);
-    let mut ring = open_ring(&reader);
-    check(&mut ring, &reader);
+    drop(reader);
+    let (engine, report) = moat_engine::open(device.clone(), options()).unwrap();
+    let mut q = queue();
+    let mut reader = engine.reader(&mut q).unwrap();
+    check(&mut q, &mut reader, &engine);
     assert_eq!(report.chunks, ok_keys.len() + succeeded.len() + 5);
 }
 
 #[test]
 fn lsn_is_monotonic_and_reported() {
     let device = new_device(4);
-    let Opened { mut writer, .. } = open(&device);
+    let (_engine, mut q, mut writer, _reader) = setup(&device);
     let mut last = 0;
     for i in 0..50u128 {
-        let PutOutcome::Written { lsn, .. } = writer.put(id(i), b"x", PutOptions::default()).unwrap() else {
+        let PutOutcome::Written { lsn, .. } = writer.put(&mut q, id(i), b"x", PutOptions::default()).unwrap() else {
             panic!("expected write");
         };
         assert!(lsn > last);
         last = lsn;
     }
     assert_eq!(writer.next_lsn(), last + 1);
+    // A re-created writer continues the sequence.
+    flush(&mut q, &mut writer);
+    let engine = open(&device);
+    let mut q2 = queue();
+    let writer2 = engine.writer(&mut q2).unwrap();
+    assert!(writer2.next_lsn() > last);
 }
 
 #[test]
-fn range_reads_verify_only_touched_blocks() {
-    let device = new_device(8);
-    let Opened { mut writer, reader, .. } = open(&device);
-    let mut ring = open_ring(&reader);
-    let value = value_for(7, 0, 100_000);
-    writer.put(id(7), &value, PutOptions::default()).unwrap();
-    writer.flush().unwrap();
+fn range_reads_cover_boundaries_in_both_modes() {
+    for verify_reads in [false, true] {
+        let device = new_device(8);
+        let engine = open_with(
+            &device,
+            Options {
+                verify_reads,
+                ..options()
+            },
+        );
+        let mut q = queue();
+        let mut writer = engine.writer(&mut q).unwrap();
+        let mut reader = engine.reader(&mut q).unwrap();
+        for (i, len) in [0, 1000, 4096, 65536, 100_000, CHUNK_MAX as usize]
+            .into_iter()
+            .enumerate()
+        {
+            let key = id(i as u128);
+            let value = value_for(i as u128, 0, len);
+            writer.put(&mut q, key, &value, PutOptions::default()).unwrap();
+            flush(&mut q, &mut writer);
+            for range in [
+                0..0,
+                0..10,
+                100..100,
+                4090..4110,
+                65530..65540,
+                70_000..70_010,
+                99_990..200_000,
+                200_000..300_000,
+            ] {
+                let start = (range.start as usize).min(len);
+                let end = (range.end as usize).min(len).max(start);
+                let got = blocking::get(&mut q, &mut reader, &key, Some(range)).unwrap().unwrap();
+                assert_eq!(&*got, &value[start..end], "len={len}, verify_reads={verify_reads}");
+            }
+            assert_eq!(read(&mut q, &mut reader, &key).unwrap(), value);
+        }
+    }
+}
 
-    let mut get = |r: std::ops::Range<u64>| ring.get_sync(&id(7), Some(r)).unwrap().unwrap().to_vec();
-    assert_eq!(get(0..10), value[0..10]);
-    assert_eq!(get(65530..65540), value[65530..65540]);
-    assert_eq!(get(99_990..200_000), value[99_990..]);
-    assert_eq!(get(200_000..300_000), Vec::<u8>::new());
-    assert_eq!(get(0..100_000), value);
-
-    let value_small = value_for(8, 0, 1000);
-    writer.put(id(8), &value_small, PutOptions::default()).unwrap();
-    writer.flush().unwrap();
-    assert_eq!(
-        &*ring.get_sync(&id(8), Some(10..20)).unwrap().unwrap(),
-        &value_small[10..20]
-    );
+#[test]
+fn unchecked_range_reads_need_only_one_page() {
+    let device = new_device(4);
+    let (_engine, mut q, mut writer, mut reader) = setup(&device);
+    assert!(!Options::default().verify_reads);
+    let value = value_for(1, 0, CHUNK_MAX as usize);
+    writer.put(&mut q, id(1), &value, PutOptions::default()).unwrap();
+    flush(&mut q, &mut writer);
+    for range in [0..10, 70_000..70_010, CHUNK_MAX as u64..CHUNK_MAX as u64] {
+        let data = blocking::get(&mut q, &mut reader, &id(1), Some(range.clone()))
+            .unwrap()
+            .unwrap();
+        assert_eq!(&*data, &value[range.start as usize..range.end as usize]);
+        let (buf, _) = data.into_raw();
+        assert_eq!(buf.capacity(), 4096);
+    }
 }
 
 #[test]
 fn overwrite_semantics() {
     let device = new_device(4);
-    let Opened { mut writer, reader, .. } = open(&device);
-    let mut ring = open_ring(&reader);
+    let (_engine, mut q, mut writer, mut reader) = setup(&device);
     let v0 = value_for(1, 0, 3000);
     let v1 = value_for(1, 1, 90_000);
     let v2 = value_for(1, 2, 10);
 
-    let PutOutcome::Written { lsn: lsn0, .. } = writer.put(id(1), &v0, PutOptions::default()).unwrap() else {
+    let PutOutcome::Written { lsn: lsn0, .. } = writer.put(&mut q, id(1), &v0, PutOptions::default()).unwrap() else {
         panic!()
     };
     // A duplicate is rejected even while the first put is still pending.
     assert_eq!(
-        writer.put(id(1), &v1, PutOptions::default()).unwrap(),
+        writer.put(&mut q, id(1), &v1, PutOptions::default()).unwrap(),
         PutOutcome::Exists
     );
-    writer.flush().unwrap();
+    flush(&mut q, &mut writer);
     assert_eq!(
-        writer.put(id(1), &v1, PutOptions::default()).unwrap(),
+        writer.put(&mut q, id(1), &v1, PutOptions::default()).unwrap(),
         PutOutcome::Exists
     );
-    assert_eq!(read(&mut ring, &id(1)).unwrap(), v0);
+    assert_eq!(read(&mut q, &mut reader, &id(1)).unwrap(), v0);
 
     let overwrite = PutOptions {
         overwrite: true,
         ..Default::default()
     };
-    let PutOutcome::Written { lsn: lsn1, .. } = writer.put(id(1), &v1, overwrite).unwrap() else {
+    let PutOutcome::Written { lsn: lsn1, .. } = writer.put(&mut q, id(1), &v1, overwrite).unwrap() else {
         panic!()
     };
     assert!(lsn1 > lsn0);
     // A large record is submitted immediately but only visible once applied.
-    writer.flush().unwrap();
-    assert_eq!(read(&mut ring, &id(1)).unwrap(), v1);
+    flush(&mut q, &mut writer);
+    assert_eq!(read(&mut q, &mut reader, &id(1)).unwrap(), v1);
     assert_eq!(reader.stat(&id(1)).unwrap().lsn, lsn1);
 
     // A small overwrite following a large one: the pending small record has a
     // higher LSN and must win once flushed.
-    writer.put(id(1), &v2, overwrite).unwrap();
-    writer.flush().unwrap();
-    assert_eq!(read(&mut ring, &id(1)).unwrap(), v2);
+    writer.put(&mut q, id(1), &v2, overwrite).unwrap();
+    flush(&mut q, &mut writer);
+    assert_eq!(read(&mut q, &mut reader, &id(1)).unwrap(), v2);
 
     // The reverse: a small pending record followed by a large one. The large
     // record reaches the device first but has the higher LSN and must win.
     let v3 = value_for(1, 3, 20);
     let v4 = value_for(1, 4, 70_000);
-    writer.put(id(1), &v3, overwrite).unwrap();
-    writer.put(id(1), &v4, overwrite).unwrap();
-    writer.flush().unwrap();
-    assert_eq!(read(&mut ring, &id(1)).unwrap(), v4);
+    writer.put(&mut q, id(1), &v3, overwrite).unwrap();
+    writer.put(&mut q, id(1), &v4, overwrite).unwrap();
+    flush(&mut q, &mut writer);
+    assert_eq!(read(&mut q, &mut reader, &id(1)).unwrap(), v4);
 }
 
 #[test]
 fn delete_is_durable_across_reopen() {
     let device = new_device(4);
     {
-        let Opened { mut writer, reader, .. } = open(&device);
-        let mut ring = open_ring(&reader);
-        writer.put(id(1), b"a", PutOptions::default()).unwrap();
-        writer.put(id(2), b"b", PutOptions::default()).unwrap();
-        writer.flush().unwrap();
-        assert!(writer.delete(&id(1)).unwrap());
-        assert!(!writer.delete(&id(1)).unwrap());
-        assert!(!writer.delete(&id(3)).unwrap());
-        assert!(read(&mut ring, &id(1)).is_none());
-        assert_eq!(read(&mut ring, &id(2)).unwrap(), b"b");
-        // Deliberately no close: recovery must find the tombstone by scanning.
+        let (_engine, mut q, mut writer, mut reader) = setup(&device);
+        writer.put(&mut q, id(1), b"a", PutOptions::default()).unwrap();
+        writer.put(&mut q, id(2), b"b", PutOptions::default()).unwrap();
+        flush(&mut q, &mut writer);
+        assert!(delete(&mut q, &mut writer, &id(1)));
+        assert!(!delete(&mut q, &mut writer, &id(1)));
+        assert!(!delete(&mut q, &mut writer, &id(3)));
+        assert!(read(&mut q, &mut reader, &id(1)).is_none());
+        assert_eq!(read(&mut q, &mut reader, &id(2)).unwrap(), b"b");
+        // Deliberately no seal: recovery must find the tombstone by scanning.
     }
-    let Opened { reader, report, .. } = open(&device);
-    let mut ring = open_ring(&reader);
+    let (engine, report) = moat_engine::open(device.clone(), options()).unwrap();
+    let mut q = queue();
+    let mut reader = engine.reader(&mut q).unwrap();
     assert_eq!(report.chunks, 1);
-    assert!(read(&mut ring, &id(1)).is_none());
-    assert_eq!(read(&mut ring, &id(2)).unwrap(), b"b");
+    assert!(read(&mut q, &mut reader, &id(1)).is_none());
+    assert_eq!(read(&mut q, &mut reader, &id(2)).unwrap(), b"b");
 }
 
 #[test]
-fn delete_after_pending_put_of_same_key() {
+fn delete_interleaved_with_pending_puts() {
     let device = new_device(4);
-    let Opened { mut writer, reader, .. } = open(&device);
-    let mut ring = open_ring(&reader);
-    writer.put(id(1), b"pending", PutOptions::default()).unwrap();
-    assert!(writer.delete(&id(1)).unwrap());
-    assert!(read(&mut ring, &id(1)).is_none());
+    let (_engine, mut q, mut writer, mut reader) = setup(&device);
+    // Delete of a key whose put is still pending: the tombstone outranks it,
+    // and the key is free for a new put at once (not `Exists`).
+    writer.put(&mut q, id(1), b"pending", PutOptions::default()).unwrap();
+    assert!(matches!(
+        writer.delete(&mut q, &id(1)).unwrap(),
+        DeleteOutcome::Deleted { .. }
+    ));
+    assert!(matches!(
+        writer.put(&mut q, id(1), b"x", PutOptions::default()).unwrap(),
+        PutOutcome::Written { .. }
+    ));
+    writer.put(&mut q, id(4), b"pending", PutOptions::default()).unwrap();
+    assert!(matches!(
+        writer.delete(&mut q, &id(4)).unwrap(),
+        DeleteOutcome::Deleted { .. }
+    ));
+    assert!(matches!(writer.delete(&mut q, &id(4)).unwrap(), DeleteOutcome::Missing));
+    // Large put (submitted at once) then a small pending put of the same key,
+    // then a delete, then a new put: the last put must be what remains.
+    let overwrite = PutOptions {
+        overwrite: true,
+        ..Default::default()
+    };
+    writer.put(&mut q, id(2), &value_for(2, 0, 70_000), overwrite).unwrap();
+    writer.put(&mut q, id(2), b"small", overwrite).unwrap();
+    assert!(matches!(
+        writer.delete(&mut q, &id(2)).unwrap(),
+        DeleteOutcome::Deleted { .. }
+    ));
+    writer.put(&mut q, id(2), b"final", overwrite).unwrap();
+    // A framed record pending in the other staging batch, then deleted; the
+    // framed batch is closed after the inline one that holds the tombstone.
+    writer.put(&mut q, id(3), &value_for(3, 0, 4096), overwrite).unwrap();
+    assert!(matches!(
+        writer.delete(&mut q, &id(3)).unwrap(),
+        DeleteOutcome::Deleted { .. }
+    ));
+    flush(&mut q, &mut writer);
+    let check = |q: &mut dyn IoQueue, reader: &mut Reader| {
+        assert_eq!(read(q, reader, &id(1)).unwrap(), b"x");
+        assert_eq!(read(q, reader, &id(2)).unwrap(), b"final");
+        assert!(read(q, reader, &id(3)).is_none());
+        assert!(read(q, reader, &id(4)).is_none());
+    };
+    check(&mut q, &mut reader);
     drop(writer);
-    let Opened { reader, .. } = open(&device);
-    let mut ring = open_ring(&reader);
-    assert!(read(&mut ring, &id(1)).is_none());
+    drop(reader);
+    let (_engine, mut q, _writer, mut reader) = setup(&device);
+    check(&mut q, &mut reader);
 }
 
 #[test]
@@ -515,32 +647,35 @@ fn recovery_from_footers_and_scan() {
     let mut rng = XorShift(0x1234);
     let mut expected = HashMap::new();
     {
-        let Opened { mut writer, .. } = open(&device);
+        let (_engine, mut q, mut writer, _reader) = setup(&device);
         for i in 0..400u128 {
             let len = random_len(&mut rng);
             let v = value_for(i, 0, len);
-            writer.put(id(i), &v, PutOptions::default()).unwrap();
+            put(&mut q, &mut writer, id(i), &v, PutOptions::default());
             expected.insert(i, v);
         }
-        writer.flush().unwrap();
-        // Drop without close: the hot segment stays active.
+        flush(&mut q, &mut writer);
+        // Drop without sealing: the hot segment stays active.
     }
-    let Opened { reader, report, writer } = open(&device);
-    let mut ring = open_ring(&reader);
+    let (engine, report) = moat_engine::open(device.clone(), options()).unwrap();
+    let mut q = queue();
+    let mut reader = engine.reader(&mut q).unwrap();
+    let writer = engine.writer(&mut q).unwrap();
     assert!(report.scanned >= 1, "an active segment must have been scanned");
     assert!(report.sealed >= 1, "earlier segments must have been sealed");
     assert_eq!(report.chunks, 400);
     for (i, v) in &expected {
-        assert_eq!(read(&mut ring, &id(*i)).unwrap(), *v);
+        assert_eq!(read(&mut q, &mut reader, &id(*i)).unwrap(), *v);
     }
-    writer.close().unwrap();
+    close(&mut q, writer);
 
-    let Opened { reader, report, .. } = open(&device);
-    let mut ring = open_ring(&reader);
-    assert_eq!(report.scanned, 0, "close seals everything");
+    let (engine, report) = moat_engine::open(device.clone(), options()).unwrap();
+    let mut q = queue();
+    let mut reader = engine.reader(&mut q).unwrap();
+    assert_eq!(report.scanned, 0, "a clean shutdown seals everything");
     assert_eq!(report.chunks, 400);
     for (i, v) in &expected {
-        assert_eq!(read(&mut ring, &id(*i)).unwrap(), *v);
+        assert_eq!(read(&mut q, &mut reader, &id(*i)).unwrap(), *v);
     }
 }
 
@@ -556,20 +691,20 @@ fn torn_tail_never_returns_wrong_data() {
         let mut safe = HashMap::new();
         let mut unsafe_keys = HashMap::new();
         {
-            let Opened { mut writer, .. } = open(&device);
+            let (_engine, mut q, mut writer, _reader) = setup(&device);
             for i in 0..60u128 {
                 let v = value_for(i, 0, random_len(&mut rng));
-                writer.put(id(i), &v, PutOptions::default()).unwrap();
+                writer.put(&mut q, id(i), &v, PutOptions::default()).unwrap();
                 safe.insert(i, v);
             }
-            writer.flush().unwrap();
+            flush(&mut q, &mut writer);
             let before = device.with_data(|d| d.to_vec());
             for i in 100..130u128 {
                 let v = value_for(i, 0, random_len(&mut rng));
-                writer.put(id(i), &v, PutOptions::default()).unwrap();
+                writer.put(&mut q, id(i), &v, PutOptions::default()).unwrap();
                 unsafe_keys.insert(i, v);
             }
-            writer.flush().unwrap();
+            flush(&mut q, &mut writer);
             // Damage every page that changed after the safe point.
             device.with_data_mut(|after| {
                 let mut damaged = 0;
@@ -595,14 +730,13 @@ fn torn_tail_never_returns_wrong_data() {
                 assert!(damaged > 0);
             });
         }
-        let Opened { reader, .. } = open(&device);
-        let mut ring = open_ring(&reader);
+        let (_engine, mut q, _writer, mut reader) = setup(&device);
         for (i, v) in &safe {
-            assert_eq!(read(&mut ring, &id(*i)).unwrap(), *v, "mode {mode} key {i}");
+            assert_eq!(read(&mut q, &mut reader, &id(*i)).unwrap(), *v, "mode {mode} key {i}");
         }
         let mut survived = 0;
         for (i, v) in &unsafe_keys {
-            match ring.get_sync(&id(*i), None) {
+            match blocking::get(&mut q, &mut reader, &id(*i), None) {
                 Ok(Some(got)) => {
                     assert_eq!(&*got, &v[..], "mode {mode} key {i}");
                     survived += 1;
@@ -616,26 +750,110 @@ fn torn_tail_never_returns_wrong_data() {
 }
 
 #[test]
-fn bit_rot_in_sealed_value_is_detected() {
-    let device = new_device(4);
-    let Opened { mut writer, reader, .. } = open(&device);
-    let mut ring = open_ring(&reader);
-    let v = value_for(5, 0, 90_000);
-    writer.put(id(5), &v, PutOptions::default()).unwrap();
-    writer.close().unwrap();
-    let before = device.with_data(|d| d.to_vec());
-    // Find the value on disk and flip one byte deep inside it.
-    let pos = before
-        .windows(64)
-        .position(|w| w == &v[1000..1064])
-        .expect("value on disk");
-    device.with_data_mut(|d| d[pos + 70_000] ^= 1);
+fn bit_rot_in_sealed_value_is_detected_and_reclaim_drops_it() {
+    for verify_reads in [false, true] {
+        let device = new_device(4);
+        let engine = open_with(
+            &device,
+            Options {
+                verify_reads,
+                ..options()
+            },
+        );
+        let mut q = queue();
+        let mut writer = engine.writer(&mut q).unwrap();
+        let mut reader = engine.reader(&mut q).unwrap();
+        let v = value_for(5, 0, 90_000);
+        writer.put(&mut q, id(5), &v, PutOptions::default()).unwrap();
+        writer.put(&mut q, id(6), b"neighbour", PutOptions::default()).unwrap();
+        seal(&mut q, &mut writer);
+        let before = device.with_data(|d| d.to_vec());
+        // Find the value on disk and flip one byte deep inside it.
+        let pos = before
+            .windows(64)
+            .position(|w| w == &v[1000..1064])
+            .expect("value on disk");
+        device.with_data_mut(|d| d[pos + 70_000] ^= 1);
 
-    // Block 0 (first 64 KiB) is intact; a range inside it still reads.
-    assert_eq!(&*ring.get_sync(&id(5), Some(0..100)).unwrap().unwrap(), &v[0..100]);
-    // The damaged block is refused and the entry is dropped from the index.
-    assert!(matches!(ring.get_sync(&id(5), None), Err(Error::Corrupt(_))));
-    assert!(ring.get_sync(&id(5), None).unwrap().is_none());
+        // Block 0 (first 64 KiB) is intact; a range inside it still reads.
+        assert_eq!(
+            &*blocking::get(&mut q, &mut reader, &id(5), Some(0..100))
+                .unwrap()
+                .unwrap(),
+            &v[0..100]
+        );
+        // Enabling verification rejects corruption on every read, even when the
+        // damaged byte is outside the requested range but in a touched block.
+        for range in [None, None, Some(70_000..70_010)] {
+            let result = blocking::get(&mut q, &mut reader, &id(5), range.clone());
+            if verify_reads {
+                assert!(matches!(result, Err(Error::Corrupt(_))));
+            } else {
+                let mut damaged = v.clone();
+                damaged[71_000] ^= 1;
+                let range = range.unwrap_or(0..v.len() as u64);
+                assert_eq!(
+                    &*result.unwrap().unwrap(),
+                    &damaged[range.start as usize..range.end as usize]
+                );
+            }
+        }
+        // Reclaim drops the rotten record instead of copying it forward, and
+        // keeps its intact neighbour.
+        let report = reclaim(&mut q, &mut writer, ReclaimPolicy::Storage).unwrap();
+        assert_eq!(report.corrupt, 1);
+        assert_eq!(report.relocated, 1);
+        assert!(!engine.contains(&id(5)));
+        assert_eq!(read(&mut q, &mut reader, &id(6)).unwrap(), b"neighbour");
+    }
+}
+
+#[test]
+fn header_validation_is_required_for_verification_or_expiry() {
+    for verify_reads in [false, true] {
+        for expire_at in [0, u64::MAX] {
+            let device = new_device(4);
+            let engine = open_with(
+                &device,
+                Options {
+                    verify_reads,
+                    ..options()
+                },
+            );
+            let mut q = queue();
+            let mut writer = engine.writer(&mut q).unwrap();
+            let mut reader = engine.reader(&mut q).unwrap();
+            let value = value_for(1, 0, 100_000);
+            writer
+                .put(
+                    &mut q,
+                    id(1),
+                    &value,
+                    PutOptions {
+                        expire_at,
+                        ..Default::default()
+                    },
+                )
+                .unwrap();
+            flush(&mut q, &mut writer);
+            let stat = reader.stat(&id(1)).unwrap();
+            let segment = SEGMENT * (stat.segment as u64 + 1);
+            // The first large batch follows the segment header page.
+            let header = segment as usize + 4096 + moat_engine::layout::BATCH_HEADER_LEN;
+            device.with_data_mut(|data| data[header] ^= 1);
+            for range in [0..10, 70000..70010, 100_000..100_000] {
+                let result = blocking::get(&mut q, &mut reader, &id(1), Some(range.clone()));
+                if verify_reads || expire_at != 0 {
+                    assert!(matches!(result, Err(Error::Corrupt(_))));
+                } else {
+                    assert_eq!(
+                        &*result.unwrap().unwrap(),
+                        &value[range.start as usize..range.end as usize]
+                    );
+                }
+            }
+        }
+    }
 }
 
 #[test]
@@ -644,13 +862,13 @@ fn corrupt_footer_falls_back_to_scan() {
     let mut rng = XorShift(0x42);
     let mut expected = HashMap::new();
     {
-        let Opened { mut writer, .. } = open(&device);
+        let (_engine, mut q, mut writer, _reader) = setup(&device);
         for i in 0..40u128 {
             let v = value_for(i, 0, random_len(&mut rng));
-            writer.put(id(i), &v, PutOptions::default()).unwrap();
+            writer.put(&mut q, id(i), &v, PutOptions::default()).unwrap();
             expected.insert(i, v);
         }
-        writer.close().unwrap();
+        close(&mut q, writer);
     }
     // Damage the first footer: it sits right after the data of segment 0, so
     // locate it by its magic.
@@ -659,15 +877,16 @@ fn corrupt_footer_falls_back_to_scan() {
         let pos = d.windows(8).position(|w| w == magic).expect("footer present");
         d[pos + 100] ^= 0xff;
     });
-    let Opened { reader, report, .. } = open(&device);
-    let mut ring = open_ring(&reader);
+    let (engine, report) = moat_engine::open(device.clone(), options()).unwrap();
+    let mut q = queue();
+    let mut reader = engine.reader(&mut q).unwrap();
     assert_eq!(report.bad_footers, 1);
     assert!(report.scanned >= 1);
     for (i, v) in &expected {
-        assert_eq!(read(&mut ring, &id(*i)).unwrap(), *v);
+        assert_eq!(read(&mut q, &mut reader, &id(*i)).unwrap(), *v);
     }
     // The rescanned segment was re-sealed with a fresh footer.
-    let Opened { report, .. } = open(&device);
+    let (_engine, report) = moat_engine::open(device.clone(), options()).unwrap();
     assert_eq!(report.bad_footers, 0);
     assert_eq!(report.scanned, 0);
 }
@@ -675,8 +894,7 @@ fn corrupt_footer_falls_back_to_scan() {
 #[test]
 fn reclaim_storage_keeps_every_live_chunk() {
     let device = new_device(20);
-    let Opened { mut writer, reader, .. } = open(&device);
-    let mut ring = open_ring(&reader);
+    let (engine, mut q, mut writer, mut reader) = setup(&device);
     let mut rng = XorShift(0xbeef);
     let mut model: HashMap<u128, Vec<u8>> = HashMap::new();
     let overwrite = PutOptions {
@@ -688,19 +906,24 @@ fn reclaim_storage_keeps_every_live_chunk() {
         for i in 0..150u128 {
             match rng.below(4) {
                 0 if model.contains_key(&i) => {
-                    writer.delete(&id(i)).unwrap();
+                    // Deletes are not awaited: the tombstone rides in the
+                    // pending batch like any record.
+                    assert!(matches!(
+                        writer.delete(&mut q, &id(i)).unwrap(),
+                        DeleteOutcome::Deleted { .. }
+                    ));
                     model.remove(&i);
                 }
                 _ => {
                     let v = value_for(i, round, random_len(&mut rng));
-                    writer.put(id(i), &v, overwrite).unwrap();
+                    put(&mut q, &mut writer, id(i), &v, overwrite);
                     model.insert(i, v);
                 }
             }
         }
-        writer.flush().unwrap();
+        flush(&mut q, &mut writer);
         while writer.free_segments() < 6 {
-            let report = writer.reclaim(ReclaimPolicy::Storage).unwrap().expect("victim");
+            let report = reclaim(&mut q, &mut writer, ReclaimPolicy::Storage).expect("victim");
             assert_eq!(
                 report.records,
                 report.relocated + report.dropped + report.tombstones_relocated + report.tombstones_dropped
@@ -710,58 +933,134 @@ fn reclaim_storage_keeps_every_live_chunk() {
     // A few extra passes exercise the tombstone rules on already-compacted
     // segments (relocated records and forwarded tombstones).
     for _ in 0..8 {
-        if writer.free_segments() < 3 || writer.reclaim(ReclaimPolicy::Storage).unwrap().is_none() {
+        if writer.free_segments() < 3 || reclaim(&mut q, &mut writer, ReclaimPolicy::Storage).is_none() {
             break;
         }
     }
 
-    let check = |ring: &mut ReadRing| {
+    let check = |q: &mut dyn IoQueue, reader: &mut Reader| {
         for i in 0..150u128 {
-            assert_eq!(read(ring, &id(i)), model.get(&i).cloned(), "key {i}");
+            assert_eq!(read(q, reader, &id(i)), model.get(&i).cloned(), "key {i}");
         }
     };
-    check(&mut ring);
-    let usage = reader.usage();
+    check(&mut q, &mut reader);
+    let usage = engine.usage();
     assert_eq!(usage.chunks, model.len());
 
     drop(writer);
-    let Opened { reader, .. } = open(&device);
-    let mut ring = open_ring(&reader);
-    check(&mut ring);
+    drop(reader);
+    let (_engine, mut q, _writer, mut reader) = setup(&device);
+    check(&mut q, &mut reader);
+}
+
+#[test]
+fn reclaim_runs_concurrently_with_foreground_writes() {
+    let device = new_device(24);
+    let (engine, mut q, mut writer, mut reader) = setup(&device);
+    let overwrite = PutOptions {
+        overwrite: true,
+        ..Default::default()
+    };
+    let mut model: HashMap<u128, Vec<u8>> = HashMap::new();
+    let mut rng = XorShift(0xc0ffee);
+    for i in 0..200u128 {
+        let v = value_for(i, 0, 20_000);
+        put(&mut q, &mut writer, id(i), &v, PutOptions::default());
+        model.insert(i, v);
+    }
+    seal(&mut q, &mut writer);
+
+    // Start a reclaim pass and keep writing (overwrites and deletes of keys
+    // the pass is relocating) while it runs; poll both to completion.
+    let ticket = writer.reclaim(&mut q, ReclaimPolicy::Storage).unwrap().expect("victim");
+    let mut done = Vec::new();
+    let mut finished = false;
+    let mut round = 1u32;
+    while !finished {
+        for _ in 0..5 {
+            let k = rng.below(200) as u128;
+            if rng.below(3) == 0 {
+                match writer.delete(&mut q, &id(k)).unwrap() {
+                    DeleteOutcome::Deleted { .. } => {
+                        model.remove(&k);
+                    }
+                    DeleteOutcome::Missing => assert!(!model.contains_key(&k)),
+                }
+            } else {
+                let v = value_for(k, round, 3_000 + (k as usize % 5) * 7_000);
+                writer.put(&mut q, id(k), &v, overwrite).unwrap();
+                model.insert(k, v);
+            }
+        }
+        round += 1;
+        q.poll(true).unwrap();
+        writer.poll(&mut q, &mut done).unwrap();
+        for c in done.drain(..) {
+            if c.ticket == ticket {
+                let Outcome::Reclaim(report) = c.result.unwrap() else {
+                    panic!("not a reclaim outcome")
+                };
+                assert!(report.records > 0);
+                finished = true;
+            } else {
+                c.result.unwrap();
+            }
+        }
+    }
+    flush(&mut q, &mut writer);
+    for k in 0..200u128 {
+        assert_eq!(read(&mut q, &mut reader, &id(k)), model.get(&k).cloned(), "key {k}");
+    }
+    assert_eq!(engine.usage().chunks, model.len());
+    close(&mut q, writer);
+    drop(reader);
+    let (_engine, mut q, _writer, mut reader) = setup(&device);
+    for k in 0..200u128 {
+        assert_eq!(
+            read(&mut q, &mut reader, &id(k)),
+            model.get(&k).cloned(),
+            "key {k} after reopen"
+        );
+    }
 }
 
 #[test]
 fn reclaim_cache_evicts_oldest_and_reinserts_accessed() {
     let device = new_device(12);
-    let Opened { mut writer, reader, .. } = open(&device);
-    let mut ring = open_ring(&reader);
+    let (engine, mut q, mut writer, mut reader) = setup(&device);
     // Fill several segments with 48 KiB values (packed, ~20 per segment).
     for i in 0..100u128 {
-        writer
-            .put(id(i), &value_for(i, 0, 48 << 10), PutOptions::default())
-            .unwrap();
+        put(
+            &mut q,
+            &mut writer,
+            id(i),
+            &value_for(i, 0, 48 << 10),
+            PutOptions::default(),
+        );
     }
-    writer.seal_active().unwrap();
+    seal(&mut q, &mut writer);
     let free_before = writer.free_segments();
 
     // Touch the even keys among the oldest records.
     for i in (0..20u128).step_by(2) {
-        read(&mut ring, &id(i)).unwrap();
+        read(&mut q, &mut reader, &id(i)).unwrap();
     }
 
-    let report = writer
-        .reclaim(ReclaimPolicy::Cache {
+    let report = reclaim(
+        &mut q,
+        &mut writer,
+        ReclaimPolicy::Cache {
             reinsert_accessed: true,
-        })
-        .unwrap()
-        .unwrap();
+        },
+    )
+    .unwrap();
     assert!(report.relocated > 0 && report.dropped > 0);
     assert_eq!(
         writer.free_segments(),
         free_before + 1 - u32::from(report.relocated > 0)
     );
     for i in 0..report.records as u128 {
-        let present = reader.contains(&id(i));
+        let present = engine.contains(&id(i));
         assert_eq!(present, i % 2 == 0, "key {i}");
     }
 
@@ -771,31 +1070,44 @@ fn reclaim_cache_evicts_oldest_and_reinserts_accessed() {
             reinsert_accessed: false,
         })
         .unwrap();
-    let report = writer
-        .reclaim(ReclaimPolicy::Cache {
+    let report = reclaim(
+        &mut q,
+        &mut writer,
+        ReclaimPolicy::Cache {
             reinsert_accessed: false,
-        })
-        .unwrap()
-        .unwrap();
+        },
+    )
+    .unwrap();
     assert_eq!(report.seg_no, victim);
     assert_eq!(report.relocated, 0);
     assert!(report.dropped > 0);
+    // Only one pass at a time.
+    if let Some(t) = writer.reclaim(&mut q, ReclaimPolicy::Storage).unwrap() {
+        assert!(matches!(
+            writer.reclaim(&mut q, ReclaimPolicy::Storage),
+            Err(Error::Busy)
+        ));
+        blocking::wait(&mut q, &mut writer, t).unwrap();
+    }
 }
 
 #[test]
 fn expiry_hides_and_reclaim_drops() {
     let clock = Arc::new(ManualClock::new(1_000));
     let device = new_device(6);
-    let Opened { mut writer, reader, .. } = open_with(
+    let engine = open_with(
         &device,
         Options {
             clock: clock.clone(),
             ..options()
         },
     );
-    let mut ring = open_ring(&reader);
+    let mut q = queue();
+    let mut writer = engine.writer(&mut q).unwrap();
+    let mut reader = engine.reader(&mut q).unwrap();
     writer
         .put(
+            &mut q,
             id(1),
             b"ephemeral",
             PutOptions {
@@ -804,35 +1116,92 @@ fn expiry_hides_and_reclaim_drops() {
             },
         )
         .unwrap();
-    writer.put(id(2), b"forever", PutOptions::default()).unwrap();
-    writer.flush().unwrap();
-    assert!(read(&mut ring, &id(1)).is_some());
+    writer.put(&mut q, id(2), b"forever", PutOptions::default()).unwrap();
+    flush(&mut q, &mut writer);
+    assert!(read(&mut q, &mut reader, &id(1)).is_some());
     clock.set(1_100);
-    assert!(read(&mut ring, &id(1)).is_none());
-    assert!(read(&mut ring, &id(2)).is_some());
+    assert!(read(&mut q, &mut reader, &id(1)).is_none());
+    assert!(read(&mut q, &mut reader, &id(2)).is_some());
 
-    writer.seal_active().unwrap();
-    let report = writer.reclaim(ReclaimPolicy::Storage).unwrap().unwrap();
+    seal(&mut q, &mut writer);
+    let report = reclaim(&mut q, &mut writer, ReclaimPolicy::Storage).unwrap();
     assert_eq!(report.dropped, 1);
     assert_eq!(report.relocated, 1);
-    assert!(!reader.contains(&id(1)));
-    assert!(read(&mut ring, &id(2)).is_some());
+    assert!(!engine.contains(&id(1)));
+    assert!(read(&mut q, &mut reader, &id(2)).is_some());
 }
 
 #[test]
 fn no_space_is_reported_not_panicked() {
     let device = new_device(2);
-    let Opened { mut writer, .. } = open(&device);
+    let (_engine, mut q, mut writer, _reader) = setup(&device);
     let big = vec![1u8; CHUNK_MAX as usize];
     let mut written = 0;
     loop {
-        match writer.put(id(written), &big, PutOptions::default()) {
+        match writer.put(&mut q, id(written), &big, PutOptions::default()) {
             Ok(PutOutcome::Written { .. }) => written += 1,
             Err(Error::NoSpace) => break,
             other => panic!("unexpected {other:?}"),
         }
     }
     assert!(written >= 14, "two segments of 1 MiB hold at least 14 x 128 KiB");
+    flush(&mut q, &mut writer);
+}
+
+#[test]
+fn index_budget_is_enforced() {
+    let device = new_device(4);
+    let engine = open_with(
+        &device,
+        Options {
+            index_capacity: 64,
+            // Exactly the initial table: no growth allowed.
+            index_memory_budget: 64 * 64,
+            ..options()
+        },
+    );
+    let mut q = queue();
+    let mut writer = engine.writer(&mut q).unwrap();
+    let mut n = 0u128;
+    loop {
+        match writer.put(&mut q, id(n), b"v", PutOptions::default()) {
+            Ok(PutOutcome::Written { .. }) => n += 1,
+            Err(Error::IndexFull) => break,
+            other => panic!("unexpected {other:?}"),
+        }
+        flush(&mut q, &mut writer);
+    }
+    assert_eq!(n, 56, "a 64-slot table takes 7/8 load");
+    // Overwrites still work at the budget.
+    assert!(matches!(
+        writer.put(
+            &mut q,
+            id(0),
+            b"w",
+            PutOptions {
+                overwrite: true,
+                ..Default::default()
+            }
+        ),
+        Ok(PutOutcome::Written { .. })
+    ));
+    // One delete is not enough: a rebuild at the same size needs the live
+    // count at or below 3/4, so the table is compacted only after enough
+    // deletes; then new keys fit again.
+    assert!(delete(&mut q, &mut writer, &id(1)));
+    assert!(matches!(
+        writer.put(&mut q, id(1000), b"v", PutOptions::default()),
+        Err(Error::IndexFull)
+    ));
+    for i in 2..12u128 {
+        assert!(delete(&mut q, &mut writer, &id(i)));
+    }
+    assert!(matches!(
+        writer.put(&mut q, id(1000), b"v", PutOptions::default()),
+        Ok(PutOutcome::Written { .. })
+    ));
+    flush(&mut q, &mut writer);
+    assert_eq!(engine.usage().chunks, 56 - 11 + 1);
 }
 
 #[test]
@@ -846,9 +1215,9 @@ fn open_rejects_unformatted_and_foreign_devices() {
     // Segments formatted under a different uuid are treated as free, not as data.
     let device = new_device(4);
     {
-        let Opened { mut writer, .. } = open(&device);
-        writer.put(id(1), b"old", PutOptions::default()).unwrap();
-        writer.close().unwrap();
+        let (_engine, mut q, mut writer, _reader) = setup(&device);
+        writer.put(&mut q, id(1), b"old", PutOptions::default()).unwrap();
+        close(&mut q, writer);
     }
     let mut opts = format_options();
     opts.disk_uuid = [0xcd; 16];
@@ -867,10 +1236,10 @@ fn open_rejects_unformatted_and_foreign_devices() {
     use moat_engine::Device;
     device.write_at(&sb, 0).unwrap();
     device.write_at(&sb, 4096).unwrap();
-    let Opened { reader, report, .. } = open(&device);
+    let (engine, report) = moat_engine::open(device.clone(), options()).unwrap();
     assert_eq!(report.unreadable_headers, 4);
     assert_eq!(report.chunks, 0);
-    assert!(!reader.contains(&id(1)));
+    assert!(!engine.contains(&id(1)));
 }
 
 /// Random operations against a reference model, with periodic flushes,
@@ -882,8 +1251,7 @@ fn randomized_against_model() {
     let mut rng = XorShift(0x9e37_79b9);
     let mut model: HashMap<u128, (u32, Vec<u8>)> = HashMap::new();
     let mut versions: HashMap<u128, u32> = HashMap::new();
-    let mut opened = open(&device);
-    let mut ring = open_ring(&opened.reader);
+    let (mut engine, mut q, mut writer, mut reader) = setup(&device);
     let keys = 300u64;
 
     for step in 0..6_000u32 {
@@ -893,68 +1261,65 @@ fn randomized_against_model() {
                 let version = versions.entry(k).or_insert(0);
                 *version += 1;
                 let v = value_for(k, *version, random_len(&mut rng));
-                let outcome = opened
-                    .writer
-                    .put(
-                        id(k),
-                        &v,
-                        PutOptions {
-                            overwrite: true,
-                            ..Default::default()
-                        },
-                    )
-                    .unwrap();
+                let outcome = put(
+                    &mut q,
+                    &mut writer,
+                    id(k),
+                    &v,
+                    PutOptions {
+                        overwrite: true,
+                        ..Default::default()
+                    },
+                );
                 assert!(matches!(outcome, PutOutcome::Written { .. }));
                 model.insert(k, (*version, v));
             }
             55..=69 => {
-                let existed = opened.writer.delete(&id(k)).unwrap();
+                let existed = matches!(writer.delete(&mut q, &id(k)).unwrap(), DeleteOutcome::Deleted { .. });
                 assert_eq!(existed, model.remove(&k).is_some(), "delete {k} at step {step}");
             }
             70..=89 => {
                 // Reads see everything flushed; flush first so the model applies.
-                opened.writer.flush().unwrap();
-                let got = read(&mut ring, &id(k));
+                flush(&mut q, &mut writer);
+                let got = read(&mut q, &mut reader, &id(k));
                 assert_eq!(got, model.get(&k).map(|(_, v)| v.clone()), "get {k} at step {step}");
             }
             90..=95 => {
-                opened.writer.flush().unwrap();
-                if opened.writer.free_segments() < 6 {
-                    opened.writer.reclaim(ReclaimPolicy::Storage).unwrap();
+                flush(&mut q, &mut writer);
+                if writer.free_segments() < 6 {
+                    reclaim(&mut q, &mut writer, ReclaimPolicy::Storage);
                 }
             }
             _ => {
-                // Crash-free reopen: drop the writer without closing half the time.
-                drop(ring);
+                // Reopen: clean shutdown half the time, a "crash" (drop with
+                // everything flushed but unsealed) otherwise.
+                drop(reader);
                 if rng.below(2) == 0 {
-                    let Opened { writer, .. } = opened;
-                    writer.close().unwrap();
+                    close(&mut q, writer);
                 } else {
-                    opened.writer.flush().unwrap();
-                    drop(opened);
+                    flush(&mut q, &mut writer);
+                    drop(writer);
                 }
-                opened = open(&device);
-                ring = open_ring(&opened.reader);
+                drop(engine);
+                (engine, q, writer, reader) = setup(&device);
             }
         }
-        if opened.writer.free_segments() < 3 {
-            opened.writer.flush().unwrap();
+        if writer.free_segments() < 3 {
+            flush(&mut q, &mut writer);
             for _ in 0..32 {
-                if opened.writer.free_segments() >= 6
-                    || opened.writer.reclaim(ReclaimPolicy::Storage).unwrap().is_none()
-                {
+                if writer.free_segments() >= 6 || reclaim(&mut q, &mut writer, ReclaimPolicy::Storage).is_none() {
                     break;
                 }
             }
         }
     }
 
-    opened.writer.flush().unwrap();
+    flush(&mut q, &mut writer);
     for k in 0..keys as u128 {
-        let got = read(&mut ring, &id(k));
+        let got = read(&mut q, &mut reader, &id(k));
         assert_eq!(got, model.get(&k).map(|(_, v)| v.clone()), "final {k}");
     }
-    assert_eq!(opened.reader.usage().chunks, model.len());
+    assert_eq!(engine.usage().chunks, model.len());
 }
 
 #[test]
@@ -965,27 +1330,29 @@ fn concurrent_readers_never_see_torn_values() {
     };
 
     let device = new_device(16);
-    let Opened { mut writer, reader, .. } = open(&device);
+    let (engine, mut q, mut writer, _reader) = setup(&device);
     let keys = 64u128;
     // Values are 40 KiB so every segment holds ~25 records and reclaim churns.
     let len = 40 << 10;
     for k in 0..keys {
-        writer.put(id(k), &value_for(k, 0, len), PutOptions::default()).unwrap();
+        put(&mut q, &mut writer, id(k), &value_for(k, 0, len), PutOptions::default());
     }
-    writer.flush().unwrap();
+    flush(&mut q, &mut writer);
 
     let stop = Arc::new(AtomicBool::new(false));
     let readers: Vec<_> = (0..4)
         .map(|t| {
-            let reader = reader.clone();
+            let engine = engine.clone();
             let stop = stop.clone();
             thread::spawn(move || {
-                let mut ring = open_ring(&reader);
+                // Each reading thread owns its queue and pool.
+                let mut q = queue();
+                let mut reader = engine.reader(&mut q).unwrap();
                 let mut rng = XorShift(0x100 + t);
                 let mut reads = 0u64;
                 while !stop.load(Ordering::Relaxed) {
                     let k = rng.below(keys as u64) as u128;
-                    match ring.get_sync(&id(k), None).unwrap() {
+                    match blocking::get(&mut q, &mut reader, &id(k), None).unwrap() {
                         Some(v) => {
                             // Any version is acceptable, but it must be a whole one.
                             let ok = (0..64u32).any(|ver| *v == value_for(k, ver, len)[..]);
@@ -995,6 +1362,7 @@ fn concurrent_readers_never_see_torn_values() {
                         None => panic!("key {k} vanished"),
                     }
                 }
+                reader.detach(&mut q);
                 reads
             })
         })
@@ -1006,14 +1374,14 @@ fn concurrent_readers_never_see_torn_values() {
     };
     for round in 1..40u32 {
         for k in 0..keys {
-            writer.put(id(k), &value_for(k, round, len), overwrite).unwrap();
+            put(&mut q, &mut writer, id(k), &value_for(k, round, len), overwrite);
         }
-        writer.flush().unwrap();
+        flush(&mut q, &mut writer);
         for _ in 0..32 {
             if writer.free_segments() >= 6 {
                 break;
             }
-            writer.reclaim(ReclaimPolicy::Storage).unwrap().unwrap();
+            reclaim(&mut q, &mut writer, ReclaimPolicy::Storage).unwrap();
         }
     }
     stop.store(true, Ordering::Relaxed);
@@ -1024,9 +1392,30 @@ fn concurrent_readers_never_see_torn_values() {
 /// The same engine on a real file, with `O_DIRECT` and io_uring where the
 /// platform supports them (tmpfs does not support `O_DIRECT`; the test then
 /// falls back to buffered I/O).
+#[cfg(target_os = "linux")]
 #[test]
-fn file_device_roundtrip_with_direct_io() {
-    use moat_engine::FileDevice;
+fn file_device_roundtrip_with_direct_io_and_uring() {
+    use moat_engine::{FileDevice, uring::UringQueue};
+
+    /// Keep the registered pool below the locked-memory limit of standard
+    /// hosted CI runners. The 128 KiB class still accommodates the test
+    /// format's 64 KiB maximum chunk plus its metadata.
+    fn file_queue_options() -> QueueOptions {
+        QueueOptions {
+            depth: 64,
+            pool: PoolOptions {
+                bytes: 1 << 20,
+                max_class: 128 << 10,
+                huge_pages: HugePages::Disabled,
+            },
+            descriptors: 4,
+        }
+    }
+    let file_options = Options {
+        batch_limit: 128 << 10,
+        scan_window: 128 << 10,
+        ..options()
+    };
 
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("disk.img");
@@ -1036,47 +1425,64 @@ fn file_device_roundtrip_with_direct_io() {
         Err(_) => FileDevice::create(&path, len, false).unwrap(),
     };
     let device: Arc<FileDevice> = Arc::new(device);
-    moat_engine::format(&*device, &file_format_options()).unwrap();
+    moat_engine::format(
+        &*device,
+        &FormatOptions {
+            chunk_max: FILE_CHUNK_MAX,
+            ..format_options()
+        },
+    )
+    .unwrap();
 
     let mut rng = XorShift(0xfeed);
     let mut expected = HashMap::new();
     {
-        let Opened { mut writer, reader, .. } = moat_engine::open(device.clone(), file_options()).unwrap();
-        let mut ring = reader.ring(&file_queue_options()).unwrap();
+        let (engine, _) = moat_engine::open(device.clone(), file_options.clone()).unwrap();
+        let mut q = UringQueue::new(&file_queue_options()).unwrap();
+        let mut writer = engine.writer(&mut q).unwrap();
+        let mut reader = engine.reader(&mut q).unwrap();
         for i in 0..64u128 {
             let len = random_len(&mut rng).min(FILE_CHUNK_MAX as usize);
             let v = value_for(i, 0, len);
-            writer.put(id(i), &v, PutOptions::default()).unwrap();
+            put(&mut q, &mut writer, id(i), &v, PutOptions::default());
             expected.insert(i, v);
         }
-        writer.flush().unwrap();
+        flush(&mut q, &mut writer);
         for (i, v) in &expected {
-            assert_eq!(read(&mut ring, &id(*i)).unwrap(), *v);
+            assert_eq!(read(&mut q, &mut reader, &id(*i)).unwrap(), *v);
         }
-        writer.close().unwrap();
+        // Reclaim through the ring as well.
+        seal(&mut q, &mut writer);
+        reclaim(&mut q, &mut writer, ReclaimPolicy::Storage).unwrap();
+        for (i, v) in &expected {
+            assert_eq!(read(&mut q, &mut reader, &id(*i)).unwrap(), *v);
+        }
+        close(&mut q, writer);
+        reader.detach(&mut q);
     }
     let reopened = Arc::new(FileDevice::open(&path, false).unwrap());
-    let Opened { reader, report, .. } = moat_engine::open(reopened, file_options()).unwrap();
-    let mut ring = reader.ring(&file_queue_options()).unwrap();
+    let (engine, report) = moat_engine::open(reopened, file_options).unwrap();
+    let mut q = UringQueue::new(&file_queue_options()).unwrap();
+    let mut reader = engine.reader(&mut q).unwrap();
     assert_eq!(report.chunks, 64);
+    assert_eq!(report.scanned, 0);
     for (i, v) in &expected {
-        assert_eq!(read(&mut ring, &id(*i)).unwrap(), *v);
+        assert_eq!(read(&mut q, &mut reader, &id(*i)).unwrap(), *v);
     }
 }
 
 /// Values that are (just under) a page multiple are stored framed: header in
-/// the batch's header area, value page aligned, verified from the index CRC.
+/// the batch's header area, value page aligned.
 #[test]
 fn framed_records_roundtrip_recover_and_reclaim() {
     let device = new_device(16);
-    let Opened { mut writer, reader, .. } = open(&device);
-    let mut ring = open_ring(&reader);
+    let (_engine, mut q, mut writer, mut reader) = setup(&device);
     let sizes = [4096usize, 4029, 8192, 12288, 16384 - 10, 65536 - 68];
     let mut expected = HashMap::new();
     for i in 0..300u128 {
         let len = sizes[i as usize % sizes.len()];
         let v = value_for(i, 0, len);
-        writer.put(id(i), &v, PutOptions::default()).unwrap();
+        put(&mut q, &mut writer, id(i), &v, PutOptions::default());
         expected.insert(i, v);
     }
     // An expiring page-sized value must not be framed (its expiry lives in the
@@ -1084,6 +1490,7 @@ fn framed_records_roundtrip_recover_and_reclaim() {
     let clockless = value_for(1000, 0, 4096);
     writer
         .put(
+            &mut q,
             id(1000),
             &clockless,
             PutOptions {
@@ -1092,70 +1499,83 @@ fn framed_records_roundtrip_recover_and_reclaim() {
             },
         )
         .unwrap();
-    writer.flush().unwrap();
+    flush(&mut q, &mut writer);
     for (i, v) in &expected {
-        assert_eq!(read(&mut ring, &id(*i)).unwrap(), *v, "key {i}");
+        assert_eq!(read(&mut q, &mut reader, &id(*i)).unwrap(), *v, "key {i}");
     }
-    assert_eq!(read(&mut ring, &id(1000)).unwrap(), clockless);
+    assert_eq!(read(&mut q, &mut reader, &id(1000)).unwrap(), clockless);
     // Range reads inside a framed value.
-    let got = ring.get_sync(&id(0), Some(100..300)).unwrap().unwrap();
+    let got = blocking::get(&mut q, &mut reader, &id(0), Some(100..300))
+        .unwrap()
+        .unwrap();
     assert_eq!(&*got, &expected[&0][100..300]);
 
     // Recovery from a mix of footers (sealed) and scan (active).
     drop(writer);
-    let Opened { mut writer, reader, .. } = open(&device);
-    let mut ring = open_ring(&reader);
+    drop(reader);
+    let (_engine, mut q, mut writer, mut reader) = setup(&device);
     for (i, v) in &expected {
-        assert_eq!(read(&mut ring, &id(*i)).unwrap(), *v, "key {i} after reopen");
+        assert_eq!(read(&mut q, &mut reader, &id(*i)).unwrap(), *v, "key {i} after reopen");
     }
 
     // Reclaim relocates framed records as framed records.
-    writer.seal_active().unwrap();
+    seal(&mut q, &mut writer);
     let mut relocated = 0;
     for _ in 0..4 {
-        if let Some(report) = writer.reclaim(ReclaimPolicy::Storage).unwrap() {
+        if let Some(report) = reclaim(&mut q, &mut writer, ReclaimPolicy::Storage) {
             relocated += report.relocated;
         }
     }
     assert!(relocated > 0);
     for (i, v) in &expected {
-        assert_eq!(read(&mut ring, &id(*i)).unwrap(), *v, "key {i} after reclaim");
+        assert_eq!(read(&mut q, &mut reader, &id(*i)).unwrap(), *v, "key {i} after reclaim");
     }
-    writer.close().unwrap();
-    let Opened { reader, report, .. } = open(&device);
-    let mut ring = open_ring(&reader);
+    close(&mut q, writer);
+    drop(reader);
+    let (engine, report) = moat_engine::open(device.clone(), options()).unwrap();
+    let mut q = queue();
+    let mut reader = engine.reader(&mut q).unwrap();
     assert_eq!(report.chunks, expected.len() + 1);
     for (i, v) in &expected {
-        assert_eq!(read(&mut ring, &id(*i)).unwrap(), *v, "key {i} after second reopen");
+        assert_eq!(
+            read(&mut q, &mut reader, &id(*i)).unwrap(),
+            *v,
+            "key {i} after second reopen"
+        );
     }
 }
 
 #[test]
-fn framed_corruption_is_caught_with_and_without_header() {
-    for strict in [false, true] {
+fn framed_corruption_obeys_read_verification_option() {
+    for verify_reads in [false, true] {
         let device = new_device(4);
-        let Opened { mut writer, reader, .. } = open_with(
+        let engine = open_with(
             &device,
             Options {
-                verify_header_on_read: strict,
+                verify_reads,
                 ..options()
             },
         );
-        let mut ring = open_ring(&reader);
+        let mut q = queue();
+        let mut writer = engine.writer(&mut q).unwrap();
+        let mut reader = engine.reader(&mut q).unwrap();
         let v = value_for(9, 0, 4096);
-        writer.put(id(9), &v, PutOptions::default()).unwrap();
-        writer.close().unwrap();
+        writer.put(&mut q, id(9), &v, PutOptions::default()).unwrap();
+        close(&mut q, writer);
         let pos = device
             .with_data(|d| d.windows(64).position(|w| w == &v[2000..2064]))
             .expect("value on disk");
         // The value starts on a page boundary: framed layout.
         assert_eq!((pos as u64 - 2000) % 4096, 0);
         device.with_data_mut(|d| d[pos + 100] ^= 1);
-        assert!(
-            matches!(ring.get_sync(&id(9), None), Err(Error::Corrupt(_))),
-            "strict={strict}"
-        );
-        assert!(ring.get_sync(&id(9), None).unwrap().is_none());
+        let result = blocking::get(&mut q, &mut reader, &id(9), None);
+        if verify_reads {
+            assert!(matches!(result, Err(Error::Corrupt(_))));
+        } else {
+            let mut damaged = v.clone();
+            damaged[2100] ^= 1;
+            assert_eq!(&*result.unwrap().unwrap(), damaged);
+        }
     }
 }
 
@@ -1164,15 +1584,15 @@ fn framed_corruption_is_caught_with_and_without_header() {
 #[test]
 fn small_records_never_straddle_unnecessarily() {
     let device = new_device(24);
-    let Opened { mut writer, reader, .. } = open(&device);
+    let (_engine, mut q, mut writer, reader) = setup(&device);
     let mut rng = XorShift(0x3333);
     let mut lens = Vec::new();
     for i in 0..500u128 {
         let len = (rng.below(60 << 10) as usize).max(16);
-        writer.put(id(i), &value_for(i, 0, len), PutOptions::default()).unwrap();
+        put(&mut q, &mut writer, id(i), &value_for(i, 0, len), PutOptions::default());
         lens.push(len);
     }
-    writer.flush().unwrap();
+    flush(&mut q, &mut writer);
     for (i, &len) in lens.iter().enumerate() {
         let stat = reader.stat(&id(i as u128)).unwrap();
         let meta = 68u64; // header + one block checksum
@@ -1192,4 +1612,199 @@ fn small_records_never_straddle_unnecessarily() {
             assert_eq!(spanned, (meta + len as u64).div_ceil(4096), "len {len} at {hdr_off}");
         }
     }
+}
+
+/// Room for the footer must account for records in batches that are enqueued
+/// but not yet applied; with many batches in flight at a segment boundary an
+/// undercount would let the footer spill into the next segment.
+#[test]
+fn footer_room_accounts_for_unapplied_batches() {
+    let device = new_device(12);
+    let engine = open(&device);
+    let opts = QueueOptions {
+        depth: 1024,
+        ..queue_options()
+    };
+    let mut q = SyncQueue::new(&opts, CompletionOrder::Fifo).unwrap();
+    let mut writer = engine.writer(&mut q).unwrap();
+    // Tiny values pack ~1,900 records into each 256 KiB staging batch, so a
+    // batch's footer share (~90 KiB) is what decides whether it fits; nothing
+    // is polled until the pool runs dry, so many batches are in flight when
+    // segments roll over.
+    let n = 30_000u128;
+    for i in 0..n {
+        put(&mut q, &mut writer, id(i), &value_for(i, 0, 64), PutOptions::default());
+    }
+    close(&mut q, writer);
+    let (engine, report) = moat_engine::open(device.clone(), options()).unwrap();
+    assert_eq!(report.unreadable_headers, 0);
+    assert_eq!(report.chunks, n as usize);
+    let mut q = queue();
+    let mut reader = engine.reader(&mut q).unwrap();
+    for i in (0..n).step_by(97) {
+        assert_eq!(
+            read(&mut q, &mut reader, &id(i)).unwrap(),
+            value_for(i, 0, 64),
+            "key {i}"
+        );
+    }
+}
+
+/// The pool, not the ring depth, is the back-pressure signal: a tiny ring is
+/// absorbed by the writer's and reader's ready queues.
+#[test]
+fn tiny_ring_depth_is_absorbed_by_ready_queues() {
+    let device = new_device(8);
+    let engine = open(&device);
+    let opts = QueueOptions {
+        depth: 2,
+        ..queue_options()
+    };
+    let mut q = SyncQueue::new(&opts, CompletionOrder::Reverse).unwrap();
+    let mut writer = engine.writer(&mut q).unwrap();
+    let mut reader = engine.reader(&mut q).unwrap();
+    let mut expected = HashMap::new();
+    for i in 0..30u128 {
+        let v = value_for(i, 0, 70_000);
+        writer.put(&mut q, id(i), &v, PutOptions::default()).unwrap();
+        expected.insert(i, v);
+    }
+    assert!(writer.in_flight() > 2, "most batches wait in the ready queue");
+    flush(&mut q, &mut writer);
+    let mut tokens = HashMap::new();
+    for i in expected.keys() {
+        assert_eq!(
+            reader.get(&mut q, &id(*i), None, *i as u64).unwrap(),
+            moat_engine::ReadOutcome::Submitted
+        );
+        tokens.insert(*i as u64, *i);
+    }
+    let mut out = Vec::new();
+    while !tokens.is_empty() {
+        q.poll(true).unwrap();
+        reader.poll(&mut q, &mut out).unwrap();
+        for c in out.drain(..) {
+            let i = tokens.remove(&c.token).unwrap();
+            assert_eq!(&*c.result.unwrap().unwrap(), &expected[&i][..]);
+        }
+    }
+    assert_eq!(reader.in_flight(), 0);
+}
+
+/// The load generator uses a per-disk FIFO for each homogeneous write phase.
+/// Device completion order must not change publication order for that phase.
+#[test]
+fn homogeneous_writes_publish_tickets_in_order() {
+    for len in [4096, 70_000] {
+        let device = new_device(8);
+        let engine = open(&device);
+        let mut q = SyncQueue::new(
+            &QueueOptions {
+                depth: 2,
+                ..queue_options()
+            },
+            CompletionOrder::Reverse,
+        )
+        .unwrap();
+        let mut writer = engine.writer(&mut q).unwrap();
+        let mut tickets = Vec::new();
+        for i in 0..32 {
+            let PutOutcome::Written { ticket, .. } = writer
+                .put(&mut q, id(i), &vec![0x5a; len], PutOptions::default())
+                .unwrap()
+            else {
+                panic!("new key must be written");
+            };
+            tickets.push(ticket);
+        }
+        let barrier = writer.flush(&mut q).unwrap();
+        let mut observed = Vec::new();
+        let mut done = Vec::new();
+        let mut flushed = false;
+        while !flushed {
+            q.poll(true).unwrap();
+            writer.poll(&mut q, &mut done).unwrap();
+            for completion in done.drain(..) {
+                completion.result.unwrap();
+                if completion.ticket == barrier {
+                    flushed = true;
+                } else {
+                    observed.push(completion.ticket);
+                }
+            }
+        }
+        assert_eq!(observed, tickets);
+    }
+}
+
+// Two 64 KiB batches fill each scan window exactly; the next window still
+// contains live records. Exercise both recovery and reclaim across that edge.
+fn check_scan_window_boundary(mode: &str) {
+    for order in [CompletionOrder::Fifo, CompletionOrder::Reverse] {
+        let device = Arc::new(MemDevice::new(SEGMENT * 5));
+        moat_engine::format(
+            &*device,
+            &FormatOptions {
+                chunk_max: 64 << 10,
+                ..format_options()
+            },
+        )
+        .unwrap();
+        let opts = Options {
+            pack_threshold: 32 << 10,
+            batch_limit: 128 << 10,
+            scan_window: 128 << 10,
+            ..options()
+        };
+        let expected: Vec<_> = (0..6).map(|i| value_for(i, 0, 60 << 10)).collect();
+        {
+            let (engine, _) = moat_engine::open(device.clone(), opts.clone()).unwrap();
+            let mut q = SyncQueue::new(&queue_options(), order).unwrap();
+            let mut writer = engine.writer(&mut q).unwrap();
+            for (i, value) in expected.iter().enumerate() {
+                put(&mut q, &mut writer, id(i as u128), value, PutOptions::default());
+            }
+            flush(&mut q, &mut writer);
+            if mode == "reclaim" {
+                seal(&mut q, &mut writer);
+                let report = reclaim(&mut q, &mut writer, ReclaimPolicy::Storage).unwrap();
+                assert_eq!(report.relocated, 6, "{mode}");
+                close(&mut q, writer);
+            } else if mode == "bad_footer" {
+                close(&mut q, writer);
+            }
+        }
+        if mode == "bad_footer" {
+            device.with_data_mut(|data| {
+                let pos = data.windows(8).position(|w| w == b"MOATFOT1").unwrap();
+                data[pos + 100] ^= 0xff;
+            });
+        }
+        let (engine, report) = moat_engine::open(device.clone(), opts).unwrap();
+        assert_eq!(report.chunks, 6, "{mode}");
+        let mut q = queue();
+        let mut reader = engine.reader(&mut q).unwrap();
+        for (i, value) in expected.iter().enumerate() {
+            assert_eq!(
+                read(&mut q, &mut reader, &id(i as u128)).as_ref(),
+                Some(value),
+                "{mode}"
+            );
+        }
+    }
+}
+
+#[test]
+fn scan_window_boundary_active_recovery() {
+    check_scan_window_boundary("active");
+}
+
+#[test]
+fn scan_window_boundary_footer_recovery() {
+    check_scan_window_boundary("bad_footer");
+}
+
+#[test]
+fn scan_window_boundary_reclaim() {
+    check_scan_window_boundary("reclaim");
 }

--- a/core/moat-server/Cargo.toml
+++ b/core/moat-server/Cargo.toml
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 [package]
-name = "moat-common"
-description = "Common types shared by all moat components: chunk identifiers, checksums, alignment helpers."
+name = "moat-server"
+description = "The chunkserver node: disk discovery, placement, worker threads that drive every disk's engine through one I/O queue."
 version.workspace = true
 edition.workspace = true
 repository.workspace = true
@@ -25,17 +25,21 @@ license.workspace = true
 readme.workspace = true
 rust-version.workspace = true
 
-[features]
-# `From` conversions between `ChunkId` and `uuid::Uuid`.
-uuid = ["dep:uuid"]
-
 [dependencies]
-crc-fast = { workspace = true }
 libc = { workspace = true }
-uuid = { workspace = true, optional = true }
+moat-common = { workspace = true }
+moat-engine = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
 
 [[bench]]
-name = "checksum"
+name = "node"
+harness = false
+
+[[bench]]
+name = "queue"
 harness = false
 
 [lints]

--- a/core/moat-server/benches/node.rs
+++ b/core/moat-server/benches/node.rs
@@ -1,0 +1,780 @@
+// Copyright 2026- Moat Project Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Whole-node throughput and latency: many disks, many pinned workers, one
+//! io_uring queue per worker, every worker reading every disk and each disk
+//! written by its owner. The load generator is a [`Handler`] on every worker,
+//! exactly where the network reactor will sit.
+//!
+//! ```sh
+//! # List the NVMe namespaces that would be used (nothing is written):
+//! cargo bench -p moat-server --bench node
+//! # Format them and run (destroys their contents!):
+//! MOAT_BENCH_FORMAT=yes cargo bench -p moat-server --bench node
+//! ```
+//!
+//! Disk selection: `MOAT_BENCH_DISKS` (comma-separated device or file paths;
+//! default: every NVMe namespace that is not partitioned, mounted, swap or
+//! under an md/dm holder, and at least `MOAT_BENCH_MIN_TB` TB, default 1).
+//! Every selected device is **formatted**; `MOAT_BENCH_FORMAT=yes` is
+//! required to go past the listing.
+//!
+//! Knobs: `MOAT_BENCH_BYTES` (bytes used per disk, default 64 GiB; a quarter
+//! per write workload), `MOAT_BENCH_WORKERS` (default: 4 per disk, bounded by
+//! cores), `MOAT_BENCH_CORES` (CPU list, default: every online CPU but the
+//! first two), `MOAT_BENCH_DEPTH` (queue depth, 1024), `MOAT_BENCH_POOL_MB`
+//! (pool per worker, 512), `MOAT_BENCH_LARGE` / `MOAT_BENCH_SMALL` (value
+//! sizes, 1 MiB / 4 KiB), `MOAT_BENCH_LARGE_INFLIGHT` (outstanding large reads
+//! per worker, 4), `MOAT_BENCH_INFLIGHT` (outstanding small reads per worker,
+//! comma-separated list, default 32), `MOAT_BENCH_WRITE_INFLIGHT` (outstanding
+//! large puts per owned disk, 64), `MOAT_BENCH_SMALL_WRITE_INFLIGHT`
+//! (outstanding small puts per owned disk; defaults to WRITE_INFLIGHT when
+//! explicitly set, otherwise 512), `MOAT_BENCH_WRITE_PREFETCH` (prefetch the
+//! index slot this many puts ahead, default 16; zero disables the hint),
+//! `MOAT_BENCH_SECONDS` (duration of each
+//! read phase, 10), `MOAT_BENCH_SYNC` (blocking queue instead of io_uring, for
+//! files), `MOAT_BENCH_SEGMENT_MB` (segment size, 1024), `MOAT_BENCH_REOPEN`
+//! (do not format or write; reopen the disks from a previous run with the same
+//! sizes and go straight to the read phases, for profiling),
+//! `MOAT_BENCH_WRITE_PHASES` (comma-separated large,small; both by default),
+//! `MOAT_BENCH_READ_PHASES` (comma-separated large,small; both by default),
+//! `MOAT_BENCH_REPORT_DISKS` (print per-disk phase completion counts and IOPS),
+//! `MOAT_BENCH_SHARD_READS` (assign each worker one disk, for locality comparisons),
+//! `MOAT_BENCH_WAIT_READS` (wait for I/O after refilling, for polling comparisons),
+//! Read and write latency histograms sample one in 16 operations.
+//! Default cores are spread across last-level caches, using SMT siblings last.
+//! Explicit `MOAT_BENCH_CORES` preserves the supplied order.
+//! `MOAT_BENCH_VERIFY` (enable header and value checksum verification on reads).
+//! `MOAT_BENCH_HUGE_PAGES` selects disabled, preferred (default), or required.
+//! `MOAT_BENCH_EXPECT_BACKING` checks each arena against plain, thp, 2m, or 1g;
+//! thp denotes advice acceptance, not proof of promotion. `MOAT_BENCH_REPORT_POOL`
+//! prints each worker's arena size and backing before its workload starts.
+
+#[path = "support/cpus.rs"]
+mod cpus;
+
+#[path = "support/pool.rs"]
+mod pool;
+
+use std::{
+    collections::{HashMap, VecDeque},
+    path::PathBuf,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
+    },
+    time::{Duration, Instant},
+};
+
+use moat_common::{ChunkId, PoolOptions, block_checksums};
+use moat_engine::{
+    Device, Error, FileDevice, FormatOptions, Options, PutOptions, PutOutcome, QueueOptions, ReadOutcome,
+};
+use moat_server::{Context, Handler, Node, PollMode, QueueBackend, Step, WorkerOptions, disk};
+
+fn env(name: &str, default: u64) -> u64 {
+    std::env::var(name).ok().and_then(|s| s.parse().ok()).unwrap_or(default)
+}
+
+fn env_list(name: &str) -> Option<Vec<String>> {
+    std::env::var(name).ok().map(|s| {
+        s.split(',')
+            .map(|v| v.trim().to_string())
+            .filter(|v| !v.is_empty())
+            .collect()
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Latency histogram: 16 buckets per power of two of nanoseconds.
+// ---------------------------------------------------------------------------
+
+const HIST_BUCKETS: usize = 64 * 16;
+
+#[derive(Clone)]
+struct Hist {
+    buckets: Vec<u64>,
+    count: u64,
+}
+
+impl Hist {
+    fn new() -> Self {
+        Self {
+            buckets: vec![0; HIST_BUCKETS],
+            count: 0,
+        }
+    }
+
+    fn record(&mut self, d: Duration) {
+        let ns = (d.as_nanos() as u64).max(1);
+        let exp = 63 - ns.leading_zeros() as usize;
+        let mant = if exp >= 4 { (ns >> (exp - 4)) & 0xf } else { 0 } as usize;
+        self.buckets[(exp << 4) | mant] += 1;
+        self.count += 1;
+    }
+
+    fn merge(&mut self, other: &Hist) {
+        for (a, b) in self.buckets.iter_mut().zip(&other.buckets) {
+            *a += b;
+        }
+        self.count += other.count;
+    }
+
+    fn percentile(&self, p: f64) -> Duration {
+        let target = ((self.count as f64 * p).ceil() as u64).max(1);
+        let mut seen = 0;
+        for (i, &n) in self.buckets.iter().enumerate() {
+            seen += n;
+            if seen >= target {
+                let (exp, mant) = (i >> 4, (i & 0xf) as u64);
+                let ns = if exp >= 4 {
+                    ((16 + mant) << (exp - 4)) + (1u64 << (exp - 4)) / 2
+                } else {
+                    1u64 << exp
+                };
+                return Duration::from_nanos(ns);
+            }
+        }
+        Duration::ZERO
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Phases
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Kind {
+    WriteLarge,
+    WriteSmall,
+    ReadLarge { inflight: usize },
+    ReadSmall { inflight: usize },
+}
+
+struct Plan {
+    large: usize,
+    small: usize,
+    write_inflight: usize,
+    small_write_inflight: usize,
+    write_prefetch: u64,
+    shard_reads: bool,
+    wait_reads: bool,
+    /// Values per disk in each size class.
+    large_count: u64,
+    small_count: u64,
+    phases: Vec<Kind>,
+}
+
+struct SharedState {
+    plan: Plan,
+    /// Index into `plan.phases`, or `phases.len()` to stop.
+    phase: AtomicUsize,
+    /// Workers that finished the current phase.
+    done: AtomicUsize,
+    /// Set by the driver to end a timed phase.
+    stop: AtomicBool,
+    ops: AtomicU64,
+    bytes: AtomicU64,
+    hist: Mutex<Hist>,
+    per_disk_ops: Vec<AtomicU64>,
+}
+
+fn key(kind: u128, disk: usize, i: u64) -> ChunkId {
+    ChunkId::from_u128((kind << 100) | ((disk as u128) << 64) | i as u128)
+}
+
+const LARGE_KEY: u128 = 1;
+const SMALL_KEY: u128 = 2;
+/// Phase index before the driver starts the first phase.
+const NOT_STARTED: usize = usize::MAX;
+
+struct Rng(u64);
+
+impl Rng {
+    fn next(&mut self) -> u64 {
+        self.0 ^= self.0 << 13;
+        self.0 ^= self.0 >> 7;
+        self.0 ^= self.0 << 17;
+        self.0
+    }
+}
+
+/// The load generator on one worker.
+struct Load {
+    shared: Arc<SharedState>,
+    seen_phase: Option<usize>,
+    finished_phase: bool,
+    rng: Rng,
+    // write state
+    write_cursor: Vec<u64>,
+    write_pending: Vec<VecDeque<(u64, Option<Instant>)>>,
+    write_outstanding: Vec<usize>,
+    // read state: outstanding reads by slot (the slot number is the token)
+    read_pending: Vec<Option<(usize, Option<Instant>)>>,
+    read_free: Vec<usize>,
+    read_outstanding: usize,
+    hist: Hist,
+    ops: u64,
+    bytes: u64,
+    per_disk: Vec<u64>,
+    pattern_large: Arc<Vec<u8>>,
+    sums_large: Arc<Vec<u32>>,
+    pattern_small: Arc<Vec<u8>>,
+}
+
+impl Load {
+    fn begin_phase(&mut self, cx: &mut Context<'_>, phase: usize) {
+        self.seen_phase = Some(phase);
+        self.finished_phase = false;
+        self.write_cursor = vec![0; cx.disks.len()];
+        self.write_pending = (0..cx.disks.len()).map(|_| VecDeque::new()).collect();
+        self.write_outstanding = vec![0; cx.disks.len()];
+        self.read_pending.clear();
+        self.read_free.clear();
+        self.read_outstanding = 0;
+        self.hist = Hist::new();
+        self.ops = 0;
+        self.bytes = 0;
+        self.per_disk = vec![0; cx.disks.len()];
+    }
+
+    fn finish_phase(&mut self) {
+        self.finished_phase = true;
+        let s = &self.shared;
+        s.ops.fetch_add(self.ops, Ordering::AcqRel);
+        s.bytes.fetch_add(self.bytes, Ordering::AcqRel);
+        for (d, n) in self.per_disk.iter().enumerate() {
+            s.per_disk_ops[d].fetch_add(*n, Ordering::AcqRel);
+        }
+        s.hist.lock().unwrap().merge(&self.hist);
+        s.done.fetch_add(1, Ordering::AcqRel);
+    }
+
+    fn run_write(&mut self, cx: &mut Context<'_>, large: bool) -> Step {
+        let inflight = if large {
+            self.shared.plan.write_inflight
+        } else {
+            self.shared.plan.small_write_inflight
+        };
+        let (len, count, kind) = if large {
+            (self.shared.plan.large, self.shared.plan.large_count, LARGE_KEY)
+        } else {
+            (self.shared.plan.small, self.shared.plan.small_count, SMALL_KEY)
+        };
+        for (disk, c) in cx.writes.drain(..) {
+            // Each phase writes one record class per disk. The writer applies
+            // those batches in order, so tracking needs no per-put hash lookup.
+            let (ticket, started) = self.write_pending[disk].pop_front().expect("known ticket");
+            assert_eq!(ticket, c.ticket);
+            self.write_outstanding[disk] -= 1;
+            c.result.unwrap();
+            if let Some(started) = started {
+                self.hist.record(started.elapsed());
+            }
+            self.ops += 1;
+            self.bytes += len as u64;
+            self.per_disk[disk] += 1;
+        }
+        let mut all_issued = true;
+        for disk in 0..cx.disks.len() {
+            if !cx.owns(disk) {
+                continue;
+            }
+            while self.write_cursor[disk] < count && self.write_outstanding[disk] < inflight {
+                let i = self.write_cursor[disk];
+                let id = key(kind, disk, i);
+                let (q, slot) = cx.disk(disk);
+                let w = slot.writer.as_mut().unwrap();
+                let ahead = self.shared.plan.write_prefetch;
+                if ahead > 0 && i.saturating_add(ahead) < count {
+                    w.prefetch(&key(kind, disk, i + ahead));
+                }
+                let outcome = if large {
+                    match w.prepare_large(q, len as u32) {
+                        Ok(mut v) => {
+                            v.value_mut().copy_from_slice(&self.pattern_large);
+                            w.put_large(q, id, v, Some(&self.sums_large), PutOptions::default())
+                        }
+                        Err(e) => Err(e),
+                    }
+                } else {
+                    w.put(q, id, &self.pattern_small, PutOptions::default())
+                };
+                match outcome {
+                    Ok(PutOutcome::Written { ticket, .. }) => {
+                        let started = ticket.is_multiple_of(16).then(Instant::now);
+                        self.write_pending[disk].push_back((ticket, started));
+                        self.write_outstanding[disk] += 1;
+                        self.write_cursor[disk] += 1;
+                    }
+                    Ok(PutOutcome::Exists) => self.write_cursor[disk] += 1,
+                    Err(Error::Busy) => {
+                        all_issued = false;
+                        break;
+                    }
+                    Err(e) => panic!("disk {disk}: {e}"),
+                }
+            }
+        }
+        if all_issued && self.write_outstanding.iter().all(|&n| n == 0) {
+            self.finish_phase();
+            return Step::Idle;
+        }
+        Step::Continue
+    }
+
+    fn run_read(&mut self, cx: &mut Context<'_>, large: bool, inflight: usize) -> Step {
+        let (len, count, kind) = if large {
+            (self.shared.plan.large, self.shared.plan.large_count, LARGE_KEY)
+        } else {
+            (self.shared.plan.small, self.shared.plan.small_count, SMALL_KEY)
+        };
+        for (disk, c) in cx.reads.drain(..) {
+            let slot = c.token as usize;
+            let (d, started) = self.read_pending[slot].take().expect("known token");
+            self.read_free.push(slot);
+            self.read_outstanding -= 1;
+            debug_assert_eq!(d, disk);
+            let data = c.result.unwrap().expect("not expired");
+            debug_assert_eq!(data.len(), len);
+            if let Some(started) = started {
+                self.hist.record(started.elapsed());
+            }
+            self.ops += 1;
+            self.bytes += len as u64;
+            self.per_disk[disk] += 1;
+        }
+        let stop = self.shared.stop.load(Ordering::Acquire);
+        if stop {
+            if self.read_outstanding == 0 {
+                self.finish_phase();
+                return Step::Idle;
+            }
+            return Step::Continue;
+        }
+        let disks = cx.disks.len();
+        while self.read_outstanding < inflight {
+            let r = self.rng.next();
+            let disk = if self.shared.plan.shard_reads {
+                cx.worker % disks
+            } else {
+                (r % disks as u64) as usize
+            };
+            let i = (r >> 20) % count;
+            let token = match self.read_free.pop() {
+                Some(s) => s,
+                None => {
+                    self.read_pending.push(None);
+                    self.read_pending.len() - 1
+                }
+            };
+            let (q, slot) = cx.disk(disk);
+            match slot.reader.get(q, &key(kind, disk, i), None, token as u64) {
+                Ok(ReadOutcome::Submitted) => {
+                    // Timestamps cost a vdso call each; sample one in 16.
+                    let started = (r >> 40).is_multiple_of(16).then(Instant::now);
+                    self.read_pending[token] = Some((disk, started));
+                    self.read_outstanding += 1;
+                }
+                Ok(ReadOutcome::Miss) => panic!("missing key {i} on disk {disk}"),
+                Err(Error::Busy) => {
+                    self.read_free.push(token);
+                    break;
+                }
+                Err(e) => panic!("{e}"),
+            }
+        }
+        if self.shared.plan.wait_reads {
+            cx.queue.poll(true).unwrap();
+        }
+        Step::Continue
+    }
+}
+
+impl Handler for Load {
+    fn start(&mut self, cx: &mut Context<'_>) {
+        pool::inspect(cx.queue.pool(), cx.worker);
+    }
+
+    fn run(&mut self, cx: &mut Context<'_>) -> Step {
+        let phase = self.shared.phase.load(Ordering::Acquire);
+        if phase == NOT_STARTED {
+            return Step::Idle;
+        }
+        if phase >= self.shared.plan.phases.len() {
+            return Step::Stop;
+        }
+        if self.seen_phase != Some(phase) {
+            self.begin_phase(cx, phase);
+        }
+        if self.finished_phase {
+            // Drain stragglers (none expected) and wait for the next phase.
+            cx.reads.clear();
+            cx.writes.clear();
+            return Step::Idle;
+        }
+        match self.shared.plan.phases[phase] {
+            Kind::WriteLarge => self.run_write(cx, true),
+            Kind::WriteSmall => self.run_write(cx, false),
+            Kind::ReadLarge { inflight } => self.run_read(cx, true, inflight),
+            Kind::ReadSmall { inflight } => self.run_read(cx, false, inflight),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Driver
+// ---------------------------------------------------------------------------
+
+struct Selected {
+    path: PathBuf,
+    label: String,
+    numa: Option<usize>,
+}
+
+fn select_disks() -> Vec<Selected> {
+    if let Some(paths) = env_list("MOAT_BENCH_DISKS") {
+        let known: HashMap<PathBuf, disk::NvmeDisk> = disk::discover()
+            .unwrap_or_default()
+            .into_iter()
+            .map(|d| (d.path.clone(), d))
+            .collect();
+        return paths
+            .into_iter()
+            .map(|p| {
+                let path = PathBuf::from(p);
+                match known.get(&path) {
+                    Some(d) => {
+                        assert!(
+                            d.is_available(),
+                            "{}: in use ({:?}); refusing to format",
+                            d.path.display(),
+                            d.in_use
+                        );
+                        Selected {
+                            label: format!(
+                                "{} serial={} model={} {:.1} TB",
+                                d.name,
+                                d.serial,
+                                d.model,
+                                tb(d.capacity)
+                            ),
+                            numa: d.numa_node,
+                            path,
+                        }
+                    }
+                    None => Selected {
+                        label: path.display().to_string(),
+                        numa: None,
+                        path,
+                    },
+                }
+            })
+            .collect();
+    }
+    let min_bytes = env("MOAT_BENCH_MIN_TB", 1) * 1_000_000_000_000;
+    disk::discover()
+        .expect("sysfs")
+        .into_iter()
+        .filter(|d| d.is_available() && d.capacity >= min_bytes)
+        .map(|d| Selected {
+            label: format!(
+                "{} serial={} model={} {:.1} TB",
+                d.name,
+                d.serial,
+                d.model,
+                tb(d.capacity)
+            ),
+            numa: d.numa_node,
+            path: d.path,
+        })
+        .collect()
+}
+
+fn tb(bytes: u64) -> f64 {
+    bytes as f64 / 1e12
+}
+
+fn gib_per_s(bytes: u64, elapsed: Duration) -> f64 {
+    bytes as f64 / elapsed.as_secs_f64() / (1u64 << 30) as f64
+}
+
+fn numa_of_cpus() -> HashMap<usize, usize> {
+    let mut map = HashMap::new();
+    for node in 0..64 {
+        let cpus = disk::cpus_of_node(node);
+        if cpus.is_empty() && node > 0 {
+            break;
+        }
+        for c in cpus {
+            map.insert(c, node);
+        }
+    }
+    map
+}
+
+fn main() {
+    let selected = select_disks();
+    println!("{} disk(s):", selected.len());
+    for s in &selected {
+        println!("  {}", s.label);
+    }
+    if selected.is_empty() {
+        return;
+    }
+    let sync = std::env::var_os("MOAT_BENCH_SYNC").is_some();
+    let reopen = std::env::var_os("MOAT_BENCH_REOPEN").is_some();
+    if !reopen && std::env::var("MOAT_BENCH_FORMAT").ok().as_deref() != Some("yes") {
+        println!("set MOAT_BENCH_FORMAT=yes to format these devices and run (destroys their contents)");
+        return;
+    }
+
+    let bytes = env("MOAT_BENCH_BYTES", 64 << 30);
+    let large = env("MOAT_BENCH_LARGE", 1 << 20) as usize;
+    let small = env("MOAT_BENCH_SMALL", 4 << 10) as usize;
+    let segment = env("MOAT_BENCH_SEGMENT_MB", 1024) << 20;
+    let seconds = env("MOAT_BENCH_SECONDS", 10);
+    let depth = env("MOAT_BENCH_DEPTH", 1024) as u32;
+    let pool_mb = env("MOAT_BENCH_POOL_MB", 512) as usize;
+    let large_inflight = env("MOAT_BENCH_LARGE_INFLIGHT", 4) as usize;
+    let write_inflight = env("MOAT_BENCH_WRITE_INFLIGHT", 64) as usize;
+    // One packed batch holds slightly fewer than 256 four-KiB values. Keep
+    // enough records outstanding to overlap several batches with encoding.
+    let small_write_inflight = env("MOAT_BENCH_SMALL_WRITE_INFLIGHT", env("MOAT_BENCH_WRITE_INFLIGHT", 512)) as usize;
+    assert!(write_inflight > 0 && small_write_inflight > 0);
+    let inflights: Vec<usize> = env_list("MOAT_BENCH_INFLIGHT")
+        .map(|l| l.iter().filter_map(|v| v.parse().ok()).collect())
+        .unwrap_or_else(|| vec![32]);
+    let budget = bytes / 4;
+    let large_count = budget / large as u64;
+    let small_count = budget / small as u64;
+
+    // Cores and workers.
+    let cores: Vec<usize> = env_list("MOAT_BENCH_CORES")
+        .map(|l| l.iter().flat_map(|s| disk::parse_cpu_list(s)).collect())
+        .unwrap_or_else(cpus::spread);
+    let workers = env("MOAT_BENCH_WORKERS", (selected.len() * 4) as u64) as usize;
+    let workers = workers.min(cores.len().max(1));
+    let numa = numa_of_cpus();
+    let worker_cores: Vec<Option<usize>> = (0..workers).map(|w| cores.get(w).copied()).collect();
+    let worker_numa: Vec<Option<usize>> = worker_cores
+        .iter()
+        .map(|c| c.and_then(|c| numa.get(&c).copied()))
+        .collect();
+
+    // Format and open every disk in parallel.
+    println!(
+        "{} {} disk(s): segment {} MiB, chunk max 4 MiB; using {} GiB per disk",
+        if reopen { "reopening" } else { "formatting" },
+        selected.len(),
+        segment >> 20,
+        bytes >> 30
+    );
+    let started = Instant::now();
+    let devices: Vec<Arc<dyn Device>> = selected
+        .iter()
+        .enumerate()
+        .map(|(i, s)| {
+            let path = s.path.clone();
+            std::thread::spawn(move || {
+                let device = FileDevice::open(&path, !sync).unwrap_or_else(|e| panic!("{}: {e}", path.display()));
+                if reopen {
+                    return Arc::new(device) as Arc<dyn Device>;
+                }
+                let mut uuid = [0u8; 16];
+                uuid[..8].copy_from_slice(&(i as u64 + 1).to_le_bytes());
+                uuid[8..].copy_from_slice(&0x6d6f_6174_6265_6e63u64.to_le_bytes());
+                moat_engine::format(
+                    &device,
+                    &FormatOptions {
+                        segment_size: segment,
+                        chunk_max: 4 << 20,
+                        disk_uuid: uuid,
+                    },
+                )
+                .unwrap_or_else(|e| panic!("{}: format: {e}", path.display()));
+                Arc::new(device) as Arc<dyn Device>
+            })
+        })
+        .collect::<Vec<_>>()
+        .into_iter()
+        .map(|h| h.join().unwrap())
+        .collect();
+    if !reopen {
+        println!("formatted in {:.1?}", started.elapsed());
+    }
+    let started = Instant::now();
+    let index_capacity = ((large_count + small_count) as usize * 2).next_power_of_two();
+    let verify_reads = std::env::var_os("MOAT_BENCH_VERIFY").is_some();
+    let mut node = Node::open(
+        devices,
+        Options {
+            index_capacity,
+            verify_reads,
+            ..Default::default()
+        },
+    )
+    .expect("open");
+    let disk_numa: Vec<Option<usize>> = selected.iter().map(|s| s.numa).collect();
+    node.assign_owners(workers, &disk_numa, &worker_numa);
+    println!("opened in {:.1?}; owners: {:?}", started.elapsed(), node.owners());
+    println!(
+        "{workers} worker(s) on cores {:?}, queue depth {depth}, pool {pool_mb} MiB/worker, io_uring={}, verify_reads={verify_reads}",
+        &cores[..workers.min(cores.len())],
+        !sync
+    );
+
+    let mut phases = Vec::new();
+    if !reopen {
+        let writes = env_list("MOAT_BENCH_WRITE_PHASES").unwrap_or_else(|| vec!["large".into(), "small".into()]);
+        if writes.iter().any(|p| p == "large") {
+            phases.push(Kind::WriteLarge);
+        }
+        if writes.iter().any(|p| p == "small") {
+            phases.push(Kind::WriteSmall);
+        }
+    }
+    let read_phases = env_list("MOAT_BENCH_READ_PHASES").unwrap_or_else(|| vec!["large".into(), "small".into()]);
+    if read_phases.iter().any(|p| p == "large") {
+        phases.push(Kind::ReadLarge {
+            inflight: large_inflight,
+        });
+    }
+    if read_phases.iter().any(|p| p == "small") {
+        phases.extend(inflights.iter().map(|&inflight| Kind::ReadSmall { inflight }));
+    }
+    let shared = Arc::new(SharedState {
+        plan: Plan {
+            large,
+            small,
+            write_inflight,
+            small_write_inflight,
+            write_prefetch: env("MOAT_BENCH_WRITE_PREFETCH", 16),
+            shard_reads: std::env::var_os("MOAT_BENCH_SHARD_READS").is_some(),
+            wait_reads: std::env::var_os("MOAT_BENCH_WAIT_READS").is_some(),
+            large_count,
+            small_count,
+            phases,
+        },
+        phase: AtomicUsize::new(NOT_STARTED),
+        done: AtomicUsize::new(0),
+        stop: AtomicBool::new(false),
+        ops: AtomicU64::new(0),
+        bytes: AtomicU64::new(0),
+        hist: Mutex::new(Hist::new()),
+        per_disk_ops: (0..node.engines().len()).map(|_| AtomicU64::new(0)).collect(),
+    });
+    let pattern_large: Arc<Vec<u8>> = Arc::new((0..large).map(|i| (i % 253) as u8).collect());
+    let sums_large = Arc::new(block_checksums(&pattern_large));
+    let pattern_small: Arc<Vec<u8>> = Arc::new((0..small).map(|i| (i % 251) as u8).collect());
+
+    let worker_opts: Vec<WorkerOptions> = (0..workers)
+        .map(|w| WorkerOptions {
+            core: worker_cores[w],
+            queue: QueueOptions {
+                depth,
+                pool: PoolOptions {
+                    bytes: pool_mb << 20,
+                    max_class: 8 << 20,
+                    huge_pages: pool::policy(),
+                },
+                descriptors: (node.engines().len() * 2 + 8) as u32,
+            },
+            backend: if sync { QueueBackend::Sync } else { QueueBackend::Uring },
+            poll_mode: PollMode::Busy,
+        })
+        .collect();
+    // Hold the phase index at "not started" until every worker is up.
+    let handles = node
+        .start(&worker_opts, |w| Load {
+            shared: shared.clone(),
+            seen_phase: None,
+            finished_phase: false,
+            rng: Rng(0x9e37_79b9_7f4a_7c15 ^ ((w as u64 + 1).wrapping_mul(0x1234_5678_9abc_def1))),
+            write_cursor: Vec::new(),
+            write_pending: Vec::new(),
+            write_outstanding: Vec::new(),
+            read_pending: Vec::new(),
+            read_free: Vec::new(),
+            read_outstanding: 0,
+            hist: Hist::new(),
+            ops: 0,
+            bytes: 0,
+            per_disk: Vec::new(),
+            pattern_large: pattern_large.clone(),
+            sums_large: sums_large.clone(),
+            pattern_small: pattern_small.clone(),
+        })
+        .expect("start workers");
+
+    let disks = node.engines().len();
+    for (p, kind) in shared.plan.phases.iter().enumerate() {
+        shared.done.store(0, Ordering::Release);
+        shared.stop.store(false, Ordering::Release);
+        shared.ops.store(0, Ordering::Release);
+        shared.bytes.store(0, Ordering::Release);
+        for d in &shared.per_disk_ops {
+            d.store(0, Ordering::Release);
+        }
+        *shared.hist.lock().unwrap() = Hist::new();
+        let start = Instant::now();
+        shared.phase.store(p, Ordering::Release);
+        let timed = matches!(kind, Kind::ReadLarge { .. } | Kind::ReadSmall { .. });
+        if timed {
+            std::thread::sleep(Duration::from_secs(seconds));
+            shared.stop.store(true, Ordering::Release);
+        }
+        while shared.done.load(Ordering::Acquire) < workers {
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        let elapsed = start.elapsed();
+        let ops = shared.ops.load(Ordering::Acquire);
+        let bytes = shared.bytes.load(Ordering::Acquire);
+        let hist = shared.hist.lock().unwrap().clone();
+        let per_disk: Vec<u64> = shared.per_disk_ops.iter().map(|d| d.load(Ordering::Acquire)).collect();
+        let (min, max) = (
+            per_disk.iter().copied().min().unwrap_or(0),
+            per_disk.iter().copied().max().unwrap_or(0),
+        );
+        let label = match kind {
+            Kind::WriteLarge => format!("put {} KiB x {large_count}/disk", large >> 10),
+            Kind::WriteSmall => format!("put {} KiB x {small_count}/disk", small >> 10),
+            Kind::ReadLarge { inflight } => format!("get {} KiB, {inflight}/worker", large >> 10),
+            Kind::ReadSmall { inflight } => format!("get {} KiB, {inflight}/worker", small >> 10),
+        };
+        println!(
+            "{label:<30} {:>8.2} GiB/s {:>12.0} ops/s  p50 {:>8.1?} p99 {:>8.1?} p999 {:>8.1?}  ({disks} disks, per-disk ops {min}..{max}, {elapsed:.1?})",
+            gib_per_s(bytes, elapsed),
+            ops as f64 / elapsed.as_secs_f64(),
+            hist.percentile(0.50),
+            hist.percentile(0.99),
+            hist.percentile(0.999),
+        );
+        if std::env::var_os("MOAT_BENCH_REPORT_DISKS").is_some() {
+            for (disk, count) in per_disk.iter().enumerate() {
+                println!(
+                    "disk-result phase={p} disk={disk} path={} ops={count} iops={:.0}",
+                    selected[disk].path.display(),
+                    *count as f64 / elapsed.as_secs_f64(),
+                );
+            }
+        }
+    }
+    shared.phase.store(shared.plan.phases.len(), Ordering::Release);
+    let started = Instant::now();
+    for h in handles {
+        h.join().expect("worker");
+    }
+    println!("shutdown (seal + detach) in {:.1?}", started.elapsed());
+}

--- a/core/moat-server/benches/queue.rs
+++ b/core/moat-server/benches/queue.rs
@@ -1,0 +1,272 @@
+// Copyright 2026- Moat Project Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Read-only isolation of the queue and checksum costs, without engine metadata.
+//!
+//! Reads existing data; never formats or writes. Select available NVMe data
+//! disks automatically, or provide MOAT_BENCH_DISKS. Knobs: WORKERS (80),
+//! CORES (online CPUs after the first two), DEPTH (1024), INFLIGHT (128),
+//! SECONDS (10), IO_BYTES (4096), SPAN (16 GiB), OFFSET (1 GiB), all prefixed
+//! with MOAT_BENCH_. SHARD_READS assigns one disk per worker. CHECKSUM performs
+//! the same per-64-KiB CRC work as an engine read but has no expected digest;
+//! this is a cost isolation experiment, not an integrity verification test.
+//! WAIT_READS waits for a completion instead of busy polling. CRC_PASSES (1)
+//! repeats the CRC work on each returned block to isolate arithmetic cost.
+//! MEMORY_ONLY requires CHECKSUM and repeatedly checks initialized pool buffers
+//! without issuing I/O; its throughput is memory processing, not disk I/O.
+//! CRC_SOURCE (io, hot, cold) selects the CRC input: the returned I/O buffer,
+//! a reused hot buffer, or a 128 MiB rotation per worker. The latter two are
+//! synthetic controls and never verify the returned I/O data. MEMORY_ONLY
+//! requires CRC_SOURCE=io; any non-io source requires CHECKSUM.
+//! Default cores are spread across shared caches, with SMT siblings last.
+//! POOL_MB (512) sets each worker's pool size. HUGE_PAGES accepts disabled,
+//! preferred (default), or required. EXPECT_BACKING accepts plain, thp, 2m,
+//! or 1g and rejects unexpected arena backing before timing; thp still needs
+//! a smaps audit to confirm promotion. REPORT_POOL prints arena backing.
+//! TOUCH_STRIDE (0, disabled) reads one byte per stride after each completed
+//! I/O, independently of CHECKSUM, to isolate cache-line access costs.
+
+#[cfg(target_os = "linux")]
+#[path = "support/cpus.rs"]
+mod cpus;
+
+#[cfg(target_os = "linux")]
+#[path = "support/pool.rs"]
+mod pool;
+
+#[cfg(target_os = "linux")]
+use moat_common::{PoolOptions, crc32c};
+#[cfg(target_os = "linux")]
+use moat_engine::{Device, FileDevice, IoQueue, QueueOptions};
+#[cfg(target_os = "linux")]
+use moat_server::{disk, worker::pin_to_core};
+#[cfg(target_os = "linux")]
+use std::{
+    hint::black_box,
+    sync::{Arc, Barrier},
+    time::{Duration, Instant},
+};
+
+#[cfg(target_os = "linux")]
+fn env(name: &str, default: u64) -> u64 {
+    std::env::var(name).ok().and_then(|s| s.parse().ok()).unwrap_or(default)
+}
+
+#[cfg(target_os = "linux")]
+fn main() {
+    let available = disk::discover().unwrap();
+    let selected: Vec<_> = match std::env::var("MOAT_BENCH_DISKS") {
+        Ok(paths) => paths
+            .split(',')
+            .map(|path| {
+                let found = available
+                    .iter()
+                    .find(|d| d.path.to_string_lossy() == path)
+                    .expect("known NVMe disk");
+                assert!(found.is_available(), "disk is in use");
+                found.clone()
+            })
+            .collect(),
+        Err(_) => available
+            .into_iter()
+            .filter(|d| d.is_available() && d.capacity >= 1_000_000_000_000)
+            .collect(),
+    };
+    assert!(!selected.is_empty());
+    let cores = std::env::var("MOAT_BENCH_CORES")
+        .map(|s| disk::parse_cpu_list(&s))
+        .unwrap_or_else(|_| cpus::spread());
+    let workers = env("MOAT_BENCH_WORKERS", 80) as usize;
+    assert!(workers > 0 && workers <= cores.len());
+    let bytes = env("MOAT_BENCH_IO_BYTES", 4096) as usize;
+    let span = env("MOAT_BENCH_SPAN", 16 << 30);
+    let offset = env("MOAT_BENCH_OFFSET", 1 << 30);
+    let inflight = env("MOAT_BENCH_INFLIGHT", 128) as usize;
+    let duration = Duration::from_secs(env("MOAT_BENCH_SECONDS", 10));
+    let shard = std::env::var_os("MOAT_BENCH_SHARD_READS").is_some();
+    let crc_source = std::env::var("MOAT_BENCH_CRC_SOURCE").unwrap_or_else(|_| "io".into());
+    assert!(["io", "hot", "cold"].contains(&crc_source.as_str()));
+    let control_bytes = match crc_source.as_str() {
+        "hot" => bytes,
+        "cold" => 128 << 20,
+        _ => 0,
+    };
+    let memory_only = std::env::var_os("MOAT_BENCH_MEMORY_ONLY").is_some();
+    let crc_passes = env("MOAT_BENCH_CRC_PASSES", 1);
+    let checksum = std::env::var_os("MOAT_BENCH_CHECKSUM").is_some();
+    let touch_stride = env("MOAT_BENCH_TOUCH_STRIDE", 0) as usize;
+    let wait = std::env::var_os("MOAT_BENCH_WAIT_READS").is_some();
+    assert!(crc_passes > 0 && (!memory_only || checksum));
+    assert!(crc_source == "io" || (checksum && !memory_only));
+    assert!(bytes > 0 && bytes.is_multiple_of(4096) && offset.is_multiple_of(4096));
+    assert!(span >= bytes as u64 && !duration.is_zero() && inflight > 0);
+    let devices: Vec<Arc<dyn Device>> = selected
+        .iter()
+        .map(|d| {
+            assert!(offset.checked_add(span).unwrap() <= d.capacity);
+            Arc::new(FileDevice::open(&d.path, true).unwrap()) as Arc<dyn Device>
+        })
+        .collect();
+    let options = QueueOptions {
+        depth: env("MOAT_BENCH_DEPTH", 1024) as u32,
+        descriptors: devices.len() as u32,
+        pool: PoolOptions {
+            bytes: (env("MOAT_BENCH_POOL_MB", 512) as usize) << 20,
+            max_class: 8 << 20,
+            huge_pages: pool::policy(),
+        },
+    };
+    assert!(bytes <= options.pool.max_class && inflight <= options.depth as usize);
+    let barrier = Arc::new(Barrier::new(workers));
+    let reports = std::thread::scope(|scope| {
+        let handles: Vec<_> = (0..workers)
+            .map(|worker| {
+                let barrier = barrier.clone();
+                let devices = &devices;
+                let core = cores[worker];
+                let crc_source = &crc_source;
+                scope.spawn(move || {
+                    pin_to_core(core).unwrap();
+                    let mut q = moat_engine::uring::UringQueue::new(&options).unwrap_or_else(|error| {
+                        // Peers may already be waiting at the startup barrier.
+                        eprintln!("queue setup failed on worker {worker}: {error}");
+                        std::process::exit(1);
+                    });
+                    pool::inspect(q.pool(), worker);
+                    let descs: Vec<_> = devices.iter().map(|d| q.attach(d).unwrap()).collect();
+                    let mut rng = 0x9e37_79b9_7f4a_7c15u64 ^ (worker as u64 + 1).wrapping_mul(0x1234_5678_9abc_def1);
+                    let mut done = Vec::new();
+                    let mut count = 0u64;
+                    let mut polls = 0u64;
+                    let mut empty_polls = 0u64;
+                    let mut outstanding_sum = 0u64;
+                    let control: Vec<_> = (0..control_bytes / bytes)
+                        .map(|_| {
+                            let mut buf = q.pool().alloc(bytes).unwrap();
+                            buf[..bytes].fill(0x5a);
+                            buf
+                        })
+                        .collect();
+                    let memory: Vec<_> = if memory_only {
+                        (0..inflight)
+                            .map(|_| {
+                                let mut buf = q.pool().alloc(bytes).expect("memory control fits pool");
+                                buf[..bytes].fill(0x5a);
+                                buf
+                            })
+                            .collect()
+                    } else {
+                        Vec::new()
+                    };
+                    barrier.wait();
+                    let start = Instant::now();
+                    loop {
+                        let stop = start.elapsed() >= duration;
+                        if memory_only {
+                            if stop {
+                                break;
+                            }
+                            for buf in &memory {
+                                check(&buf[..bytes], crc_passes);
+                                count += 1;
+                            }
+                            continue;
+                        }
+                        while !stop && q.in_flight() < inflight {
+                            let Some(buf) = q.pool().alloc(bytes) else { break };
+                            rng ^= rng << 13;
+                            rng ^= rng >> 7;
+                            rng ^= rng << 17;
+                            let d = if shard {
+                                worker % descs.len()
+                            } else {
+                                (rng % descs.len() as u64) as usize
+                            };
+                            let at = offset + ((rng >> 20) % (span / bytes as u64)) * bytes as u64;
+                            q.read(descs[d], buf, bytes, at, 0).unwrap();
+                        }
+                        if stop && q.in_flight() == 0 {
+                            break;
+                        }
+                        outstanding_sum += q.in_flight() as u64;
+                        let completed = q.poll(wait).unwrap();
+                        polls += 1;
+                        empty_polls += u64::from(completed == 0);
+                        for desc in &descs {
+                            q.take(*desc, &mut done);
+                        }
+                        for completion in done.drain(..) {
+                            assert_eq!(completion.result.unwrap(), bytes);
+                            let buf = completion.buf.unwrap();
+                            if touch_stride > 0 {
+                                for at in (0..bytes).step_by(touch_stride) {
+                                    black_box(buf[at]);
+                                }
+                            }
+                            if checksum {
+                                if crc_source == "io" {
+                                    check(&buf[..bytes], crc_passes);
+                                } else {
+                                    check(&control[count as usize % control.len()][..bytes], crc_passes);
+                                }
+                            }
+                            count += 1;
+                        }
+                    }
+                    let elapsed = start.elapsed();
+                    for desc in descs {
+                        q.detach(desc);
+                    }
+                    (count, elapsed, polls, empty_polls, outstanding_sum)
+                })
+            })
+            .collect();
+        handles.into_iter().map(|h| h.join().unwrap()).collect::<Vec<_>>()
+    });
+    let total: u64 = reports.iter().map(|r| r.0).sum();
+    let elapsed = reports.iter().map(|r| r.1).max().unwrap().as_secs_f64();
+    if memory_only {
+        println!(
+            "memory workers={workers} bytes={bytes} buffers={inflight} crc_passes={crc_passes} crc_source={crc_source}: {:.3} GB/s of payload, no device I/O",
+            total as f64 * bytes as f64 / elapsed / 1e9
+        );
+        return;
+    }
+    let polls: u64 = reports.iter().map(|r| r.2).sum();
+    let empty: u64 = reports.iter().map(|r| r.3).sum();
+    let outstanding: u64 = reports.iter().map(|r| r.4).sum();
+    println!(
+        "queue disks={} workers={workers} bytes={bytes} inflight={inflight} shard={shard} checksum={checksum} wait={wait} crc_passes={crc_passes} crc_source={crc_source} touch_stride={touch_stride}: {:.3} GB/s {:.0} IOPS, avg outstanding {:.1}, {:.1}% empty polls, {:.1} completions/poll",
+        devices.len(),
+        total as f64 * bytes as f64 / elapsed / 1e9,
+        total as f64 / elapsed,
+        outstanding as f64 / polls as f64,
+        empty as f64 * 100.0 / polls as f64,
+        total as f64 / polls as f64
+    );
+}
+
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    eprintln!("The io_uring queue benchmark requires Linux.");
+}
+
+#[cfg(target_os = "linux")]
+fn check(data: &[u8], passes: u64) {
+    for block in data.chunks(64 << 10) {
+        for _ in 0..passes {
+            black_box(crc32c(black_box(block)));
+        }
+    }
+}

--- a/core/moat-server/benches/support/cpus.rs
+++ b/core/moat-server/benches/support/cpus.rs
@@ -1,0 +1,78 @@
+// Copyright 2026- Moat Project Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! CPU ordering for the load generator: distribute work across shared caches
+//! before using more cores in the same cache, and use SMT siblings last.
+
+use std::{collections::BTreeMap, fs, path::Path};
+
+use moat_server::disk;
+
+pub fn spread() -> Vec<usize> {
+    let mut online = disk::online_cpus();
+    if online.len() > 2 {
+        online.drain(..2);
+    }
+    spread_in(Path::new("/sys/devices/system/cpu"), &online)
+}
+
+pub(super) fn spread_in(root: &Path, online: &[usize]) -> Vec<usize> {
+    let mut caches: BTreeMap<Vec<usize>, BTreeMap<Vec<usize>, Vec<usize>>> = BTreeMap::new();
+    for &cpu in online {
+        let dir = root.join(format!("cpu{cpu}"));
+        let siblings = fs::read_to_string(dir.join("topology/thread_siblings_list"))
+            .map(|s| disk::parse_cpu_list(&s))
+            .unwrap_or_else(|_| vec![cpu]);
+        let cache = fs::read_dir(dir.join("cache"))
+            .ok()
+            .into_iter()
+            .flatten()
+            .filter_map(Result::ok)
+            .filter_map(|entry| {
+                let path = entry.path();
+                let level = fs::read_to_string(path.join("level"))
+                    .ok()?
+                    .trim()
+                    .parse::<u32>()
+                    .ok()?;
+                let kind = fs::read_to_string(path.join("type")).ok()?;
+                if kind.trim() == "Instruction" {
+                    return None;
+                }
+                let shared = fs::read_to_string(path.join("shared_cpu_list")).ok()?;
+                Some((level, disk::parse_cpu_list(&shared)))
+            })
+            .max_by_key(|(level, _)| *level)
+            .map(|(_, cpus)| cpus)
+            .unwrap_or_else(|| online.to_vec());
+        caches.entry(cache).or_default().entry(siblings).or_default().push(cpu);
+    }
+    let groups: Vec<Vec<Vec<usize>>> = caches
+        .into_values()
+        .map(|cores| cores.into_values().collect())
+        .collect();
+    let cores = groups.iter().map(Vec::len).max().unwrap_or(0);
+    let siblings = groups.iter().flatten().map(Vec::len).max().unwrap_or(0);
+    let mut ordered = Vec::with_capacity(online.len());
+    for sibling in 0..siblings {
+        for core in 0..cores {
+            for group in &groups {
+                if let Some(&cpu) = group.get(core).and_then(|c| c.get(sibling)) {
+                    ordered.push(cpu);
+                }
+            }
+        }
+    }
+    ordered
+}

--- a/core/moat-server/benches/support/pool.rs
+++ b/core/moat-server/benches/support/pool.rs
@@ -1,0 +1,60 @@
+// Copyright 2026- Moat Project Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Pool controls shared by the device and engine benchmarks.
+
+use moat_common::{BufferPool, HugePages, arena::Backing};
+
+pub fn policy() -> HugePages {
+    match std::env::var("MOAT_BENCH_HUGE_PAGES").as_deref().unwrap_or("preferred") {
+        "disabled" => HugePages::Disabled,
+        "preferred" => HugePages::Preferred,
+        "required" => HugePages::Required,
+        other => panic!("unknown huge page policy: {other}"),
+    }
+}
+
+/// Check explicit backing before timing, so a fallback cannot masquerade as
+/// the intended experiment. THP promotion still needs an external smaps audit.
+pub fn inspect(pool: &BufferPool, worker: usize) {
+    let expected = std::env::var("MOAT_BENCH_EXPECT_BACKING")
+        .ok()
+        .map(|value| match value.as_str() {
+            "1g" => Backing::Huge1G,
+            "2m" => Backing::Huge2M,
+            "thp" => Backing::Transparent,
+            "plain" => Backing::Plain,
+            other => {
+                eprintln!("unknown expected arena backing: {other}");
+                std::process::exit(1);
+            }
+        });
+    if expected.is_some() || std::env::var_os("MOAT_BENCH_REPORT_POOL").is_some() {
+        for arena in pool.arenas() {
+            eprintln!(
+                "pool worker={worker} bytes={} backing={:?} base={:p}",
+                arena.len(),
+                arena.backing(),
+                arena.as_ptr()
+            );
+            if let Some(expected) = expected
+                && arena.backing() != expected
+            {
+                // A worker panic can strand peers at their startup barrier.
+                eprintln!("unexpected pool backing on worker {worker}: wanted {expected:?}");
+                std::process::exit(1);
+            }
+        }
+    }
+}

--- a/core/moat-server/src/disk.rs
+++ b/core/moat-server/src/disk.rs
@@ -1,0 +1,282 @@
+// Copyright 2026- Moat Project Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! NVMe disk discovery through sysfs.
+//!
+//! Disks are identified by controller serial and namespace, never by their
+//! `/dev/nvmeXnY` name, which changes across reboots. Discovery also reports
+//! whether a namespace is *in use* by something else (a partition table, an
+//! md or dm holder, a mount, swap): such disks are never data disks and a
+//! caller must not format them. This is how the system disk, typically an md
+//! RAID over two small NVMe drives, stays out of the data set.
+
+use std::{
+    fs, io,
+    path::{Path, PathBuf},
+};
+
+/// One NVMe namespace.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NvmeDisk {
+    /// Kernel block device name, e.g. `nvme3n1`.
+    pub name: String,
+    /// Device node, e.g. `/dev/nvme3n1`.
+    pub path: PathBuf,
+    /// Controller serial number (trimmed).
+    pub serial: String,
+    /// Controller model (trimmed).
+    pub model: String,
+    /// Capacity in bytes.
+    pub capacity: u64,
+    /// Logical block size in bytes.
+    pub block_size: u32,
+    /// NUMA node of the controller, if known.
+    pub numa_node: Option<usize>,
+    /// Why the disk is unavailable as a data disk, if it is.
+    pub in_use: Option<InUse>,
+}
+
+/// What claims a disk.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InUse {
+    /// The namespace is partitioned.
+    Partitioned,
+    /// A stacked device (md, dm) sits on top of it.
+    Holder(String),
+    /// A filesystem is mounted from it.
+    Mounted(String),
+    /// It is an active swap device.
+    Swap,
+}
+
+impl NvmeDisk {
+    /// Whether the disk may be used (and formatted) as a data disk.
+    pub fn is_available(&self) -> bool {
+        self.in_use.is_none()
+    }
+}
+
+fn read_trimmed(path: &Path) -> Option<String> {
+    fs::read_to_string(path).ok().map(|s| s.trim().to_string())
+}
+
+fn read_num<T: std::str::FromStr>(path: &Path) -> Option<T> {
+    read_trimmed(path)?.parse().ok()
+}
+
+/// Whether `name` is a whole NVMe namespace (`nvme<ctrl>n<ns>`, no partition).
+fn is_namespace(name: &str) -> bool {
+    let Some(rest) = name.strip_prefix("nvme") else {
+        return false;
+    };
+    let mut parts = rest.split('n');
+    let ctrl = parts.next().unwrap_or("");
+    let ns = parts.next().unwrap_or("");
+    parts.next().is_none()
+        && !ctrl.is_empty()
+        && !ns.is_empty()
+        && ctrl.chars().all(|c| c.is_ascii_digit())
+        && ns.chars().all(|c| c.is_ascii_digit())
+}
+
+/// Lists every NVMe namespace on the machine, in name order.
+pub fn discover() -> io::Result<Vec<NvmeDisk>> {
+    discover_in(Path::new("/sys/class/block"), Path::new("/proc"))
+}
+
+fn discover_in(block: &Path, proc: &Path) -> io::Result<Vec<NvmeDisk>> {
+    let mounts = fs::read_to_string(proc.join("mounts")).unwrap_or_default();
+    let swaps = fs::read_to_string(proc.join("swaps")).unwrap_or_default();
+    let mut disks = Vec::new();
+    let mut names: Vec<String> = fs::read_dir(block)?
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .filter(|n| is_namespace(n))
+        .collect();
+    names.sort_by_key(|a| natural_key(a));
+    for name in names {
+        let dir = block.join(&name);
+        let device = dir.join("device");
+        let sectors: u64 = read_num(&dir.join("size")).unwrap_or(0);
+        let block_size: u32 = read_num(&dir.join("queue/logical_block_size")).unwrap_or(512);
+        let path = PathBuf::from(format!("/dev/{name}"));
+        let in_use = in_use(&dir, &name, &path, &mounts, &swaps);
+        let numa_node = read_num::<i64>(&device.join("device/numa_node"))
+            .or_else(|| read_num::<i64>(&device.join("numa_node")))
+            .filter(|&n| n >= 0)
+            .map(|n| n as usize);
+        disks.push(NvmeDisk {
+            serial: read_trimmed(&device.join("serial")).unwrap_or_default(),
+            model: read_trimmed(&device.join("model")).unwrap_or_default(),
+            capacity: sectors * 512,
+            block_size,
+            numa_node,
+            in_use,
+            name,
+            path,
+        });
+    }
+    Ok(disks)
+}
+
+fn in_use(dir: &Path, name: &str, path: &Path, mounts: &str, swaps: &str) -> Option<InUse> {
+    if let Ok(entries) = fs::read_dir(dir)
+        && entries
+            .filter_map(|e| e.ok())
+            .any(|e| e.file_name().to_string_lossy().starts_with(&format!("{name}p")))
+    {
+        return Some(InUse::Partitioned);
+    }
+    if let Ok(mut holders) = fs::read_dir(dir.join("holders"))
+        && let Some(Ok(h)) = holders.next()
+    {
+        return Some(InUse::Holder(h.file_name().to_string_lossy().into_owned()));
+    }
+    let node = path.to_string_lossy();
+    for line in mounts.lines() {
+        let mut f = line.split_whitespace();
+        if let (Some(dev), Some(at)) = (f.next(), f.next())
+            && dev == node
+        {
+            return Some(InUse::Mounted(at.to_string()));
+        }
+    }
+    if swaps
+        .lines()
+        .skip(1)
+        .any(|l| l.split_whitespace().next() == Some(&*node))
+    {
+        return Some(InUse::Swap);
+    }
+    None
+}
+
+/// Sort key that orders `nvme2n1` before `nvme10n1`.
+fn natural_key(name: &str) -> Vec<u64> {
+    name.split(|c: char| !c.is_ascii_digit())
+        .filter(|s| !s.is_empty())
+        .filter_map(|s| s.parse().ok())
+        .collect()
+}
+
+/// The CPUs of NUMA node `node`, from sysfs. Empty if unknown.
+pub fn cpus_of_node(node: usize) -> Vec<usize> {
+    read_trimmed(Path::new(&format!("/sys/devices/system/node/node{node}/cpulist")))
+        .map(|s| parse_cpu_list(&s))
+        .unwrap_or_default()
+}
+
+/// The CPUs this process may run on.
+pub fn online_cpus() -> Vec<usize> {
+    // SAFETY: a zeroed cpu_set_t is a valid set for sched_getaffinity to fill.
+    unsafe {
+        let mut set: libc::cpu_set_t = std::mem::zeroed();
+        if libc::sched_getaffinity(0, std::mem::size_of::<libc::cpu_set_t>(), &mut set) != 0 {
+            return Vec::new();
+        }
+        (0..libc::CPU_SETSIZE as usize)
+            .filter(|&c| libc::CPU_ISSET(c, &set))
+            .collect()
+    }
+}
+
+/// Parses a kernel CPU list such as `0-3,8,10-11`.
+pub fn parse_cpu_list(s: &str) -> Vec<usize> {
+    let mut cpus = Vec::new();
+    for part in s.split(',').map(str::trim).filter(|p| !p.is_empty()) {
+        match part.split_once('-') {
+            Some((a, b)) => {
+                if let (Ok(a), Ok(b)) = (a.parse::<usize>(), b.parse::<usize>()) {
+                    cpus.extend(a..=b);
+                }
+            }
+            None => {
+                if let Ok(c) = part.parse() {
+                    cpus.push(c);
+                }
+            }
+        }
+    }
+    cpus
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn namespace_names() {
+        assert!(is_namespace("nvme0n1"));
+        assert!(is_namespace("nvme12n3"));
+        assert!(!is_namespace("nvme0n1p1"));
+        assert!(!is_namespace("nvme0"));
+        assert!(!is_namespace("sda"));
+        assert!(!is_namespace("nvme0c0n1"));
+    }
+
+    #[test]
+    fn cpu_lists_and_natural_order() {
+        assert_eq!(parse_cpu_list("0-3,8,10-11"), vec![0, 1, 2, 3, 8, 10, 11]);
+        assert_eq!(parse_cpu_list(""), Vec::<usize>::new());
+        let mut names = vec!["nvme10n1", "nvme2n1", "nvme1n2", "nvme1n1"];
+        names.sort_by_key(|n| natural_key(n));
+        assert_eq!(names, vec!["nvme1n1", "nvme1n2", "nvme2n1", "nvme10n1"]);
+    }
+
+    #[test]
+    fn discovery_from_a_fake_sysfs() {
+        let dir = tempfile::tempdir().unwrap();
+        let block = dir.path().join("block");
+        let proc = dir.path().join("proc");
+        fs::create_dir_all(&proc).unwrap();
+        for (name, serial, size, partitioned, holder) in [
+            ("nvme0n1", "S1", 1u64 << 30, false, false),
+            ("nvme1n1", "S2", 2u64 << 30, true, false),
+            ("nvme2n1", "S3", 3u64 << 30, false, true),
+            ("nvme3n1", "S4", 4u64 << 30, false, false),
+        ] {
+            let d = block.join(name);
+            fs::create_dir_all(d.join("device/device")).unwrap();
+            fs::create_dir_all(d.join("queue")).unwrap();
+            fs::create_dir_all(d.join("holders")).unwrap();
+            fs::write(d.join("size"), format!("{}\n", size / 512)).unwrap();
+            fs::write(d.join("queue/logical_block_size"), "4096\n").unwrap();
+            fs::write(d.join("device/serial"), format!("{serial}  \n")).unwrap();
+            fs::write(d.join("device/model"), "Test Drive\n").unwrap();
+            fs::write(d.join("device/device/numa_node"), "1\n").unwrap();
+            if partitioned {
+                fs::create_dir_all(d.join(format!("{name}p1"))).unwrap();
+            }
+            if holder {
+                fs::create_dir_all(d.join("holders/md0")).unwrap();
+            }
+        }
+        // A non-NVMe device and a partition entry must be ignored.
+        fs::create_dir_all(block.join("sda")).unwrap();
+        fs::create_dir_all(block.join("nvme1n1p1")).unwrap();
+        fs::write(proc.join("mounts"), "/dev/nvme3n1 /data ext4 rw 0 0\n").unwrap();
+        fs::write(proc.join("swaps"), "Filename Type Size Used Priority\n").unwrap();
+
+        let disks = discover_in(&block, &proc).unwrap();
+        assert_eq!(disks.len(), 4);
+        assert_eq!(disks[0].serial, "S1");
+        assert_eq!(disks[0].capacity, 1 << 30);
+        assert_eq!(disks[0].block_size, 4096);
+        assert_eq!(disks[0].numa_node, Some(1));
+        assert!(disks[0].is_available());
+        assert_eq!(disks[1].in_use, Some(InUse::Partitioned));
+        assert_eq!(disks[2].in_use, Some(InUse::Holder("md0".into())));
+        assert_eq!(disks[3].in_use, Some(InUse::Mounted("/data".into())));
+    }
+}

--- a/core/moat-server/src/lib.rs
+++ b/core/moat-server/src/lib.rs
@@ -1,0 +1,42 @@
+// Copyright 2026- Moat Project Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! The chunkserver node layer: many disks, one kind of worker.
+//!
+//! This crate turns a set of [`moat_engine::Engine`]s into a running node:
+//!
+//! - [`disk`] finds the machine's NVMe namespaces by serial and tells the
+//!   system disk (partitioned, mounted, or under an md/dm holder) apart from
+//!   data disks.
+//! - [`placement`] decides which disk a chunk lives on, deterministically and
+//!   without a table.
+//! - [`worker`] is the thread that owns one I/O queue and drives every disk
+//!   through it: a reader for each disk, the writer for each disk it owns,
+//!   and a pluggable [`worker::Handler`] as the source of requests.
+//! - [`node`] opens every disk in parallel, assigns owners and starts
+//!   workers.
+//!
+//! The network transport is not here yet; the handler abstraction is where it
+//! plugs in.
+
+pub mod disk;
+pub mod node;
+pub mod placement;
+pub mod worker;
+
+pub use node::{Node, NodeError};
+pub use placement::{Placement, Target};
+pub use worker::{
+    Context, DiskId, DiskSlot, Handler, PollMode, QueueBackend, Step, Worker, WorkerError, WorkerOptions,
+};

--- a/core/moat-server/src/node.rs
+++ b/core/moat-server/src/node.rs
@@ -1,0 +1,228 @@
+// Copyright 2026- Moat Project Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A node: the disks of one machine and the workers that drive them.
+//!
+//! Opening a node recovers every disk in parallel on temporary threads (the
+//! blocking part), assigns each disk an owner worker, and can then start any
+//! number of workers, each attached to every disk and holding the writers of
+//! the disks it owns.
+
+use std::{sync::Arc, thread};
+
+use moat_common::ChunkId;
+use moat_engine::{Device, Engine, Options, RecoveryReport};
+
+use crate::{
+    placement::{Placement, Target},
+    worker::{DiskId, Handler, Worker, WorkerError, WorkerOptions},
+};
+
+/// Errors from assembling a node.
+#[derive(Debug, thiserror::Error)]
+pub enum NodeError {
+    /// A disk failed to open.
+    #[error("disk {disk}: {source}")]
+    Open {
+        /// Index of the disk in the list passed to `open`.
+        disk: DiskId,
+        /// The cause.
+        #[source]
+        source: moat_engine::Error,
+    },
+    /// A worker failed to start.
+    #[error(transparent)]
+    Worker(#[from] WorkerError),
+    /// The node has no disks.
+    #[error("no disks")]
+    NoDisks,
+}
+
+/// The opened disks of a machine.
+pub struct Node {
+    engines: Vec<Engine>,
+    reports: Vec<RecoveryReport>,
+    owners: Vec<usize>,
+    placement: Placement,
+}
+
+impl Node {
+    /// Opens every device, all in parallel. `numa` gives each disk's NUMA
+    /// node when known; it only informs owner assignment.
+    pub fn open(devices: Vec<Arc<dyn Device>>, options: Options) -> Result<Self, NodeError> {
+        if devices.is_empty() {
+            return Err(NodeError::NoDisks);
+        }
+        let handles: Vec<_> = devices
+            .into_iter()
+            .map(|device| {
+                let options = options.clone();
+                thread::spawn(move || moat_engine::open(device, options))
+            })
+            .collect();
+        let mut engines = Vec::new();
+        let mut reports = Vec::new();
+        for (disk, h) in handles.into_iter().enumerate() {
+            let (engine, report) = h
+                .join()
+                .unwrap_or_else(|_| {
+                    Err(moat_engine::Error::Io(std::io::Error::other(
+                        "recovery thread panicked",
+                    )))
+                })
+                .map_err(|source| NodeError::Open { disk, source })?;
+            engines.push(engine);
+            reports.push(report);
+        }
+        let placement = Placement::new(
+            engines
+                .iter()
+                .map(|e| Target {
+                    uuid: e.disk_uuid(),
+                    weight: e.capacity(),
+                })
+                .collect(),
+        );
+        let owners = vec![0; engines.len()];
+        Ok(Self {
+            engines,
+            reports,
+            owners,
+            placement,
+        })
+    }
+
+    /// The engines, indexed by [`DiskId`].
+    pub fn engines(&self) -> &[Engine] {
+        &self.engines
+    }
+
+    /// What recovery found on each disk.
+    pub fn reports(&self) -> &[RecoveryReport] {
+        &self.reports
+    }
+
+    /// The worker that owns `disk` (holds its writer).
+    pub fn owner_of(&self, disk: DiskId) -> usize {
+        self.owners[disk]
+    }
+
+    /// The owner of every disk, indexed by [`DiskId`].
+    pub fn owners(&self) -> &[usize] {
+        &self.owners
+    }
+
+    /// The disk `id` is placed on.
+    pub fn disk_of(&self, id: &ChunkId) -> DiskId {
+        self.placement.disk_of(id).expect("a node has at least one disk")
+    }
+
+    /// The placement over this node's disks.
+    pub fn placement(&self) -> &Placement {
+        &self.placement
+    }
+
+    /// Assigns each disk to one of `workers` workers, spreading disks evenly
+    /// and preferring a worker on the disk's NUMA node when both `disk_numa`
+    /// (per disk) and `worker_numa` (per worker) are known.
+    pub fn assign_owners(&mut self, workers: usize, disk_numa: &[Option<usize>], worker_numa: &[Option<usize>]) {
+        assert!(workers > 0, "at least one worker");
+        let mut load = vec![0usize; workers];
+        for disk in 0..self.engines.len() {
+            let node = disk_numa.get(disk).copied().flatten();
+            let local = |w: usize| node.is_some() && worker_numa.get(w).copied().flatten() == node;
+            // Least loaded local worker, else least loaded worker.
+            let pick = (0..workers)
+                .filter(|&w| local(w))
+                .min_by_key(|&w| (load[w], w))
+                .or_else(|| (0..workers).min_by_key(|&w| (load[w], w)))
+                .expect("workers > 0");
+            self.owners[disk] = pick;
+            load[pick] += 1;
+        }
+    }
+
+    /// Sets the owner of every disk explicitly.
+    pub fn set_owners(&mut self, owners: Vec<usize>) {
+        assert_eq!(owners.len(), self.engines.len());
+        self.owners = owners;
+    }
+
+    /// Starts one worker per entry of `workers`, each attached to every disk
+    /// and owning the disks assigned to it, running the handler `make`
+    /// produces for it.
+    pub fn start<H: Handler>(
+        &self,
+        workers: &[WorkerOptions],
+        mut make: impl FnMut(usize) -> H,
+    ) -> Result<Vec<Worker<H>>, NodeError> {
+        let mut started = Vec::with_capacity(workers.len());
+        for (w, opts) in workers.iter().enumerate() {
+            let disks = self
+                .engines
+                .iter()
+                .enumerate()
+                .map(|(d, e)| (e.clone(), self.owners[d] == w))
+                .collect();
+            started.push(Worker::spawn(w, opts.clone(), disks, make(w))?);
+        }
+        Ok(started)
+    }
+}
+
+impl std::fmt::Debug for Node {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Node")
+            .field("disks", &self.engines.len())
+            .field("owners", &self.owners)
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn owner_assignment_prefers_numa_and_balances() {
+        let devices: Vec<Arc<dyn Device>> = (0..4)
+            .map(|_| {
+                let d = moat_engine::MemDevice::new(4 << 20);
+                moat_engine::format(
+                    &d,
+                    &moat_engine::FormatOptions {
+                        segment_size: 1 << 20,
+                        chunk_max: 64 << 10,
+                        disk_uuid: [1; 16],
+                    },
+                )
+                .unwrap();
+                Arc::new(d) as Arc<dyn Device>
+            })
+            .collect();
+        let mut node = Node::open(
+            devices,
+            Options {
+                index_capacity: 64,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        // Disks 0,1 on node 0; 2,3 on node 1. Workers 0,1 on node 0; 2 on 1.
+        node.assign_owners(3, &[Some(0), Some(0), Some(1), Some(1)], &[Some(0), Some(0), Some(1)]);
+        assert_eq!(node.owners(), &[0, 1, 2, 2]);
+        node.assign_owners(2, &[None; 4], &[None; 2]);
+        assert_eq!(node.owners(), &[0, 1, 0, 1]);
+    }
+}

--- a/core/moat-server/src/node.rs
+++ b/core/moat-server/src/node.rs
@@ -58,8 +58,8 @@ pub struct Node {
 }
 
 impl Node {
-    /// Opens every device, all in parallel. `numa` gives each disk's NUMA
-    /// node when known; it only informs owner assignment.
+    /// Opens every device in parallel. Use [`Self::assign_owners`] to assign
+    /// disks to workers after recovery.
     pub fn open(devices: Vec<Arc<dyn Device>>, options: Options) -> Result<Self, NodeError> {
         if devices.is_empty() {
             return Err(NodeError::NoDisks);
@@ -71,17 +71,22 @@ impl Node {
                 thread::spawn(move || moat_engine::open(device, options))
             })
             .collect();
-        let mut engines = Vec::new();
-        let mut reports = Vec::new();
-        for (disk, h) in handles.into_iter().enumerate() {
-            let (engine, report) = h
-                .join()
-                .unwrap_or_else(|_| {
+        // Join every recovery thread before propagating an error: no disk
+        // should still be recovering after `open` has returned to its caller.
+        let recovered: Vec<_> = handles
+            .into_iter()
+            .map(|h| {
+                h.join().unwrap_or_else(|_| {
                     Err(moat_engine::Error::Io(std::io::Error::other(
                         "recovery thread panicked",
                     )))
                 })
-                .map_err(|source| NodeError::Open { disk, source })?;
+            })
+            .collect();
+        let mut engines = Vec::new();
+        let mut reports = Vec::new();
+        for (disk, result) in recovered.into_iter().enumerate() {
+            let (engine, report) = result.map_err(|source| NodeError::Open { disk, source })?;
             engines.push(engine);
             reports.push(report);
         }
@@ -193,6 +198,31 @@ impl std::fmt::Debug for Node {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn recovery_error_does_not_leave_other_devices_open() {
+        let bad = Arc::new(moat_engine::MemDevice::new(4 << 20));
+        let good = Arc::new(moat_engine::MemDevice::new(4 << 20));
+        moat_engine::format(
+            &*good,
+            &moat_engine::FormatOptions {
+                segment_size: 1 << 20,
+                chunk_max: 64 << 10,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let result = Node::open(
+            vec![bad.clone(), good.clone()],
+            Options {
+                index_capacity: 64,
+                ..Default::default()
+            },
+        );
+        assert!(matches!(result, Err(NodeError::Open { disk: 0, .. })));
+        assert_eq!(Arc::strong_count(&bad), 1);
+        assert_eq!(Arc::strong_count(&good), 1);
+    }
 
     #[test]
     fn owner_assignment_prefers_numa_and_balances() {

--- a/core/moat-server/src/placement.rs
+++ b/core/moat-server/src/placement.rs
@@ -1,0 +1,157 @@
+// Copyright 2026- Moat Project Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Deterministic placement of chunks on disks.
+//!
+//! Weighted rendezvous hashing: every disk scores a chunk from the chunk
+//! identifier and the disk's own identity, scaled by the disk's weight
+//! (capacity), and the highest score wins. There is no table and no state;
+//! adding or removing a disk moves only the keys that land on it, and every
+//! node computes the same answer from the same disk list.
+
+use moat_common::ChunkId;
+
+/// A disk that can hold chunks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Target {
+    /// The disk's identity (its superblock uuid).
+    pub uuid: [u8; 16],
+    /// Relative weight, typically the capacity in bytes. Zero excludes the
+    /// disk.
+    pub weight: u64,
+}
+
+/// A fixed set of disks to place chunks on.
+#[derive(Debug, Clone)]
+pub struct Placement {
+    targets: Vec<Target>,
+    seeds: Vec<u64>,
+}
+
+impl Placement {
+    /// Builds a placement over `targets`; the index into this list is what
+    /// [`Placement::disk_of`] returns.
+    pub fn new(targets: Vec<Target>) -> Self {
+        let seeds = targets
+            .iter()
+            .map(|t| {
+                let lo = u64::from_le_bytes(t.uuid[..8].try_into().expect("8 bytes"));
+                let hi = u64::from_le_bytes(t.uuid[8..].try_into().expect("8 bytes"));
+                mix(lo ^ mix(hi ^ 0x6a09_e667_f3bc_c909))
+            })
+            .collect();
+        Self { targets, seeds }
+    }
+
+    /// The targets, in index order.
+    pub fn targets(&self) -> &[Target] {
+        &self.targets
+    }
+
+    /// Number of targets.
+    pub fn len(&self) -> usize {
+        self.targets.len()
+    }
+
+    /// Whether there are no targets.
+    pub fn is_empty(&self) -> bool {
+        self.targets.is_empty()
+    }
+
+    /// The disk `id` belongs on, or `None` if every target has zero weight.
+    pub fn disk_of(&self, id: &ChunkId) -> Option<usize> {
+        let key = id.mix();
+        let mut best: Option<(usize, f64)> = None;
+        for (i, (t, seed)) in self.targets.iter().zip(&self.seeds).enumerate() {
+            if t.weight == 0 {
+                continue;
+            }
+            // A uniform draw in (0, 1] per (chunk, disk), scaled by weight:
+            // the classic weighted rendezvous score.
+            let h = mix(key ^ seed);
+            let u = ((h >> 11) as f64 + 1.0) / ((1u64 << 53) as f64 + 1.0);
+            let score = -(t.weight as f64) / u.ln();
+            if best.is_none_or(|(_, s)| score > s) {
+                best = Some((i, score));
+            }
+        }
+        best.map(|(i, _)| i)
+    }
+}
+
+/// SplitMix64 finalizer.
+#[inline]
+fn mix(mut z: u64) -> u64 {
+    z = z.wrapping_add(0x9E37_79B9_7F4A_7C15);
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    z ^ (z >> 31)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn targets(n: usize, weight: impl Fn(usize) -> u64) -> Vec<Target> {
+        (0..n)
+            .map(|i| Target {
+                uuid: [i as u8 + 1; 16],
+                weight: weight(i),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn spreads_evenly_and_respects_weights() {
+        let p = Placement::new(targets(8, |_| 1));
+        let mut counts = [0u32; 8];
+        for i in 0..80_000u128 {
+            counts[p.disk_of(&ChunkId::from_u128(i * 7919)).unwrap()] += 1;
+        }
+        for c in counts {
+            assert!((9_000..11_000).contains(&c), "{counts:?}");
+        }
+
+        let p = Placement::new(targets(2, |i| if i == 0 { 1 } else { 3 }));
+        let mut counts = [0u32; 2];
+        for i in 0..40_000u128 {
+            counts[p.disk_of(&ChunkId::from_u128(i)).unwrap()] += 1;
+        }
+        let ratio = counts[1] as f64 / counts[0] as f64;
+        assert!((2.6..3.4).contains(&ratio), "{counts:?}");
+    }
+
+    #[test]
+    fn removing_a_disk_moves_only_its_keys() {
+        let all = Placement::new(targets(10, |_| 1));
+        let mut fewer = targets(10, |_| 1);
+        fewer[3].weight = 0;
+        let fewer = Placement::new(fewer);
+        let mut moved = 0;
+        for i in 0..20_000u128 {
+            let id = ChunkId::from_u128(i);
+            let (a, b) = (all.disk_of(&id).unwrap(), fewer.disk_of(&id).unwrap());
+            if a != b {
+                assert_eq!(a, 3, "only keys of the removed disk move");
+                moved += 1;
+            }
+        }
+        assert!((1_500..2_500).contains(&moved), "{moved}");
+        assert!(
+            Placement::new(targets(2, |_| 0))
+                .disk_of(&ChunkId::from_u128(1))
+                .is_none()
+        );
+    }
+}

--- a/core/moat-server/src/worker.rs
+++ b/core/moat-server/src/worker.rs
@@ -1,0 +1,379 @@
+// Copyright 2026- Moat Project Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Worker threads.
+//!
+//! A node runs one kind of worker. Every worker is pinned to a core and owns
+//! exactly one [`IoQueue`] (io_uring, one registered buffer pool, one
+//! fixed-file table) through which it drives every disk: it holds a
+//! [`Reader`] for each disk, so a read is served on the worker that receives
+//! the request, and a [`Writer`] for each disk it *owns*, so each disk's log
+//! has a single writer. The loop is the same on every worker; owning a disk
+//! only means more `Writer` calls on it.
+//!
+//! What the worker does not know is where requests come from. That is the
+//! [`Handler`]: the network reactor in a server, a load generator in a
+//! benchmark, a script in a test. It runs once per loop iteration on the
+//! worker thread, sees the completions the queue delivered since the last
+//! iteration, and issues new operations through the [`Context`]. Nothing here
+//! blocks except the queue's own wait, and only when the worker has nothing
+//! else to do.
+
+use std::{
+    io,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+        mpsc,
+    },
+    thread::{self, JoinHandle},
+    time::Duration,
+};
+
+use moat_engine::{
+    Completion, Engine, IoQueue, QueueOptions, ReadCompletion, Reader, Writer, blocking,
+    io::{CompletionOrder, SyncQueue},
+};
+
+/// Index of a disk in a node's disk list.
+pub type DiskId = usize;
+
+/// How the worker behaves when it has nothing to do.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PollMode {
+    /// Spin: the lowest latency, one core per worker.
+    Busy,
+    /// Wait for I/O when some is in flight; sleep `idle_sleep` otherwise. For
+    /// deployments that cannot dedicate cores.
+    Adaptive {
+        /// How long to sleep when neither I/O nor requests are pending.
+        idle_sleep: Duration,
+    },
+}
+
+/// Which [`IoQueue`] implementation a worker builds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QueueBackend {
+    /// io_uring (Linux). Devices must expose a file descriptor.
+    Uring,
+    /// The blocking queue; works with any device, used by tests and tools.
+    Sync,
+}
+
+/// Configuration of one worker.
+#[derive(Debug, Clone)]
+pub struct WorkerOptions {
+    /// Core to pin the thread to; `None` leaves scheduling to the OS.
+    pub core: Option<usize>,
+    /// The worker's queue: depth, pool, descriptor table.
+    pub queue: QueueOptions,
+    /// Queue implementation.
+    pub backend: QueueBackend,
+    /// Idle behaviour.
+    pub poll_mode: PollMode,
+}
+
+impl Default for WorkerOptions {
+    fn default() -> Self {
+        Self {
+            core: None,
+            queue: QueueOptions::default(),
+            backend: QueueBackend::Uring,
+            poll_mode: PollMode::Busy,
+        }
+    }
+}
+
+/// What a [`Handler::run`] call reports back to the loop.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Step {
+    /// Work was done or is pending; loop again at once.
+    Continue,
+    /// Nothing to do until I/O completes or new requests arrive.
+    Idle,
+    /// Shut the worker down after this iteration.
+    Stop,
+}
+
+/// One disk as seen from a worker: its engine, this worker's read pipeline,
+/// and the write pipeline if this worker owns the disk.
+pub struct DiskSlot {
+    /// The disk.
+    pub engine: Engine,
+    /// This worker's reader for the disk.
+    pub reader: Reader,
+    /// The disk's writer, present on its owner only.
+    pub writer: Option<Writer>,
+}
+
+/// What a [`Handler`] sees on each iteration.
+pub struct Context<'a> {
+    /// Index of this worker in the node.
+    pub worker: usize,
+    /// The worker's queue; pass it to every engine call.
+    pub queue: &'a mut dyn IoQueue,
+    /// Every disk, indexed by [`DiskId`].
+    pub disks: &'a mut [DiskSlot],
+    /// Read completions delivered since the last iteration, tagged by disk.
+    /// The handler drains them.
+    pub reads: &'a mut Vec<(DiskId, ReadCompletion)>,
+    /// Write completions delivered since the last iteration, tagged by disk.
+    /// The handler drains them.
+    pub writes: &'a mut Vec<(DiskId, Completion)>,
+}
+
+impl Context<'_> {
+    /// Whether this worker owns `disk` (holds its writer).
+    pub fn owns(&self, disk: DiskId) -> bool {
+        self.disks[disk].writer.is_some()
+    }
+
+    /// The queue and the slot of `disk`, borrowed together so the handler can
+    /// call `slot.reader.get(queue, ..)` or `slot.writer.put(queue, ..)`.
+    pub fn disk(&mut self, disk: DiskId) -> (&mut dyn IoQueue, &mut DiskSlot) {
+        (self.queue, &mut self.disks[disk])
+    }
+}
+
+/// The request source of a worker. See the [module docs](self).
+pub trait Handler: Send + 'static {
+    /// Called once on the worker thread before the loop starts, with every
+    /// pipeline attached.
+    fn start(&mut self, _cx: &mut Context<'_>) {}
+
+    /// Called once per loop iteration, after completions were collected.
+    fn run(&mut self, cx: &mut Context<'_>) -> Step;
+
+    /// Called once on the worker thread after the loop ends, before the
+    /// writers are sealed and detached.
+    fn stop(&mut self, _cx: &mut Context<'_>) {}
+}
+
+/// Errors from a worker thread.
+#[derive(Debug, thiserror::Error)]
+pub enum WorkerError {
+    /// The queue or a pipeline could not be set up, or the queue failed.
+    #[error("worker {worker}: {source}")]
+    Io {
+        /// The worker index.
+        worker: usize,
+        /// The cause.
+        #[source]
+        source: io::Error,
+    },
+    /// An engine call failed during setup or shutdown.
+    #[error("worker {worker}: {source}")]
+    Engine {
+        /// The worker index.
+        worker: usize,
+        /// The cause.
+        #[source]
+        source: moat_engine::Error,
+    },
+    /// The handler panicked; the worker thread is gone.
+    #[error("worker {0} panicked")]
+    Panicked(usize),
+}
+
+/// A running worker thread.
+pub struct Worker<H: Handler> {
+    index: usize,
+    stop: Arc<AtomicBool>,
+    thread: Option<JoinHandle<Result<H, WorkerError>>>,
+}
+
+impl<H: Handler> Worker<H> {
+    /// Starts worker `index`: pins it, builds its queue, attaches a reader for
+    /// every engine in `disks` and a writer for those flagged as owned, then
+    /// runs `handler`. Returns once the pipelines are attached, so setup
+    /// errors are reported here rather than at `join`.
+    pub fn spawn(
+        index: usize,
+        opts: WorkerOptions,
+        disks: Vec<(Engine, bool)>,
+        handler: H,
+    ) -> Result<Self, WorkerError> {
+        let stop = Arc::new(AtomicBool::new(false));
+        let (ready_tx, ready_rx) = mpsc::channel::<Result<(), WorkerError>>();
+        let stop_flag = stop.clone();
+        let thread = thread::Builder::new()
+            .name(format!("moat-worker-{index}"))
+            .spawn(move || run_worker(index, opts, disks, handler, stop_flag, ready_tx))
+            .map_err(|source| WorkerError::Io { worker: index, source })?;
+        match ready_rx.recv() {
+            Ok(Ok(())) => Ok(Self {
+                index,
+                stop,
+                thread: Some(thread),
+            }),
+            Ok(Err(e)) => {
+                let _ = thread.join();
+                Err(e)
+            }
+            Err(_) => {
+                let _ = thread.join();
+                Err(WorkerError::Panicked(index))
+            }
+        }
+    }
+
+    /// The worker's index.
+    pub fn index(&self) -> usize {
+        self.index
+    }
+
+    /// Asks the worker to stop after its current iteration.
+    pub fn stop(&self) {
+        self.stop.store(true, Ordering::Release);
+    }
+
+    /// Waits for the worker to finish and returns its handler.
+    pub fn join(mut self) -> Result<H, WorkerError> {
+        let thread = self.thread.take().expect("joined once");
+        thread.join().map_err(|_| WorkerError::Panicked(self.index))?
+    }
+}
+
+impl<H: Handler> Drop for Worker<H> {
+    fn drop(&mut self) {
+        if let Some(t) = self.thread.take() {
+            self.stop.store(true, Ordering::Release);
+            let _ = t.join();
+        }
+    }
+}
+
+/// Pins the calling thread to `core`.
+pub fn pin_to_core(core: usize) -> io::Result<()> {
+    // SAFETY: a zeroed cpu_set_t is a valid empty set; CPU_SET writes within
+    // its bounds for any core below CPU_SETSIZE, which we check.
+    unsafe {
+        let mut set: libc::cpu_set_t = std::mem::zeroed();
+        if core >= libc::CPU_SETSIZE as usize {
+            return Err(io::Error::new(io::ErrorKind::InvalidInput, "core out of range"));
+        }
+        libc::CPU_SET(core, &mut set);
+        if libc::sched_setaffinity(0, std::mem::size_of::<libc::cpu_set_t>(), &set) != 0 {
+            return Err(io::Error::last_os_error());
+        }
+    }
+    Ok(())
+}
+
+fn build_queue(opts: &WorkerOptions) -> io::Result<Box<dyn IoQueue>> {
+    match opts.backend {
+        QueueBackend::Sync => Ok(Box::new(SyncQueue::new(&opts.queue, CompletionOrder::Fifo)?)),
+        #[cfg(target_os = "linux")]
+        QueueBackend::Uring => Ok(Box::new(moat_engine::uring::UringQueue::new(&opts.queue)?)),
+        #[cfg(not(target_os = "linux"))]
+        QueueBackend::Uring => Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "io_uring is only available on Linux",
+        )),
+    }
+}
+
+fn run_worker<H: Handler>(
+    index: usize,
+    opts: WorkerOptions,
+    disks: Vec<(Engine, bool)>,
+    mut handler: H,
+    stop: Arc<AtomicBool>,
+    ready: mpsc::Sender<Result<(), WorkerError>>,
+) -> Result<H, WorkerError> {
+    let io_err = |source| WorkerError::Io { worker: index, source };
+    let engine_err = |source| WorkerError::Engine { worker: index, source };
+
+    let setup = || -> Result<(Box<dyn IoQueue>, Vec<DiskSlot>), WorkerError> {
+        if let Some(core) = opts.core {
+            pin_to_core(core).map_err(io_err)?;
+        }
+        let mut queue = build_queue(&opts).map_err(io_err)?;
+        let mut slots = Vec::with_capacity(disks.len());
+        for (engine, owner) in disks {
+            let reader = engine.reader(&mut *queue).map_err(engine_err)?;
+            let writer = if owner {
+                Some(engine.writer(&mut *queue).map_err(engine_err)?)
+            } else {
+                None
+            };
+            slots.push(DiskSlot { engine, reader, writer });
+        }
+        Ok((queue, slots))
+    };
+    let (mut queue, mut slots) = match setup() {
+        Ok(v) => v,
+        Err(e) => {
+            let _ = ready.send(Err(e));
+            return Err(WorkerError::Panicked(index));
+        }
+    };
+    let _ = ready.send(Ok(()));
+
+    let mut reads = Vec::new();
+    let mut writes = Vec::new();
+    let mut read_scratch = Vec::new();
+    let mut write_scratch = Vec::new();
+    {
+        let mut cx = Context {
+            worker: index,
+            queue: &mut *queue,
+            disks: &mut slots,
+            reads: &mut reads,
+            writes: &mut writes,
+        };
+        handler.start(&mut cx);
+
+        let mut idle = false;
+        loop {
+            // One `io_uring_enter` per iteration for every disk on this
+            // worker. In busy mode never wait; in adaptive mode wait when the
+            // handler had nothing to do (the queue returns at once if nothing
+            // is in flight).
+            let wait = idle && matches!(opts.poll_mode, PollMode::Adaptive { .. });
+            cx.queue.poll(wait).map_err(io_err)?;
+            for (d, slot) in cx.disks.iter_mut().enumerate() {
+                slot.reader.poll(cx.queue, &mut read_scratch).map_err(engine_err)?;
+                cx.reads.extend(read_scratch.drain(..).map(|c| (d, c)));
+                if let Some(w) = &mut slot.writer {
+                    w.poll(cx.queue, &mut write_scratch).map_err(engine_err)?;
+                    cx.writes.extend(write_scratch.drain(..).map(|c| (d, c)));
+                }
+            }
+            let step = handler.run(&mut cx);
+            if step == Step::Stop || stop.load(Ordering::Acquire) {
+                break;
+            }
+            idle = step == Step::Idle && cx.queue.in_flight() == 0;
+            if idle && let PollMode::Adaptive { idle_sleep } = opts.poll_mode {
+                thread::sleep(idle_sleep);
+            }
+        }
+        handler.stop(&mut cx);
+    }
+
+    // Clean shutdown: seal every owned disk so the next open needs no scan,
+    // then close every descriptor.
+    for slot in slots.iter_mut() {
+        if let Some(mut w) = slot.writer.take() {
+            blocking::seal(&mut *queue, &mut w).map_err(engine_err)?;
+            blocking::drain(&mut *queue, &mut w).map_err(engine_err)?;
+            w.detach(&mut *queue);
+        }
+    }
+    for slot in slots.drain(..) {
+        slot.reader.detach(&mut *queue);
+    }
+    Ok(handler)
+}

--- a/core/moat-server/src/worker.rs
+++ b/core/moat-server/src/worker.rs
@@ -355,8 +355,11 @@ fn run_worker<H: Handler>(
             if step == Step::Stop || stop.load(Ordering::Acquire) {
                 break;
             }
-            idle = step == Step::Idle && cx.queue.in_flight() == 0;
-            if idle && let PollMode::Adaptive { idle_sleep } = opts.poll_mode {
+            idle = step == Step::Idle;
+            if idle
+                && cx.queue.in_flight() == 0
+                && let PollMode::Adaptive { idle_sleep } = opts.poll_mode
+            {
                 thread::sleep(idle_sleep);
             }
         }

--- a/core/moat-server/tests/bench_cpus.rs
+++ b/core/moat-server/tests/bench_cpus.rs
@@ -1,0 +1,68 @@
+// Copyright 2026- Moat Project Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! CPU placement tests for the benchmark load generators.
+
+#[path = "../benches/support/cpus.rs"]
+mod cpus;
+
+#[test]
+fn topology_order_contains_each_selected_cpu_once() {
+    let mut expected = moat_server::disk::online_cpus();
+    if expected.len() > 2 {
+        expected.drain(..2);
+    }
+    let mut actual = cpus::spread();
+    actual.sort_unstable();
+    expected.sort_unstable();
+    assert_eq!(actual, expected);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::cpus::spread_in;
+    use std::fs;
+
+    #[test]
+    fn spreads_caches_before_cores_and_smt_with_offline_siblings() {
+        let temp = tempfile::tempdir().unwrap();
+        for cpu in [0, 1, 2, 3, 4, 5, 6] {
+            let dir = temp.path().join(format!("cpu{cpu}"));
+            fs::create_dir_all(dir.join("topology")).unwrap();
+            fs::create_dir_all(dir.join("cache/index3")).unwrap();
+            let core = cpu % 4;
+            fs::write(
+                dir.join("topology/thread_siblings_list"),
+                format!("{core},{}", core + 4),
+            )
+            .unwrap();
+            let cache = if core < 2 { "0-1,4-5" } else { "2-3,6-7" };
+            fs::write(dir.join("cache/index3/level"), "3").unwrap();
+            fs::write(dir.join("cache/index3/type"), "Unified").unwrap();
+            fs::write(dir.join("cache/index3/shared_cpu_list"), cache).unwrap();
+        }
+        assert_eq!(
+            spread_in(temp.path(), &[0, 1, 2, 3, 4, 5, 6]),
+            vec![0, 2, 1, 3, 4, 6, 5]
+        );
+        assert_eq!(spread_in(temp.path(), &[1, 2, 3, 5, 6]), vec![1, 2, 3, 5, 6]);
+        assert_eq!(spread_in(temp.path(), &[]), Vec::<usize>::new());
+    }
+
+    #[test]
+    fn missing_topology_keeps_available_cpus() {
+        let temp = tempfile::tempdir().unwrap();
+        assert_eq!(spread_in(temp.path(), &[2, 5, 9]), vec![2, 5, 9]);
+    }
+}

--- a/core/moat-server/tests/worker.rs
+++ b/core/moat-server/tests/worker.rs
@@ -1,0 +1,236 @@
+// Copyright 2026- Moat Project Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Several workers over several in-memory disks: owners write, everyone
+//! reads, shutdown seals, and a reopened node sees everything.
+
+use std::{
+    collections::HashMap,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+};
+
+use moat_common::{ChunkId, HugePages, PoolOptions};
+use moat_engine::{Device, Error, FormatOptions, MemDevice, Options, Outcome, PutOptions, QueueOptions, ReadOutcome};
+use moat_server::{Context, Handler, Node, PollMode, QueueBackend, Step, WorkerOptions};
+
+const DISKS: usize = 3;
+const WORKERS: usize = 4;
+const KEYS_PER_DISK: u64 = 200;
+
+fn devices() -> Vec<Arc<dyn Device>> {
+    (0..DISKS)
+        .map(|d| {
+            let dev = MemDevice::new(8 << 20);
+            moat_engine::format(
+                &dev,
+                &FormatOptions {
+                    segment_size: 1 << 20,
+                    chunk_max: 64 << 10,
+                    disk_uuid: [d as u8 + 1; 16],
+                },
+            )
+            .unwrap();
+            Arc::new(dev) as Arc<dyn Device>
+        })
+        .collect()
+}
+
+fn worker_options() -> WorkerOptions {
+    WorkerOptions {
+        core: None,
+        queue: QueueOptions {
+            depth: 64,
+            pool: PoolOptions {
+                bytes: 8 << 20,
+                max_class: 1 << 20,
+                huge_pages: HugePages::Disabled,
+            },
+            descriptors: 16,
+        },
+        backend: QueueBackend::Sync,
+        poll_mode: PollMode::Adaptive {
+            idle_sleep: std::time::Duration::from_micros(50),
+        },
+    }
+}
+
+fn key(disk: usize, i: u64) -> ChunkId {
+    ChunkId::from_u128(((disk as u128) << 64) | i as u128)
+}
+
+fn value(disk: usize, i: u64) -> Vec<u8> {
+    let len = 100 + (i as usize * 37) % 20_000;
+    (0..len).map(|b| (b as u64 * 31 + i + disk as u64) as u8).collect()
+}
+
+/// Phase 1: every owner writes its disks' keys and waits for the tickets.
+/// Phase 2: every worker reads every key of every disk. Then stop.
+struct Load {
+    writes_pending: HashMap<(usize, u64), (usize, u64)>,
+    written: bool,
+    reads_pending: HashMap<u64, (usize, u64)>,
+    next_read: usize,
+    reads_done: u64,
+    all_written: Arc<AtomicUsize>,
+    reads_total: Arc<AtomicUsize>,
+    owners: usize,
+}
+
+impl Handler for Load {
+    fn run(&mut self, cx: &mut Context<'_>) -> Step {
+        for (disk, c) in cx.writes.drain(..) {
+            let ticket = c.ticket;
+            let (d, i) = self.writes_pending.remove(&(disk, ticket)).expect("known ticket");
+            assert_eq!(d, disk);
+            assert!(matches!(c.result, Ok(Outcome::Put { .. })), "put {i} on disk {disk}");
+        }
+        if !self.written {
+            // Write everything the worker owns, respecting back-pressure.
+            let mut issued_all = true;
+            for disk in 0..cx.disks.len() {
+                if !cx.owns(disk) {
+                    continue;
+                }
+                let (q, slot) = cx.disk(disk);
+                let w = slot.writer.as_mut().unwrap();
+                for i in 0..KEYS_PER_DISK {
+                    if self.writes_pending.values().any(|&(d, k)| d == disk && k == i)
+                        || slot.engine.contains(&key(disk, i))
+                    {
+                        continue;
+                    }
+                    match w.put(q, key(disk, i), &value(disk, i), PutOptions::default()) {
+                        Ok(moat_engine::PutOutcome::Written { ticket, .. }) => {
+                            self.writes_pending.insert((disk, ticket), (disk, i));
+                        }
+                        Ok(moat_engine::PutOutcome::Exists) => {}
+                        Err(Error::Busy) => {
+                            issued_all = false;
+                            break;
+                        }
+                        Err(e) => panic!("{e}"),
+                    }
+                }
+            }
+            if issued_all && self.writes_pending.is_empty() {
+                self.written = true;
+                if cx.disks.iter().any(|s| s.writer.is_some()) {
+                    self.all_written.fetch_add(1, Ordering::AcqRel);
+                }
+            }
+            return Step::Continue;
+        }
+        if self.all_written.load(Ordering::Acquire) < self.owners {
+            return Step::Idle;
+        }
+        // Read phase: every worker reads every key of every disk, 8 at a time.
+        for (disk, c) in cx.reads.drain(..) {
+            let (d, i) = self.reads_pending.remove(&c.token).expect("known token");
+            assert_eq!(d, disk);
+            let data = c.result.unwrap().expect("not expired");
+            assert_eq!(&*data, &value(disk, i)[..], "key {i} disk {disk}");
+            self.reads_done += 1;
+        }
+        let total = DISKS * KEYS_PER_DISK as usize;
+        while self.next_read < total && self.reads_pending.len() < 8 {
+            let disk = self.next_read / KEYS_PER_DISK as usize;
+            let i = (self.next_read % KEYS_PER_DISK as usize) as u64;
+            let token = self.next_read as u64;
+            let (q, slot) = cx.disk(disk);
+            match slot.reader.get(q, &key(disk, i), None, token) {
+                Ok(ReadOutcome::Submitted) => {
+                    self.reads_pending.insert(token, (disk, i));
+                    self.next_read += 1;
+                }
+                Ok(ReadOutcome::Miss) => panic!("missing key {i} on disk {disk}"),
+                Err(Error::Busy) => break,
+                Err(e) => panic!("{e}"),
+            }
+        }
+        if self.next_read == total && self.reads_pending.is_empty() {
+            self.reads_total.fetch_add(self.reads_done as usize, Ordering::AcqRel);
+            return Step::Stop;
+        }
+        Step::Continue
+    }
+}
+
+#[test]
+fn owners_write_everyone_reads_and_a_reopened_node_recovers() {
+    let devices = devices();
+    let mut node = Node::open(
+        devices.clone(),
+        Options {
+            index_capacity: 1024,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    node.assign_owners(WORKERS, &[None; DISKS], &[None; WORKERS]);
+    let owners: std::collections::HashSet<usize> = node.owners().iter().copied().collect();
+    assert_eq!(
+        owners.len(),
+        DISKS,
+        "each disk gets a distinct owner with more workers than disks"
+    );
+
+    let all_written = Arc::new(AtomicUsize::new(0));
+    let reads_total = Arc::new(AtomicUsize::new(0));
+    let workers = node
+        .start(&vec![worker_options(); WORKERS], |_| Load {
+            writes_pending: HashMap::new(),
+            written: false,
+            reads_pending: HashMap::new(),
+            next_read: 0,
+            reads_done: 0,
+            all_written: all_written.clone(),
+            reads_total: reads_total.clone(),
+            owners: owners.len(),
+        })
+        .unwrap();
+    for w in workers {
+        w.join().unwrap();
+    }
+    assert_eq!(
+        reads_total.load(Ordering::Acquire),
+        WORKERS * DISKS * KEYS_PER_DISK as usize
+    );
+    for (d, e) in node.engines().iter().enumerate() {
+        assert_eq!(e.usage().chunks, KEYS_PER_DISK as usize, "disk {d}");
+    }
+    drop(node);
+
+    // Workers sealed their disks on shutdown: reopening needs no scan.
+    let node = Node::open(
+        devices,
+        Options {
+            index_capacity: 1024,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    for (d, r) in node.reports().iter().enumerate() {
+        assert_eq!(r.scanned, 0, "disk {d}");
+        assert_eq!(r.chunks, KEYS_PER_DISK as usize, "disk {d}");
+    }
+    // Placement is deterministic and covers every disk.
+    let mut hits = vec![0usize; DISKS];
+    for i in 0..3_000u128 {
+        hits[node.disk_of(&ChunkId::from_u128(i))] += 1;
+    }
+    assert!(hits.iter().all(|&h| h > 500), "{hits:?}");
+}

--- a/core/moat-server/tests/worker.rs
+++ b/core/moat-server/tests/worker.rs
@@ -165,7 +165,8 @@ impl Handler for Load {
             self.reads_total.fetch_add(self.reads_done as usize, Ordering::AcqRel);
             return Step::Stop;
         }
-        Step::Continue
+        // All available reads have been issued; adaptive mode may wait for I/O.
+        Step::Idle
     }
 }
 

--- a/docs/design/chunkserver.md
+++ b/docs/design/chunkserver.md
@@ -21,7 +21,7 @@
 | Metadata persistence | **No RocksDB, no separate WAL.** The log is the WAL. Recovery = read every segment header + footers of sealed segments + forward scan of at most two active segments |
 | Reclaim | **GC and cache eviction are one code path**: pick a segment → decide per record whether to relocate or drop → free the segment. Storage mode uses greedy + age rules; cache mode uses FIFO + reinsertion by access bit |
 | Disk placement | **Deterministic**: weighted rendezvous hashing of `ChunkId` over disks (weight = capacity). Engines are fully independent; adding, removing or losing a disk affects nothing else |
-| Threads | Per NIC, several pinned busy-polling **network workers** (private RDMA reactor + io_uring + registered arena; read any disk directly); per disk, one **disk writer** (sole owner of the log tail, index mutations and reclaim); tokio for the management plane only |
+| Threads | One kind of pinned, busy-polling **worker** (private RDMA reactor + io_uring + arena), as many as the CPU budget allows (~80 on a 96-core node), not "N per NIC". Every worker reads every disk directly; each disk has exactly one **owner worker** that is also its writer (sole owner of the log tail, index mutations and reclaim). Clients route PUTs to the owner, so the hot path has no cross-thread hop; a forwarding ring between workers is the cold fallback. tokio for the management plane only |
 | RDMA data path | RC QPs, inline SEND control messages. **PUT = server-grant / client-push**; **GET = client RDMA READ pull**; values ≤ `INLINE_MAX` (default 4 KiB) travel inline in one round trip |
 | Integrity | CRC32C per 64 KiB block, end to end (client computes, server verifies, verified again on read); every header, batch and footer carries its own CRC |
 | Transport abstraction | A `Transport` trait; `rdma` (verbs) is the performance path, `tcp` the fallback. The protocol state machine is transport agnostic |
@@ -168,29 +168,29 @@ struct RecordHdr {          // 64 B; crc covers the rest of the header + block_c
 ### 4.3 Write pipeline: one writer per disk
 
 ```
-network workers ×N ──(MPSC job queue)──► DiskWriter(disk d) ──io_uring──► NVMe
-       ▲                                        │
-       └──────────(SPSC completions)────────────┘  → network worker sends PutResp
+client ──PUT (routed to owner)──► owner worker of disk d ──io_uring──► NVMe
+other workers ──(SPSC forwarding ring, cold path)──┘
 ```
 
-The `DiskWriter` is one dedicated thread per disk, pinned to a core on the disk's NUMA node. It **exclusively owns** the disk's log tails (two active segments: Hot for foreground writes, Cold for records relocated by reclaim), the right to mutate the index, segment state, reclaim and footer writes. Its loop:
+Each disk has exactly one **owner worker** (§5.3), which holds the disk's `Writer` (see `engine-api.md`). It **exclusively owns** the disk's log tails (two active segments: Hot for foreground writes, Cold for records relocated by reclaim), the right to mutate the index, segment state, reclaim and footer writes. The write pipeline, per PUT that has landed and passed CRC verification:
 
-1. Take a batch of jobs from the queue (each job is a buffer that has already landed via RDMA and passed CRC verification plus record metadata, or an inline small value).
-2. Assign `lsn` (single-threaded increment, no atomics), fill `RecordHdr` **in queue order**; copy small records into the writer's own packing staging buffer (registered with io_uring), use the landing buffer directly for large ones.
-3. Bump-allocate space at the Hot segment's tail (when the remainder is too small, small queued batches may be used to fill it before sealing and switching segments), submit `WriteFixed`. io_uring depth is bounded (default 8 batches / 64 MiB).
-4. On completion, **acknowledge in submission order** (so acknowledged records always form a contiguous prefix and a scan never meets a hole), insert into the index (shard lock, memory only), update the segment's live-byte counter, post a completion to the originating worker.
-5. Flush the current packed batch as soon as the queue is empty (no artificial delay): lowest latency under light load, natural coalescing under heavy load.
+1. Assign `lsn` (single-threaded increment, no atomics), fill `RecordHdr` **in call order**; copy small records into the writer's packing staging buffer (a pool buffer registered with io_uring), use the landing buffer directly for large ones.
+2. Bump-allocate space at the Hot segment's tail; when the remainder is too small the segment is parked for asynchronous sealing and a fresh one is taken without waiting. Submit `WriteFixed` through the worker's queue.
+3. On completion, **apply in submission order** (so acknowledged records always form a contiguous prefix and a scan never meets a hole): insert into the index, update the segment's live-byte counter, deliver the completion.
+4. The pending packed batch is closed at the end of every worker iteration (no timer): lowest latency under light load, natural coalescing under heavy load.
+
+No engine call blocks on I/O; sealing, barriers and reclaim are state machines advanced by `Writer::poll` on the owner's loop. A slow disk therefore never stalls the other disks or the network traffic handled by the same worker.
 
 Why one writer rather than many workers racing on the tail with `fetch_add`:
 - Small-value packing (group commit) needs a single point of aggregation.
 - The tail advances in order, so after a crash the active segment's scan stops at the first invalid batch — there is no "later batch completed, earlier batch missing" hole.
-- Segment allocation, footers, reclaim and index mutation are all single-threaded, so **the engine has no locks except the index shard mutexes**.
+- Segment allocation, footers, reclaim and index mutation are all single-threaded, so **the engine has no locks at all**: the index is a single-writer / multi-reader structure (§4.4), everything else is owned by one thread.
 
-Single-core budget: 7 GB/s of writes is ~1,750 four-megabyte io_uring submissions per second plus memcpy of values under 64 KiB (an all-small-value workload at 7 GB/s is within one core's memcpy budget but close). If profiling shows the writer is the bottleneck, reclaim's reading and filtering move to a helper thread and index updates become CAS; v0 does not pre-build that.
+Single-core budget: 7 GB/s of writes is ~1,750 four-megabyte io_uring submissions per second plus memcpy of values under 64 KiB (an all-small-value workload at 7 GB/s is within one core's memcpy budget but close). Writes are therefore bandwidth bound and one core per disk is enough, which is why writing is *not* spread over workers the way reading is (§5.3). If profiling shows the owner is the bottleneck, reclaim's reading and filtering move to a helper thread; v0 does not pre-build that.
 
 ### 4.4 In-memory index
 
-One open-addressing hash table per disk, split into 64 shards by key hash, one `parking_lot::Mutex` per shard (shard mutexes are negligible when the critical section is memory only).
+One open-addressing hash table per disk, **single writer (the owner worker), any number of readers, no locks**. Readers see a consistent entry through a per-slot sequence number (seqlock: the writer bumps it to odd, writes the 48 bytes, bumps it to even; a reader retries if the number changed or was odd). Removal tombstones the slot; the writer rehashes in place when load or tombstones exceed the threshold, publishing the new table with a single pointer swap and retiring the old one once every reader has passed a grace period (readers are busy-polling workers, so the grace period is one loop iteration of each). The current `Mutex`-per-shard implementation is an interim step and is replaced by this structure.
 
 ```rust
 struct Entry {                 // 48 B
@@ -204,20 +204,20 @@ struct Entry {                 // 48 B
 ```
 
 - Memory ≈ 48 B / (7/8 load) ≈ 55 B per entry. 4 MiB average → 24 disks × 8 million ≈ 11 GB; 64 KiB average → ~170 GB. The extra 8 B over a minimal entry buy single-page reads for page-sized values (see §4.2). The engine enforces an `index_memory_budget`; beyond it PUT returns `NoSpace(index)`. **Deployments dominated by tiny objects must raise the budget or pack at the client.** This is a documented capacity constraint, not a hidden OOM.
-- **Reader pin protocol**: a GET looks the entry up *and* increments the target segment's `pin_count` inside the index shard lock; reclaim removes or rewrites entries under the same lock before waiting for `pin_count == 0`. A reader therefore never observes a reused segment (the post-read verification remains as a second line of defence).
+- **Reader pin protocol**: a GET reads the entry, increments the target segment's `pin_count` (atomic), then re-reads the entry's sequence number; if it changed, the reader unpins and retries. Reclaim removes or rewrites entries first and only then waits for `pin_count == 0`, so a reader whose pin is visible to reclaim also saw the entry before removal. A reader therefore never observes a reused segment (the post-read verification remains as a second line of defence).
 
 ### 4.5 Delete, GC and eviction
 
-**Delete** is a variant of the write path, forwarded by the network worker to the disk's writer:
+**Delete** is a variant of the write path and runs on the disk's owner worker (routed like a PUT, §6.3):
 
 1. Look the key up; absent → complete `Miss` without writing a tombstone (a key missing from the index either never existed or already has its tombstone on disk).
-2. Present → remove the entry under the shard lock, subtract the record's footprint from its segment's live bytes.
+2. Present → remove the entry (single-writer index update, §4.4), subtract the record's footprint from its segment's live bytes.
 3. Append a 64 B tombstone (`kind = Tombstone`, fresh lsn) to the current packed batch.
 4. **Acknowledge only after that batch's completion**: a delete means "gone after a crash too"; acknowledging after the in-memory removal alone would let recovery resurrect the old record. Latency is one 4 KiB write plus two messages (~20–40 µs on a PLP drive); a 4 KiB page holds 60+ tombstones.
 
-Data is not touched; space is reclaimed asynchronously. A worker mid-read has pinned the segment inside the index lock and is unaffected. `overwrite = true` needs no tombstone (the higher-lsn data record supersedes the old one). TTL expiry is not a delete: a GET that sees an expired record returns `Miss` and posts a "lazy index removal" job to the writer; no tombstone is written, and recovery drops expired records on load.
+Data is not touched; space is reclaimed asynchronously. A worker mid-read has pinned the segment (§4.4) and is unaffected. `overwrite = true` needs no tombstone (the higher-lsn data record supersedes the old one). TTL expiry is not a delete: a GET that sees an expired record returns `Miss` and posts a "lazy index removal" to the owner over the forwarding ring; no tombstone is written, and recovery drops expired records on load.
 
-**GC runs on the DiskWriter thread in small steps interleaved with foreground jobs**, not on its own thread, so it is serialised with PUT/Del by construction and needs no CAS. The reclaim procedure is identical in storage and cache mode:
+**GC runs on the owner worker as a state machine advanced by `Writer::poll`, in small steps interleaved with foreground work**, not on its own thread, so it is serialised with PUT/Del by construction and needs no CAS. The reclaim procedure is identical in storage and cache mode:
 
 ```
 pick_victim() → sequential read of the whole segment (io_uring, rate limited) → per record:
@@ -241,7 +241,7 @@ Reclaim mechanics:
 - The victim is read in 16 MiB windows with a few in flight, into the writer's registered GC buffer, under a per-disk token bucket (default 30% of foreground write bandwidth, released when idle). Large relocations `WriteFixed` straight from the GC buffer (zero copy); small ones go into a packed batch.
 - A relocated record gets a **new lsn** and goes into the Cold active segment. **When its completion arrives, `index[key].loc` is compared with the old location in the victim**: if unchanged the entry is repointed; if a foreground PUT interleaved between the reclaim decision and the completion has overwritten the key, the entry is left alone and the copy is immediately dead data in the Cold segment. Because the writer is single-threaded and lsns are assigned in submission order, the copy's lsn is necessarily lower than that PUT's, so recovery cannot pick the wrong one.
 - After every record is processed, every relocation completed and no index entry points at the victim any more, wait for `pin_count == 0`, rewrite the header as `Free`, push the segment onto the free list.
-- Cost of reclaiming a 1 GiB segment ≈ read 1 GiB + write the live bytes + one shard-lock lookup per record (a segment full of 4 KiB records is 260k lookups, tens of milliseconds of CPU). At 1.5 GB/s the read takes ~0.7 s.
+- Cost of reclaiming a 1 GiB segment ≈ read 1 GiB + write the live bytes + one index lookup per record (a segment full of 4 KiB records is 260k lookups, tens of milliseconds of CPU). At 1.5 GB/s the read takes ~0.7 s.
 - Write amplification: storage mode with greedy selection and hot/cold separation is typically 1.5–3× at 85–90% utilisation, which is why storage mode reports `NoSpace` around 90% instead of filling up; cache mode is `1 + reinsertion ratio`, capped at 1.2×.
 - The read path is unaffected by GC (reads bypass the writer; segments are freed only after pins drain); GC writes share the writer pipeline but foreground PUTs go first.
 - **Hot/Cold active segments**: foreground writes go to Hot, relocations to Cold. Hot/cold separation markedly lowers write amplification (the classic LFS result) at the cost of scanning two active segments on recovery.
@@ -271,7 +271,7 @@ Cost: headers 120 MB + footers ≈ index volume (48 B × records; 8 million ≈ 
 1. **Rebuild shards in parallel.** The index is already sharded by key, and each shard's rebuild (including per-key highest-lsn resolution) is independent. During recovery the machine's CPUs are idle: one thread reads footers sequentially and dispatches entries to several shard-building threads. Worst case across the machine: 11 billion entries × 80 ns / 96 cores ≈ 10 s, of the same order as the ~500 GB of random memory writes. **Worst case 10–20 s per machine; typical 1–3 s.** Parallel rebuild does not affect tombstone correctness: taking the maximum lsn is commutative and associative, so the order in which entries arrive is irrelevant (another reason to order by lsn rather than physical position); all records of one key land in one shard because keys are placed deterministically on one disk and sharded by key hash; lsns are unique per disk. The one requirement is a **per-disk barrier**: `Dead` markers may only be dropped once *all* of the disk's input (every footer and scan) has been consumed, otherwise an older data record processed later would resurrect.
 2. **Fuzzy index checkpoint** (phase two; formats and interfaces reserved in v0). No writer stall, no copy-on-write:
    - At checkpoint start the writer reports a watermark: `L0` = the lowest lsn among in-flight writes (the next lsn if none), the position of the **oldest in-flight batch** in each active segment (in-flight writes sit before the tail pointer), and the table of `(seg_no → seg_seq, state)`.
-   - A low-priority thread per disk copies the hash table shard by shard in 1 MiB slices, holding the shard lock ~100 µs per slice, memcpy to staging, release, then `WriteFixed` into `kind = Index` segments. Maximum stall per request ≈ 100 µs; p99 is untouched.
+   - A low-priority thread per disk copies the hash table in 1 MiB slices (readers are never blocked; a slice whose entries changed underneath, detected through the per-slot sequence numbers, is re-copied), memcpy to staging, then `WriteFixed` into `kind = Index` segments. The writer is never stalled; p99 is untouched.
    - After all slices complete, superblock A/B flips to the new image (with `L0`, replay start positions, the segment table, table capacity, hasher seed, per-slice CRCs); the old image's segments are freed.
    - Recovery: read the image straight into table memory (zero hashing, 21 GB ≈ 2 s); scan the two active segments from the recorded positions and every segment with `seg_seq` above the checkpoint's maximum; replay only records with `lsn ≥ L0`, merging with the image by **highest lsn** (image entries carry their lsn); drop entries pointing at `Free` segments or at segments whose `seg_seq` differs from the checkpoint's table (can be done lazily on read).
    - Correctness: every index change after T0 is either a record with `lsn ≥ L0` (inserts, overwrites, relocations — taking the *lowest in-flight* lsn is what keeps in-flight writes' late index updates inside the replay range; a delete's index removal and its tombstone lsn are assigned in the same job, so the tombstone has `lsn ≥ L0`), or has no record at all — only cache-mode Drop eviction (caught by the segment-table check; if the segment has not been reused the entry comes back as live, harmless for a cache) and lazy TTL removal (re-evaluated on read). Slices are copied under the lock, so no torn entries.
@@ -307,18 +307,30 @@ Each disk recovers and comes online independently; a slow disk does not block th
 ### 5.3 Threads
 
 ```
-NIC0 ─ workers 0..7  ┐                              ┌ DiskWriter 0  ── nvme0n1
-NIC1 ─ workers 8..15 ├─ any worker reads any disk ─►├ DiskWriter 1  ── nvme1n1
-...                  │  PUT job → that disk's writer│ ...
-NIC3 ─ workers 24..31┘                              └ DiskWriter 23 ── nvme23n1
-acceptor (TCP handshake) · admin/metrics (tokio) · NVMe health probe
+worker 0  (NIC0, owns nvme0n1)   ┐  every worker: RDMA reactor + io_uring + arena
+worker 1  (NIC0, owns nvme1n1)   │  every worker reads every disk on its own ring
+...                              ├─ GET: served where received, zero hops
+worker 19 (NIC3, owns nvme19n1)  │  PUT: client sends to the disk's owner, zero hops
+worker 20..79 (no disk)          ┘  PUT at the wrong worker: SPSC ring → owner → back (cold)
+recovery threads (start-up only) · admin/metrics (tokio) · NVMe health probe
 ```
 
-- **Network workers** (default 8 per NIC; throughput on 400G NICs typically saturates between 8 and 16 busy-polling workers per NIC, and 8 is usually enough with 4 MiB I/O): pinned to cores on the NIC's NUMA node; each owns a `Reactor` (ibv context + PD + one shared CQ, poll batch 64), an io_uring ring (reads), a registered arena (default 1 GiB, hugepages, NUMA local, `RELAXED_ORDERING`), a connection table, an in-flight request table and pending queues. Busy polling with no `yield` when idle (handing a pinned worker back to the scheduler visibly raises p99); slow timers throttled to once per 100 ms.
-- **DiskWriter**: see §4.3.
-- **Management plane**: tokio, only HTTP admin, Prometheus and topology reporting; never touches data.
-- The only cross-thread communication on the hot path is the worker → writer job queue and the writer → worker completion queue, both lock-free rings.
-- **`poll_mode = busy | adaptive`**: `adaptive` switches to `ibv_req_notify_cq` + epoll sleeping after an idle threshold, for open-source users who cannot dedicate cores. Default `busy`.
+**Why one kind of worker, and why so many.** Small I/O is CPU bound, not disk bound. Measured on a PCIe 5 NVMe (4 KiB random read, one thread, io_uring with fixed buffers and registered files, no `SQPOLL`): fio reaches 1.24 M IOPS at queue depth 128–256 with the core at 100 % (75 % in the kernel), and the engine 745 k, against a disk limit of 2.9 M; four threads reach the disk limit (fio 2.40 M, engine 2.39 M). **One disk needs about four cores of io_uring submission to be read at full rate**, so twenty disks need about eighty cores, and any design that funnels reads through one thread per disk leaves three quarters of the disks' IOPS on the table. At the same time every cross-thread hop costs ~0.2–0.3 µs of a ~1.5–2 µs per-operation budget, i.e. 10–20 % of throughput. Two consequences:
+
+- Reads are issued **from the worker that received the request**, on that worker's own ring, against any disk. No hop.
+- Workers are not split into a network pool and a disk pool. A split would need the same total CPU, add a hop to every operation and, worse, fix the ratio between the two pools: an all-large workload (NIC bound, ~1,400 GETs per worker) idles the disk pool while an all-small workload saturates both with no slack. One kind of worker that does both adapts by itself.
+
+**Worker.** Pinned to one core; each owns a `Reactor` (ibv context + PD + one shared CQ on the NIC nearest its NUMA node, poll batch 64), one `IoQueue` (io_uring; every disk attached as a descriptor, every arena registered as a fixed buffer), one arena (default 1 GiB, hugepages, NUMA local, `RELAXED_ORDERING`), one `Reader` per disk, a connection table, an in-flight request table and pending queues. Busy polling with no `yield` when idle (handing a pinned worker back to the scheduler visibly raises p99); slow timers throttled to once per 100 ms. Worker count is a configuration knob bounded by cores; the default leaves the management plane and the OS a few cores and pins the rest.
+
+**Disk owner.** Each disk is assigned to one worker, preferably on the disk's NUMA node, which additionally holds the disk's `Writer` and runs its reclaim (§4.3). Ownership is published together with the worker's QP endpoint through `/status`, so clients (§7) send a PUT straight to the owner. The owner's loop is the same loop as any other worker's; write work is simply more `Writer::put` / `Writer::poll` calls on it.
+
+**Forwarding rings (cold path).** Between every pair of workers there are two SPSC lock-free rings (256 slots each; 80 workers → ~13 k rings of a few KiB, a few MB in total). A PUT that arrives at a non-owner (stale routing metadata, a client that does not route, the TCP fallback) is forwarded with its landing buffer; the owner writes it and returns the completion on the reverse ring; the receiving worker answers the client and frees the buffer. SPSC rather than MPSC so producers never contend; each worker scans its 79 inbound rings once per iteration (~100 ns of cache-line reads when they are empty). Routing is an optimisation, never a correctness requirement.
+
+**Buffers cross threads, but are freed at home.** A landing buffer may travel to the owner and be read by the owner's io_uring (all arenas are registered on all rings and all PDs at start-up; they never move), but it is returned to the pool only by the worker that allocated it. Pools are therefore thread private and lock free; a buffer on another thread is represented by a `Send` claim (arena index, offset, home worker) that is converted back into the pool's handle when it comes home on the reverse ring.
+
+**Management plane**: tokio, only HTTP admin, Prometheus and topology reporting; never touches data. **Recovery**: `open` is blocking and runs on temporary threads, all disks in parallel, before the workers start; each engine is then attached to its owner's queue.
+
+**`poll_mode = busy | adaptive`**: `adaptive` switches to `ibv_req_notify_cq` + epoll sleeping after an idle threshold, for open-source users who cannot dedicate cores. Default `busy`.
 
 ### 5.4 Admission and QoS
 
@@ -326,7 +338,7 @@ acceptor (TCP handshake) · admin/metrics (tokio) · NVMe health probe
 |---|---|---|
 | Per-disk read bytes in flight | `ByteWindow`, CAS reservation, RAII permit | 32 MiB (Little's law: 10 GB/s × 2 ms target × 1.5 headroom) |
 | Per-disk write bytes in flight | Same, **fully separate** from the read window, no combined total | 32 MiB + writer queue depth 256 |
-| Worker arena | Size-class allocation (4 KiB … CHUNK_MAX + header), queue when exhausted | 1 GiB per worker |
+| Worker arena | Thread-private buddy pool (4 KiB … CHUNK_MAX + header), no lock; `Busy` when exhausted, request queued and retried after the next poll | 1 GiB per worker |
 | GC / migration bandwidth | Per-disk token bucket | 30% of foreground writes |
 | Queueing | Bounded queues bucketed by wait reason + deadline, `Throttle` on expiry | queue 1024 / deadline 50 ms |
 
@@ -369,17 +381,19 @@ Fixed 32 B header + type-specific body, `bytemuck` POD, little endian; DMA'd fir
 ### 6.3 PUT: server-grant / client-push
 
 ```
-Client                                        Server worker
-  |-- SEND Put{req,id,len,crcs} --------------->|  disk = disk_of(id); reserve write window (CAS); allocate arena len+header
+Client                                        Owner worker of disk_of(id)
+  |-- SEND Put{req,id,len,crcs} --------------->|  reserve write window; allocate arena len+header
   |<- SEND PutGrant{req,addr,rkey} ------------ |  (or PutResp{Throttle|Exists|NoSpace})
   |== RDMA_WRITE value → addr ================>|
   |-- RDMA_WRITE_WITH_IMM(0 B, imm=req) ------->|  RC ordering guarantees the value is visible; consumes one RECV
-  |                                              |  verify block_crcs → fill header page → job → DiskWriter
-  |                                              |  writer: append → completion → index insert → completion to worker
+  |                                              |  verify block_crcs → Writer::put_large (zero copy, same thread)
+  |                                              |  Writer::poll: batch on disk → index insert → Completion
   |<- SEND PutResp{req,Ok,lsn} ---------------- |  release arena / write window
 ```
 
-`len ≤ INLINE_MAX`: `Put` carries the value; it goes straight to the writer queue — **one round trip**.
+The client computes `disk_of(id)` itself (§5.2 is deterministic) and sends the request to that disk's owner worker (§5.3, published via `/status`), so the whole PUT runs on one thread. If the request lands on another worker it is forwarded over the SPSC ring and answered from the receiving worker after the owner's completion comes back — correct, one hop slower, and only taken when routing metadata is stale.
+
+`len ≤ INLINE_MAX`: `Put` carries the value; it goes straight into the writer's packed batch — **one round trip**.
 
 ### 6.4 GET: client RDMA READ pull
 
@@ -398,7 +412,7 @@ Client                                        Server worker
 
 Read path essentials:
 
-- **The whole path stays on the network worker that received the request; there is no cross-thread hand-off** (only writes hop to the DiskWriter). It touches three shared things: an index shard lock (memory only), the per-disk read-window atomic, and a segment pin counter. The pin is taken inside the index shard lock (§4.4), and cache mode's `ACCESSED` bit is set in the same critical section.
+- **The whole path stays on the worker that received the request; there is no cross-thread hand-off.** It touches three shared things, none of them a lock: a seqlock-protected index entry (memory only), the per-disk read-window atomic, and a segment pin counter (§4.4). Cache mode's `ACCESSED` bit is an atomic or on the entry's flags.
 - **I/O count**: a large record is laid out as `[header page(s)][value]`, so a whole-chunk read is **one contiguous I/O**; an inline small record reads its enclosing page(s) (header and value together); a framed small record reads exactly its value pages and is verified from the index CRC. Only a range read with `offset > 0` needs two SQEs (header and data pages), submitted together and completed in parallel; for small offsets the contiguous span from header to range end is read instead.
 - **System calls**: each poll iteration submits all pending SQEs with one `io_uring_enter`; completions are read from the mmap'd ring and RDMA completions via user-space `ibv_poll_cq`. Amortised, less than one syscall per GET.
 - **Server-side CRC verification is optional**: the client verifies end to end against `block_crcs` regardless; the server's check exists to detect on-disk corruption proactively and drop the index entry. Default on (`verify_on_read = both`), configurable `client_only`. Verifying a 4 MiB record costs ~50–80 µs on the worker (CRC32C at 50–80 GiB/s per core with `crc-fast`) — a visible slice of large-read latency; it can be overlapped with the client's READ after benchmarking.
@@ -419,7 +433,7 @@ Latency estimate (PCIe 5 NVMe, 60–90 µs random 4 KiB read, 8–10 GB/s per di
 
 These figures are design targets, not portable benchmark results. Performance depends on the CPU, storage firmware, kernel, filesystem or raw-device mode, queue configuration and memory topology. Reproducible results must report that environment, all `MOAT_BENCH_*` variables and the corresponding `fio` configuration instead of relying on developer-machine defaults.
 
-Throughput: large I/O is NIC bound (24 disks ≈ 200 GB/s > 4 × 46 GB/s), ~6 GB/s and ~1,400 GETs per worker with the CPU mostly idle, ~2–3 cores of CRC spread over 32 workers; small I/O is CPU / message-rate bound (~1–2 M op/s per worker, 30–60 M op/s over 32 workers, matching ~40 M random-read IOPS across 24 disks): tens of millions of 4 KiB GETs per second per machine. Server read buffers are held only a few hundred microseconds until `GetDone`, ~10–20 MB in flight per NIC.
+Throughput: large I/O is NIC bound (24 disks ≈ 200 GB/s > 4 × 46 GB/s), a few GB/s and ~1,400 GETs per worker with the CPU mostly idle, ~2–3 cores of CRC spread over the workers; small I/O is CPU bound. Measured (§5.3): one core issues 745 k engine reads/s today (fio: 1.24 M), so 80 workers give ~60 M 4 KiB GETs/s before RDMA overhead, of the same order as the disks' aggregate ~58 M IOPS. Closing the gap between the engine and fio on one core (~40 %) translates one to one into machine throughput and is the first optimisation after the topology is in place. Server read buffers are held only a few hundred microseconds until `GetDone`, ~10–20 MB in flight per NIC.
 
 Why GET pulls while PUT pushes (both patterns have production track records):
 
@@ -453,7 +467,8 @@ Same messages; `PutGrant` degrades to a `Continue` after which the client stream
 
 ## 7. Client library (`moat-client`) and large objects
 
-- Node routing: **HRW (rendezvous) hashing** over `node_id` (derived from the hostname, independent of list order); membership is a file with one hostname per line, hot-reloaded periodically; nodes report their worker endpoints through HTTP `/status`. No central metadata service, no consensus.
+- Node routing: **HRW (rendezvous) hashing** over `node_id` (derived from the hostname, independent of list order); membership is a file with one hostname per line, hot-reloaded periodically; nodes report their worker endpoints **and the disk → owner-worker map with its `layout_epoch`** through HTTP `/status`. No central metadata service, no consensus.
+- Worker routing inside a node: a PUT goes to the owner of `disk_of(id)` (§5.2, §5.3); a GET goes to any worker, chosen round robin or by the client's NIC locality. A stale owner map costs one forwarding hop on the server, never a wrong answer; the client refreshes it on the next `/status` poll.
 - One RC connection per (client, worker); synchronous and asynchronous (tokio) APIs over a single-threaded verbs actor (bounded command queue in, completion event stream out, pinned to a NIC-local core).
 - `ObjectWriter / ObjectReader`: split at `CHUNK_MAX`, configurable concurrency (default 64 in flight), per-chunk retries, manifest aggregation. A 100 GB object takes ~2 s on one 400G NIC.
 - The client computes the 64 KiB block CRCs (`crc-fast`, carry-less-multiplication folding: 50–80 GiB/s per core on current x86 servers, independent of block size).

--- a/docs/design/chunkserver.md
+++ b/docs/design/chunkserver.md
@@ -21,7 +21,7 @@
 | Metadata persistence | **No RocksDB, no separate WAL.** The log is the WAL. Recovery = read every segment header + footers of sealed segments + forward scan of at most two active segments |
 | Reclaim | **GC and cache eviction are one code path**: pick a segment → decide per record whether to relocate or drop → free the segment. Storage mode uses greedy + age rules; cache mode uses FIFO + reinsertion by access bit |
 | Disk placement | **Deterministic**: weighted rendezvous hashing of `ChunkId` over disks (weight = capacity). Engines are fully independent; adding, removing or losing a disk affects nothing else |
-| Threads | One kind of pinned, busy-polling **worker** (private RDMA reactor + io_uring + arena), as many as the CPU budget allows (~80 on a 96-core node), not "N per NIC". Every worker reads every disk directly; each disk has exactly one **owner worker** that is also its writer (sole owner of the log tail, index mutations and reclaim). Clients route PUTs to the owner, so the hot path has no cross-thread hop; a forwarding ring between workers is the cold fallback. tokio for the management plane only |
+| Threads | One kind of pinned, busy-polling **worker** (private RDMA reactor + io_uring + arena), with a configurable count bounded by the CPU budget. Every worker reads every disk directly; each disk has exactly one **owner worker** that is also its writer (sole owner of the log tail, index mutations and reclaim). Clients route PUTs to the owner, so the hot path has no cross-thread hop; a forwarding ring between workers is the cold fallback. tokio for the management plane only |
 | RDMA data path | RC QPs, inline SEND control messages. **PUT = server-grant / client-push**; **GET = client RDMA READ pull**; values ≤ `INLINE_MAX` (default 4 KiB) travel inline in one round trip |
 | Integrity | CRC32C per 64 KiB block, end to end (client computes, server verifies, verified again on read); every header, batch and footer carries its own CRC |
 | Transport abstraction | A `Transport` trait; `rdma` (verbs) is the performance path, `tcp` the fallback. The protocol state machine is transport agnostic |
@@ -163,7 +163,7 @@ struct RecordHdr {          // 64 B; crc covers the rest of the header + block_c
 - In a large batch the value starts on the first page boundary after the headers, so the on-disk layout matches the RDMA landing buffer (the client writes to `buf + header_len`) and the batch goes to disk **without a copy**.
 - Fixed overhead per record: 64 B + 4 B per 64 KiB. A large record also pays its header page(s) and tail padding (≈ 0.15% at 4 MiB, ≈ 9% at 64 KiB — hence packing below 64 KiB).
 - A tombstone is a record with `value_len = 0, kind = Tombstone`; it goes into a packed batch and is essentially free.
-- **Read amplification is engineered out for small values.** Inline records are placed so that header plus value span the minimum number of pages their length allows: 8-byte aligned by default, moved to the next page boundary when that saves a page (the gap is zero-filled and skipped by the scanner). Values whose length is within a header of a page multiple (`len % 4096 ∈ (4028, 4096]`, e.g. exactly 4 KiB or 8 KiB) would still be pushed across one extra page by an inline header, so they are written **framed**: headers collected in a header area at the front of the batch (reserved as one slot per page of batch capacity, about 2 % overhead), values page aligned after it, less than one header of padding per value. A framed value is read from its pages alone and verified against the CRC kept in the index; its header is read only when the record has an expiry (expiring values are therefore always inline) or when `verify_header_on_read` is set. Result: every value ≤ 64 KiB costs exactly `ceil(len / 4 KiB)` pages to read.
+- **Page layout for small values.** Inline records are aligned to eight bytes and moved to the next page when necessary to reduce page crossings. Values near a page multiple use a framed layout with grouped headers and page-aligned values. By default, readers use the index to read the requested value pages without a separate header; expiring records still read and validate the header. Enabling `verify_reads` expands the read to the complete checksum blocks touched by the range and includes the record header and checksum array. The index no longer caches a single-block CRC.
 
 ### 4.3 Write pipeline: one writer per disk
 
@@ -190,7 +190,7 @@ Single-core budget: 7 GB/s of writes is ~1,750 four-megabyte io_uring submission
 
 ### 4.4 In-memory index
 
-One open-addressing hash table per disk, **single writer (the owner worker), any number of readers, no locks**. Readers see a consistent entry through a per-slot sequence number (seqlock: the writer bumps it to odd, writes the 48 bytes, bumps it to even; a reader retries if the number changed or was odd). Removal tombstones the slot; the writer rehashes in place when load or tombstones exceed the threshold, publishing the new table with a single pointer swap and retiring the old one once every reader has passed a grace period (readers are busy-polling workers, so the grace period is one loop iteration of each). The current `Mutex`-per-shard implementation is an interim step and is replaced by this structure.
+One open-addressing hash table per disk, **single writer (the owner worker), any number of readers, no locks**. Readers see a consistent entry through a per-slot sequence number (seqlock: the writer bumps it to odd, writes the 48 bytes, bumps it to even; a reader retries if the number changed or was odd). Removal tombstones the slot; the writer rehashes in place when load or tombstones exceed the threshold, publishing the new table with a single pointer swap and retiring the old one once every reader has passed a grace period (readers are busy-polling workers, so the grace period is one loop iteration of each). This is what `moat-engine/src/index.rs` implements: 64-byte cache-line slots (entry plus sequence number), linear probing, tombstones on removal, a rebuild when live entries plus tombstones reach 7/8 of the table (same size when the live count is at most 3/4, else doubled, within `index_memory_budget`), and per-reader epoch slots — a reader is "inside" a lookup while its epoch is odd — that the writer consults before freeing a retired table.
 
 ```rust
 struct Entry {                 // 48 B
@@ -239,17 +239,17 @@ pick_victim() → sequential read of the whole segment (io_uring, rate limited) 
 Reclaim mechanics:
 
 - The victim is read in 16 MiB windows with a few in flight, into the writer's registered GC buffer, under a per-disk token bucket (default 30% of foreground write bandwidth, released when idle). Large relocations `WriteFixed` straight from the GC buffer (zero copy); small ones go into a packed batch.
-- A relocated record gets a **new lsn** and goes into the Cold active segment. **When its completion arrives, `index[key].loc` is compared with the old location in the victim**: if unchanged the entry is repointed; if a foreground PUT interleaved between the reclaim decision and the completion has overwritten the key, the entry is left alone and the copy is immediately dead data in the Cold segment. Because the writer is single-threaded and lsns are assigned in submission order, the copy's lsn is necessarily lower than that PUT's, so recovery cannot pick the wrong one.
+- A relocated record **keeps its lsn** and goes into the Cold active segment. Reclaim is thereby a purely physical move: the set of `(key, lsn, kind, value)` records recovery sees is unchanged by it, the lsn a client observed for a chunk stays valid across compaction, and no ordering argument between reclaim and concurrent foreground writes is needed. **When the relocation's completion arrives, `index[key].loc` is compared with the old location in the victim**: if unchanged the entry is repointed; if a foreground PUT interleaved between the reclaim decision and the completion has overwritten the key, the entry is left alone and the copy is immediately dead data in the Cold segment (the PUT's lsn is higher, so recovery agrees).
 - After every record is processed, every relocation completed and no index entry points at the victim any more, wait for `pin_count == 0`, rewrite the header as `Free`, push the segment onto the free list.
 - Cost of reclaiming a 1 GiB segment ≈ read 1 GiB + write the live bytes + one index lookup per record (a segment full of 4 KiB records is 260k lookups, tens of milliseconds of CPU). At 1.5 GB/s the read takes ~0.7 s.
 - Write amplification: storage mode with greedy selection and hot/cold separation is typically 1.5–3× at 85–90% utilisation, which is why storage mode reports `NoSpace` around 90% instead of filling up; cache mode is `1 + reinsertion ratio`, capped at 1.2×.
 - The read path is unaffected by GC (reads bypass the writer; segments are freed only after pins drain); GC writes share the writer pipeline but foreground PUTs go first.
 - **Hot/Cold active segments**: foreground writes go to Hot, relocations to Cold. Hot/cold separation markedly lowers write amplification (the classic LFS result) at the cost of scanning two active segments on recovery.
 
-**Why the tombstone rules are correct** (the part of log-structured deletion that is easiest to get wrong): recovery keeps the highest `lsn` per key (§4.6). A relocation assigns a **new lsn** (the single writer guarantees lsns increase strictly with actual write time, regardless of which active segment is written). Hence:
-- a live record's lsn is always higher than any of its stale copies, so relocation never changes who wins;
+**Why the tombstone rules are correct** (the part of log-structured deletion that is easiest to get wrong): recovery keeps the highest `lsn` per key (§4.6), and relocation never changes any record's lsn, so the only lsns that matter are the ones assigned by the single writer at put/delete time, strictly increasing in call order. Hence:
+- a copy made by relocation is byte-for-byte the record it copies, lsn included, so if both are ever seen by recovery (a crash between the copy landing and the victim being freed) either one wins and the outcome is the same; a live record's lsn is always higher than any *older version* of the key, so relocation never changes who wins;
 - dropping a tombstone T while an older data version is still on disk would let recovery resurrect it, so T is dropped only when no older segment exists (it sits in the oldest segment) or a newer live version already outranks it;
-- a relocated tombstone gets a new lsn; if the key had become live again the relocated tombstone would wrongly outrank the new data — so the rule checks liveness first, and the single writer guarantees no PUT slips in between the check and the write.
+- a relocated tombstone keeps its lsn, so a put of the same key that is still pending or in flight when the tombstone is copied (and therefore not yet in the index) keeps outranking it; reclaim never has to wait for foreground writes to drain. The one thing reclaim does wait for before it frees the victim is that every batch closed before its last decision has been applied: a record dropped because the index no longer pointed at it may owe that to a tombstone or newer version still in flight, and those must be on disk before the old copy is gone.
 
 ### 4.6 Recovery
 
@@ -283,7 +283,7 @@ Each disk recovers and comes online independently; a slow disk does not block th
 ### 4.7 Durability and consistency summary
 
 - PUT acknowledged ⇔ the completion of the record's batch `WriteFixed` has returned (durable on a PLP drive). With `sync_mode = fdatasync_per_batch` an `IORING_OP_FSYNC(DATASYNC)` follows each batch.
-- Every read verifies: `RecordHdr.magic/crc` → `key` matches → CRC of every 64 KiB block in the requested range. Any failure returns `Corrupt` (dropping the index entry and counting a metric); **wrong data is never returned**.
+- **Read verification is optional and disabled by default.** With `Options::verify_reads = true`, each read validates `RecordHdr.magic/crc`, key, LSN, value length and record kind, then verifies every 64 KiB checksum block touched by the requested range; failures return `Corrupt`. With verification disabled, readers rely on the index and segment pin to keep the location valid without scanning the payload. Expiring records still read and validate the header for TTL. Stored checksums and recovery/reclaim validation are unchanged. End-to-end client verification and checksum transport remain future network-layer work.
 - A crash can only lose unacknowledged writes; "acknowledged but unreadable" cannot happen short of media failure.
 - No partial writes inside a chunk → no COW, no chunk locks, no fragment merging.
 
@@ -307,24 +307,23 @@ Each disk recovers and comes online independently; a slow disk does not block th
 ### 5.3 Threads
 
 ```
-worker 0  (NIC0, owns nvme0n1)   ┐  every worker: RDMA reactor + io_uring + arena
-worker 1  (NIC0, owns nvme1n1)   │  every worker reads every disk on its own ring
-...                              ├─ GET: served where received, zero hops
-worker 19 (NIC3, owns nvme19n1)  │  PUT: client sends to the disk's owner, zero hops
-worker 20..79 (no disk)          ┘  PUT at the wrong worker: SPSC ring → owner → back (cold)
+worker A  (owns disk X)    ┐  every worker: RDMA reactor + io_uring + arena
+worker B  (owns disk Y)    │  every worker reads every disk on its own ring
+...                       ├─ GET: served where received
+worker C  (owns no disk)   ┘  PUT: routed to the owner; forwarding is a cold path
 recovery threads (start-up only) · admin/metrics (tokio) · NVMe health probe
 ```
 
-**Why one kind of worker, and why so many.** Small I/O is CPU bound, not disk bound. Measured on a PCIe 5 NVMe (4 KiB random read, one thread, io_uring with fixed buffers and registered files, no `SQPOLL`): fio reaches 1.24 M IOPS at queue depth 128–256 with the core at 100 % (75 % in the kernel), and the engine 745 k, against a disk limit of 2.9 M; four threads reach the disk limit (fio 2.40 M, engine 2.39 M). **One disk needs about four cores of io_uring submission to be read at full rate**, so twenty disks need about eighty cores, and any design that funnels reads through one thread per disk leaves three quarters of the disks' IOPS on the table. At the same time every cross-thread hop costs ~0.2–0.3 µs of a ~1.5–2 µs per-operation budget, i.e. 10–20 % of throughput. Two consequences:
+**Why one kind of worker.** Small reads can exhaust a submission thread's CPU budget before reaching device capacity. Allowing multiple workers to read each disk avoids tying read concurrency to the number of disk owners. Keeping network processing and I/O submission on the same worker avoids a cross-thread handoff on each request. Two consequences:
 
 - Reads are issued **from the worker that received the request**, on that worker's own ring, against any disk. No hop.
-- Workers are not split into a network pool and a disk pool. A split would need the same total CPU, add a hop to every operation and, worse, fix the ratio between the two pools: an all-large workload (NIC bound, ~1,400 GETs per worker) idles the disk pool while an all-small workload saturates both with no slack. One kind of worker that does both adapts by itself.
+- Workers are not split into a network pool and a disk pool. A split would need the same total CPU, add a hop to every operation and, worse, fix the ratio between the two pools: an all-large workload (limited by network bandwidth) idles the disk pool while an all-small workload saturates both with no slack. One kind of worker that does both adapts by itself.
 
 **Worker.** Pinned to one core; each owns a `Reactor` (ibv context + PD + one shared CQ on the NIC nearest its NUMA node, poll batch 64), one `IoQueue` (io_uring; every disk attached as a descriptor, every arena registered as a fixed buffer), one arena (default 1 GiB, hugepages, NUMA local, `RELAXED_ORDERING`), one `Reader` per disk, a connection table, an in-flight request table and pending queues. Busy polling with no `yield` when idle (handing a pinned worker back to the scheduler visibly raises p99); slow timers throttled to once per 100 ms. Worker count is a configuration knob bounded by cores; the default leaves the management plane and the OS a few cores and pins the rest.
 
 **Disk owner.** Each disk is assigned to one worker, preferably on the disk's NUMA node, which additionally holds the disk's `Writer` and runs its reclaim (§4.3). Ownership is published together with the worker's QP endpoint through `/status`, so clients (§7) send a PUT straight to the owner. The owner's loop is the same loop as any other worker's; write work is simply more `Writer::put` / `Writer::poll` calls on it.
 
-**Forwarding rings (cold path).** Between every pair of workers there are two SPSC lock-free rings (256 slots each; 80 workers → ~13 k rings of a few KiB, a few MB in total). A PUT that arrives at a non-owner (stale routing metadata, a client that does not route, the TCP fallback) is forwarded with its landing buffer; the owner writes it and returns the completion on the reverse ring; the receiving worker answers the client and frees the buffer. SPSC rather than MPSC so producers never contend; each worker scans its 79 inbound rings once per iteration (~100 ns of cache-line reads when they are empty). Routing is an optimisation, never a correctness requirement.
+**Forwarding rings (cold path).** Between every pair of workers there are two SPSC lock-free rings (256 slots each; the ring count grows quadratically with the worker count). A PUT that arrives at a non-owner (stale routing metadata, a client that does not route, the TCP fallback) is forwarded with its landing buffer; the owner writes it and returns the completion on the reverse ring; the receiving worker answers the client and frees the buffer. SPSC rather than MPSC so producers never contend; each worker scans its inbound rings once per iteration. Routing is an optimisation, never a correctness requirement.
 
 **Buffers cross threads, but are freed at home.** A landing buffer may travel to the owner and be read by the owner's io_uring (all arenas are registered on all rings and all PDs at start-up; they never move), but it is returned to the pool only by the worker that allocated it. Pools are therefore thread private and lock free; a buffer on another thread is represented by a `Send` claim (arena index, offset, home worker) that is converted back into the pool's handle when it comes home on the reverse ring.
 
@@ -413,9 +412,9 @@ Client                                        Server worker
 Read path essentials:
 
 - **The whole path stays on the worker that received the request; there is no cross-thread hand-off.** It touches three shared things, none of them a lock: a seqlock-protected index entry (memory only), the per-disk read-window atomic, and a segment pin counter (§4.4). Cache mode's `ACCESSED` bit is an atomic or on the entry's flags.
-- **I/O count**: a large record is laid out as `[header page(s)][value]`, so a whole-chunk read is **one contiguous I/O**; an inline small record reads its enclosing page(s) (header and value together); a framed small record reads exactly its value pages and is verified from the index CRC. Only a range read with `offset > 0` needs two SQEs (header and data pages), submitted together and completed in parallel; for small offsets the contiguous span from header to range end is read instead.
+- **I/O count.** The current reader submits one contiguous I/O per request. By default it covers only the requested value pages. With verification enabled, it includes the complete checksum blocks touched by the range and extends back to the header and checksum array. Expiring records also include the header. Separate SQEs for the header and data range are not implemented.
 - **System calls**: each poll iteration submits all pending SQEs with one `io_uring_enter`; completions are read from the mmap'd ring and RDMA completions via user-space `ibv_poll_cq`. Amortised, less than one syscall per GET.
-- **Server-side CRC verification is optional**: the client verifies end to end against `block_crcs` regardless; the server's check exists to detect on-disk corruption proactively and drop the index entry. Default on (`verify_on_read = both`), configurable `client_only`. Verifying a 4 MiB record costs ~50–80 µs on the worker (CRC32C at 50–80 GiB/s per core with `crc-fast`) — a visible slice of large-read latency; it can be overlapped with the client's READ after benchmarking.
+- **Server-side CRC verification is optional.** The engine defaults to `verify_reads = false`; enabling it validates the header and requested checksum blocks on every GET. Readers report corruption without mutating the index; reclaim removes corrupt records through the single writer. The planned network layer must transmit stored `block_crcs` to the client for verification after receipt; that transport path is not implemented yet.
 - **A late READ hitting a reused server buffer is safe** (the client's CRC check fails and it retries), so read buffers may be reclaimed on lease expiry without destroying the QP, unlike PUT landing buffers.
 
 Latency estimate (PCIe 5 NVMe, 60–90 µs random 4 KiB read, 8–10 GB/s per disk; 400G NIC ≈ 46 GB/s):
@@ -433,7 +432,7 @@ Latency estimate (PCIe 5 NVMe, 60–90 µs random 4 KiB read, 8–10 GB/s per di
 
 These figures are design targets, not portable benchmark results. Performance depends on the CPU, storage firmware, kernel, filesystem or raw-device mode, queue configuration and memory topology. Reproducible results must report that environment, all `MOAT_BENCH_*` variables and the corresponding `fio` configuration instead of relying on developer-machine defaults.
 
-Throughput: large I/O is NIC bound (24 disks ≈ 200 GB/s > 4 × 46 GB/s), a few GB/s and ~1,400 GETs per worker with the CPU mostly idle, ~2–3 cores of CRC spread over the workers; small I/O is CPU bound. Measured (§5.3): one core issues 745 k engine reads/s today (fio: 1.24 M), so 80 workers give ~60 M 4 KiB GETs/s before RDMA overhead, of the same order as the disks' aggregate ~58 M IOPS. Closing the gap between the engine and fio on one core (~40 %) translates one to one into machine throughput and is the first optimisation after the topology is in place. Server read buffers are held only a few hundred microseconds until `GetDone`, ~10–20 MB in flight per NIC.
+Throughput depends on device, network and CPU capacity. Large reads may be limited by device or network bandwidth, while small reads may be limited by the workers' submission and completion overhead. Worker count and queue depth are configurable. Server read buffers remain allocated until `GetDone` or lease expiry.
 
 Why GET pulls while PUT pushes (both patterns have production track records):
 
@@ -452,7 +451,7 @@ Why GET pulls while PUT pushes (both patterns have production track records):
 ### 6.6 verbs details
 
 - RC QPs; control plane SEND/RECV (inline ≤ INLINE_MAX); data plane RDMA WRITE / WRITE_WITH_IMM (PUT), RDMA READ (GET). Server arena MR access `LOCAL_WRITE | REMOTE_WRITE | REMOTE_READ`; client MR `LOCAL_WRITE | REMOTE_WRITE` (a READ's landing is an inbound write).
-- **`IBV_ACCESS_RELAXED_ORDERING` must be on, and must be registered through the `ibv_reg_mr_iova2` ABI** (bindgen cannot bind the C macro, and the old ABI silently drops optional flags at bit ≥ 20). On AMD EPYC this is a ~2× bandwidth difference, and it acts on the PCIe inbound-write side: the server MR for PUT, the client MR for GET.
+- **`IBV_ACCESS_RELAXED_ORDERING` must be on, and must be registered through the `ibv_reg_mr_iova2` ABI** (bindgen cannot bind the C macro, and the old ABI silently drops optional flags at bit ≥ 20). Its performance effect depends on the platform. It acts on the PCIe inbound-write side: the server MR for PUT, the client MR for GET.
 - One `Reactor` per worker = context + PD + one shared CQ, routing completions by `wc.qp_num` to `Weak<Endpoint>`; a single QP error poisons only its endpoint.
 - QP parameters: `max_send_wr = depth*3`, `max_recv_wr = depth`, `sq_sig_all = false`, `min_rnr_timer 12 / timeout 14 / retry 7 / rnr_retry 7 / max_rd_atomic 16`, MTU = min of both ends' `active_mtu`, SL0, GRH off on native IB (on for RoCE, detected during the handshake).
 - Connection setup: out-of-band TCP exchange of `PeerInfo{qpn, psn, lid/gid, mtu, depth, proto_version, inline_max, chunk_max}`; the TCP connection doubles as the liveness probe (EOF → fence).
@@ -471,7 +470,7 @@ Same messages; `PutGrant` degrades to a `Continue` after which the client stream
 - Worker routing inside a node: a PUT goes to the owner of `disk_of(id)` (§5.2, §5.3); a GET goes to any worker, chosen round robin or by the client's NIC locality. A stale owner map costs one forwarding hop on the server, never a wrong answer; the client refreshes it on the next `/status` poll.
 - One RC connection per (client, worker); synchronous and asynchronous (tokio) APIs over a single-threaded verbs actor (bounded command queue in, completion event stream out, pinned to a NIC-local core).
 - `ObjectWriter / ObjectReader`: split at `CHUNK_MAX`, configurable concurrency (default 64 in flight), per-chunk retries, manifest aggregation. A 100 GB object takes ~2 s on one 400G NIC.
-- The client computes the 64 KiB block CRCs (`crc-fast`, carry-less-multiplication folding: 50–80 GiB/s per core on current x86 servers, independent of block size).
+- The client computes the 64 KiB block CRCs (`crc-fast`, with runtime selection of hardware-accelerated kernels).
 
 ---
 
@@ -551,7 +550,7 @@ Known trade-offs and extension points:
 ## 12. Suggested order of implementation
 
 1. `moat-common` + `moat-engine` + model tests: get the layout, writer, index, reclaim and recovery right first — this is where all the correctness lives. *(done, including the io_uring queue, registered buffer pool and zero-copy paths; a blocking queue keeps tests deterministic and the engine portable)*
-2. `moat-server` with TCP transport + `moat-client` over TCP: end-to-end usable, developable and testable on machines without RDMA.
+2. `moat-server` with TCP transport + `moat-client` over TCP: end-to-end usable, developable and testable on machines without RDMA. *(the node layer without a transport is done: `core/moat-server` has NVMe discovery by serial, rendezvous placement, the pinned worker with one io_uring queue per worker and a pluggable request `Handler`, parallel recovery and owner assignment, and a whole-node benchmark; the TCP transport is the next `Handler`)*
 3. `moat-verbs` + `moat-transport::rdma`: reactor, endpoints, leases/fencing; drive to line rate with `moat-tools bench`.
 4. Multi-disk: NVMe discovery, placement, layout epochs, admission.
 5. Cache-mode policies, TTL, `fsck`, observability.

--- a/docs/design/chunkserver.md
+++ b/docs/design/chunkserver.md
@@ -1,7 +1,8 @@
 # A Chunkserver for Many Large NVMe Drives (design v0)
 
 > Status: design document. `moat-common` and `moat-engine` implement sections 3
-> and 4 on files and in-memory devices; everything else is planned.
+> and 4 on files and in-memory devices. `moat-server` implements disk discovery,
+> placement, recovery and workers; network transports and the client remain planned.
 >
 > The design distils operational experience with large RDMA-attached NVMe
 > storage fleets: rendezvous-style RDMA protocols, shared-CQ reactors, buffer

--- a/docs/design/chunkserver.md
+++ b/docs/design/chunkserver.md
@@ -205,7 +205,7 @@ struct Entry {                 // 48 B
 ```
 
 - Memory ≈ 48 B / (7/8 load) ≈ 55 B per entry. 4 MiB average → 24 disks × 8 million ≈ 11 GB; 64 KiB average → ~170 GB. The extra 8 B over a minimal entry buy single-page reads for page-sized values (see §4.2). The engine enforces an `index_memory_budget`; beyond it PUT returns `NoSpace(index)`. **Deployments dominated by tiny objects must raise the budget or pack at the client.** This is a documented capacity constraint, not a hidden OOM.
-- **Reader pin protocol**: a GET reads the entry, increments the target segment's `pin_count` (atomic), then re-reads the entry's sequence number; if it changed, the reader unpins and retries. Reclaim removes or rewrites entries first and only then waits for `pin_count == 0`, so a reader whose pin is visible to reclaim also saw the entry before removal. A reader therefore never observes a reused segment (the post-read verification remains as a second line of defence).
+- **Reader pin protocol**: a GET reads the entry, increments the target segment's `pin_count` (atomic), then rechecks the current table pointer and the entry's sequence number; if either changed, the reader unpins and retries against the current table. Reclaim removes or rewrites entries first and only then waits for `pin_count == 0`, so a reader whose pin is visible to reclaim also saw the entry before removal. A reader therefore never observes a reused segment (optional post-read verification also checks data integrity).
 
 ### 4.5 Delete, GC and eviction
 

--- a/docs/design/engine-api.md
+++ b/docs/design/engine-api.md
@@ -1,0 +1,420 @@
+# moat-engine: a non-blocking API over a shared I/O queue
+
+> Status: proposal. Describes the target public API of `moat-engine` and the
+> ownership model behind it, matching the worker topology of `chunkserver.md`
+> §5.3 (one kind of worker, every worker reads every disk, one owner worker
+> per disk holds its writer). The on-disk format (§3, §4 of `chunkserver.md`)
+> is unchanged.
+
+## 1. Constraints
+
+Two requirements drive everything below.
+
+1. **The I/O queue is shared and supplied from outside.** A worker thread owns
+   exactly one io_uring instance (one buffer pool, one registered fixed-file
+   table, one `io_uring_enter` per loop iteration) and drives any number of
+   engines through it. The engine never builds a ring or a pool of its own.
+2. **No engine call blocks on I/O.** Every method either does memory work and
+   returns, enqueues I/O and returns a ticket, or reports `Busy`. Completion
+   is observed only through `poll`. A slow disk can therefore never stall the
+   other disks that share its worker.
+
+Everything else is chosen to make the surface as small as those two allow.
+
+Why both are needed: without (2) a single `put` that happens to cross a
+segment boundary waits for every in-flight batch of that disk (milliseconds),
+and every disk sharing the thread waits with it. Without (1) a thread with *k*
+disks pays up to *k* `io_uring_enter` calls per iteration, each carrying a
+handful of SQEs, cannot wait on all rings at once, and holds *k* buffer pools
+that cannot lend to each other.
+
+## 2. Ownership model
+
+```
+worker thread
+ ├── IoQueue                      one ring, one pool, one fixed-file table
+ │    ├── Descriptor 0             fd slot + completion inbox
+ │    ├── Descriptor 1
+ │    └── Descriptor 2
+ ├── Writer  of engine A ── Descriptor 0
+ ├── Writer  of engine B ── Descriptor 1
+ └── Reader  of engine C ── Descriptor 2     (C's Writer lives on another worker)
+```
+
+- The **queue** is owned by the worker and passed to every engine call as
+  `&mut dyn IoQueue`. Nothing holds a reference to it across calls, so there
+  is no `Rc<RefCell<_>>`, no interior mutability, and the borrow checker
+  enforces the single-issuer rule that `IORING_SETUP_SINGLE_ISSUER` assumes.
+- A **descriptor** is what an engine object gets when it attaches a device
+  to the queue: one *open* of the device on this queue, exactly as a Unix file
+  descriptor is one open of a file. It is a `Copy` handle that names both the
+  registered file (for `IORING_OP_*_FIXED`) and the inbox its completions are
+  routed to. One descriptor per *pipeline*, not per device: a `Writer` and a
+  `Reader` of the same engine each hold their own, so each pipeline has a
+  private token space and inbox and neither has to demultiplex the other's
+  completions. (Per `chunkserver.md` §5.3 a disk's `Writer` lives on its owner
+  worker while every worker holds a `Reader` for it, so on any one queue a
+  device has at most one `Writer` and one `Reader`.) It is scoped to the
+  queue and is not the kernel's file descriptor. Descriptors are the only
+  piece of queue state a pipeline remembers.
+- Buffers are **moved** into the queue at submission and handed back with the
+  completion, exactly as today. Ownership never crosses a call boundary by
+  reference.
+- An engine object is bound to the queue it attached to. Moving a `Writer`
+  to another worker means: seal, poll until idle, `detach`, then `attach`
+  on the new worker's queue. That is a management-plane operation and is not
+  optimised.
+
+Recovery (`open`) still uses blocking `Device::read_at`/`write_at`. It runs
+before the engine is attached to any queue, once per process start, and is
+parallel across disks by running it on several threads; it is not on the data
+path and gains nothing from the ring.
+
+## 3. `IoQueue`
+
+```rust
+/// One open of a device on a queue: a fixed-file slot plus a completion inbox.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub struct Descriptor(u32);
+
+/// The queue has `depth` operations in flight; retry after `poll`.
+#[derive(Clone, Copy, Debug)]
+pub struct Full;
+
+pub struct IoCompletion {
+    pub token: u64,                 // as passed at submission
+    pub result: io::Result<usize>,  // bytes transferred
+    pub buf: Option<PooledBuf>,     // the buffer that was submitted (None for fsync)
+}
+
+pub trait IoQueue: Send {
+    /// The pool every buffer passed to this queue must come from.
+    fn pool(&self) -> &Arc<BufferPool>;
+
+    /// Registers `device` and opens an inbox for it.
+    fn attach(&mut self, device: &Arc<dyn Device>) -> io::Result<Descriptor>;
+    /// Closes a descriptor. Completions still in flight for it are discarded on
+    /// arrival (their buffers return to the pool).
+    fn detach(&mut self, desc: Descriptor);
+
+    /// Enqueue only: never blocks, never touches the device. Rejected — with
+    /// the buffer handed back untouched — when `depth` operations are already
+    /// in flight; the caller keeps the operation in its own ready queue and
+    /// retries after `poll`. Nothing else can fail at enqueue time; device
+    /// errors arrive in the completion.
+    fn read(&mut self, desc: Descriptor, buf: PooledBuf, len: usize, offset: u64, token: u64) -> Result<(), PooledBuf>;
+    fn write(&mut self, desc: Descriptor, buf: PooledBuf, len: usize, offset: u64, token: u64) -> Result<(), PooledBuf>;
+    fn fsync(&mut self, desc: Descriptor, token: u64) -> Result<(), Full>;
+    /// `depth() - in_flight()`: how many operations can be enqueued right now
+    /// without being rejected. Exact, since the caller is the only issuer.
+    fn vacant(&self) -> usize;
+
+    /// Pushes enqueued operations to the device without waiting.
+    fn submit(&mut self) -> io::Result<()>;
+    /// Submits, then reaps every finished operation into its descriptor's inbox.
+    /// With `wait` set and anything in flight, blocks until at least one
+    /// completes. Returns the number reaped. This is the worker's single
+    /// blocking point.
+    fn poll(&mut self, wait: bool) -> io::Result<usize>;
+    /// Moves the inbox of `desc` into `out`. Returns the number moved.
+    fn take(&mut self, desc: Descriptor, out: &mut Vec<IoCompletion>) -> usize;
+
+    fn in_flight(&self) -> usize;
+    fn depth(&self) -> usize;
+}
+```
+
+Two implementations, as today:
+
+- `UringQueue::new(opts: &QueueOptions)` — no file argument any more.
+  `attach` calls `IORING_REGISTER_FILES_UPDATE` with the fd from
+  `Device::fd()` and returns its slot index as the descriptor. The pool's arenas are
+  registered as fixed buffers once, at construction.
+- `SyncQueue::new(opts, order)` — `attach` keeps the `Arc<dyn Device>` and
+  performs each operation immediately with `Device::read_at`/`write_at`,
+  deferring the completion into the descriptor's inbox. The `BlockingIo` trait is
+  removed; `Device` is the blocking interface.
+
+`Device` loses `open_queue` and gains `fn fd(&self) -> Option<BorrowedFd<'_>>`
+(`None` for `MemDevice`, which therefore only works with `SyncQueue`).
+
+Today's `read`/`write` take the buffer by value and return
+`io::ErrorKind::WouldBlock` when the ring is full — which drops the buffer the
+caller just filled. Handing it back makes rejection lossless; `vacant` lets a
+pipeline push exactly as many ready operations as fit and never see a
+rejection in the common case.
+
+Routing is by descriptor, not by token: the queue keeps one `Vec<IoCompletion>`
+per descriptor and `take` swaps it out. Tokens stay private to the object that
+submitted them. The worker never sees a raw completion.
+
+## 4. Engine lifecycle
+
+```rust
+pub fn format(device: &dyn Device, opts: &FormatOptions) -> Result<()>;          // unchanged
+
+/// Blocking recovery. Rebuilds the index; touches no queue. `Send`, so disks
+/// recover in parallel on any threads.
+pub fn open(device: Arc<dyn Device>, opts: Options) -> Result<(Engine, RecoveryReport)>;
+
+/// The per-disk state every pipeline shares: index, segment table,
+/// superblock, options. `Clone + Send + Sync`; does no I/O itself.
+impl Engine {
+    pub fn stat(&self, id: &ChunkId) -> Option<ChunkStat>;
+    pub fn contains(&self, id: &ChunkId) -> bool;
+    pub fn usage(&self) -> Usage;
+    pub fn segment_size(&self) -> u64;
+    pub fn chunk_max(&self) -> u32;
+
+    /// The disk's single write pipeline, attached to `q`. Fails with
+    /// `InvalidOption` if `q`'s pool cannot hold the largest buffer the
+    /// writer will request, and with `Busy` if a writer already exists.
+    pub fn writer(&self, q: &mut dyn IoQueue) -> Result<Writer>;
+    /// A read pipeline for the calling thread, attached to `q`. Any number
+    /// may exist.
+    pub fn reader(&self, q: &mut dyn IoQueue) -> Result<Reader>;
+}
+```
+
+Three names, three roles: an `Engine` is a disk; a `Writer` or a `Reader` is a
+pipeline of that disk bound to one queue. Writers and readers are symmetric
+in shape — `attach` on creation, `poll(q, out)`, `in_flight()`, `detach(q)` —
+and differ only in what they submit. Today's `Opened`, `Reader` (a metadata
+handle) and `ReadRing` collapse into `Engine` and `Reader` respectively; the
+"ring" suffix leaked io_uring into a name that also covers `SyncQueue`.
+
+`Options` loses `queue: QueueOptions` and `writer_pool_capacity_multiplier`.
+Pool sizing is the worker's business; `attach` only checks
+`pool.max_class() >= max(large_batch_len(chunk_max), batch_limit, scan_window)`.
+
+## 5. `Writer`
+
+All methods take the queue first, never block, and are the only path that
+mutates the index, the segment table or the log tails of the disk.
+
+```rust
+pub type Ticket = u64;
+
+impl Writer {
+    // -- data ---------------------------------------------------------------
+
+    /// Small value (< pack_threshold): copied into the pending batch.
+    pub fn put(&mut self, q: &mut dyn IoQueue, id: ChunkId, value: &[u8], opts: PutOptions)
+        -> Result<PutOutcome>;
+
+    /// Large value: obtain a pool buffer to fill in place (zero copy), then
+    /// hand it back with `put_large`.
+    pub fn prepare_large(&mut self, q: &mut dyn IoQueue, value_len: u32) -> Result<LargeValue>;
+    pub fn put_large(&mut self, q: &mut dyn IoQueue, id: ChunkId, value: LargeValue,
+                     checksums: Option<&[u32]>, opts: PutOptions) -> Result<PutOutcome>;
+
+    /// Appends a tombstone. `Missing` if the id is neither indexed nor
+    /// pending; the index entry disappears when the tombstone is applied.
+    pub fn delete(&mut self, q: &mut dyn IoQueue, id: &ChunkId) -> Result<DeleteOutcome>;
+
+    // -- control ------------------------------------------------------------
+
+    /// Barrier: completes once every write accepted before it is durable
+    /// (fsync included when `sync_on_flush`).
+    pub fn flush(&mut self, q: &mut dyn IoQueue) -> Result<Ticket>;
+    /// `flush`, then seal both active segments so the next open needs no scan.
+    pub fn seal(&mut self, q: &mut dyn IoQueue) -> Result<Ticket>;
+    /// Starts one reclaim pass. `None` if there is no sealed segment.
+    /// `Busy` while a previous pass is still running.
+    pub fn reclaim(&mut self, q: &mut dyn IoQueue, policy: ReclaimPolicy) -> Result<Option<Ticket>>;
+
+    // -- progress -----------------------------------------------------------
+
+    /// Applies completions that arrived for this writer's descriptor, advances the
+    /// seal / barrier / reclaim state machines, submits whatever became ready
+    /// (including any partially filled pending batch), and appends the
+    /// resulting completions to `out`. Never waits.
+    pub fn poll(&mut self, q: &mut dyn IoQueue, out: &mut Vec<Completion>) -> Result<usize>;
+
+    pub fn in_flight(&self) -> usize;
+    pub fn free_segments(&self) -> u32;
+    pub fn next_lsn(&self) -> Lsn;
+    pub fn pick_victim(&self, policy: ReclaimPolicy) -> Option<u32>;
+
+    /// Closes the descriptor. Call after `seal` has completed and `in_flight()`
+    /// is zero; otherwise in-flight batches are abandoned (recovery handles
+    /// that, but the segment is scanned on next open).
+    pub fn detach(self, q: &mut dyn IoQueue);
+}
+
+pub enum PutOutcome    { Written { ticket: Ticket, lsn: Lsn }, Exists }
+pub enum DeleteOutcome { Deleted { ticket: Ticket, lsn: Lsn }, Missing }
+
+pub struct Completion { pub ticket: Ticket, pub result: Result<Outcome> }
+pub enum Outcome { Put, Delete, Flush, Seal, Reclaim(ReclaimReport) }
+```
+
+Removed compared with today: `submit` (the worker calls `IoQueue::submit`),
+`poll(wait)` (waiting is the queue's job), the blocking `flush`, `seal_active`
+and `close`, and the `bool` return of `delete`.
+
+### 5.1 Semantics
+
+- **Tickets** come from one counter per writer. Completions for puts and
+  deletes are delivered in ticket order; a barrier completes after every
+  ticket issued before it; reclaim completes whenever it finishes.
+- **Visibility.** A put is visible to readers and durable when its
+  completion reports `Ok`. A delete is invisible to *this writer* immediately
+  (a subsequent `put` of the id is not `Exists`) and to readers when its
+  completion reports `Ok`. Ordering between a put and a delete of the same id
+  is by LSN, which is by call order.
+- **Batching.** Small records accumulate in a pending batch that is submitted
+  when it reaches `batch_limit` or at the next `poll`, whichever comes first.
+  One worker iteration is therefore one packing window, with no timer.
+- **Errors.** `Err(Busy)` means exactly one thing: the pool has no buffer of
+  the requested class. Poll (to return buffers) and retry. Ring depth is not
+  the caller's problem: the writer keeps a ready queue of encoded batches and
+  pushes `q.vacant()` of them per `poll`; a batch the queue nevertheless
+  rejects goes back to the front of that queue with its buffer. The ready
+  queue is bounded by the pool, so it cannot grow without limit. All other
+  errors are permanent for that call.
+- **Failure of a write** fails the ticket, truncates the active segment at
+  the failed batch and abandons it; later tickets on the same segment fail
+  too, later puts go to a fresh segment. Unchanged from today.
+
+### 5.2 What `poll` does, in order
+
+1. `q.take(desc, scratch)`; match each completion to the in-flight FIFO
+   (batch tokens) or to the auxiliary table (header writes, footer writes,
+   fsync, reclaim reads).
+2. Apply every batch at the head of the FIFO whose result has arrived:
+   index insert/remove, footer entry, live-bytes accounting, completion out.
+3. Advance **sealing**: an active segment that ran out of room was swapped
+   for a fresh one at the time of the `put` and parked in `sealing`; once the
+   FIFO holds no batch for it, write its footer, then (on that completion) its
+   header, then mark it `Sealed`.
+4. Advance **barriers**: a barrier records the ticket and batch token
+   current when it was issued; it completes when the FIFO has passed that
+   token (and, for `sync_on_flush`, when its fsync has returned).
+5. Advance **reclaim**: one step of the job (issue the next window read,
+   parse a returned window and enqueue relocations into the cold batch,
+   wait for relocation batches to apply, wait for `pins == 0`, write the free
+   header). Liveness is judged against the index *plus* the pending and
+   in-flight key sets, so foreground writes never have to drain first.
+6. Close the pending small batch if non-empty and append it to the ready
+   queue; push up to `q.vacant()` ready batches.
+
+Everything the old code did inside `wait_inflight`, `wait_aux`,
+`read_blocking` and `thread::yield_now` becomes a state that step 2–5
+re-examines on the next call. Segment header and footer writes go through the
+descriptor with auxiliary tokens instead of `Device::write_at`.
+
+## 6. `Reader`
+
+```rust
+impl Reader {
+    /// Looks the chunk up and submits the read. `Busy` only if the pool is
+    /// empty; a read that finds the ring full is held in the reader's ready
+    /// queue and pushed by the next `poll`.
+    pub fn get(&mut self, q: &mut dyn IoQueue, id: &ChunkId, range: Option<Range<u64>>, token: u64)
+        -> Result<ReadOutcome>;
+    /// Verifies finished reads and appends them to `out`. Never waits.
+    pub fn poll(&mut self, q: &mut dyn IoQueue, out: &mut Vec<ReadCompletion>) -> Result<usize>;
+    pub fn in_flight(&self) -> usize;
+    pub fn detach(self, q: &mut dyn IoQueue);
+}
+```
+
+Today's `ReadRing` was already a state machine; it only stops owning a queue
+and drops `submit`, `poll(wait)` and `get_sync`. Every worker holds one
+`Reader` per disk, all on its own queue, so a GET is served on the worker that
+received it (`chunkserver.md` §5.3, §6.4).
+
+Why readers are many and writers one, in numbers: a single thread issuing
+4 KiB random reads through io_uring without `SQPOLL` tops out well below one
+PCIe 5 NVMe (measured: fio 1.24 M IOPS, the engine 745 k, the disk 2.9 M; four
+threads reach the disk with either). Reads therefore have to fan out over
+cores, while a single core's write bandwidth already matches a disk's.
+
+## 7. Synchronization: the engine has no locks
+
+The single-writer / multi-reader split is what lets the engine work without a
+single mutex. Everything is either owned by one thread or shared through
+lock-free structures:
+
+| State | Touched by | Mechanism |
+|---|---|---|
+| Log tails, LSN / seq / ticket counters, pending batch, in-flight FIFO, free list, sealing and reclaim state machines | `Writer` only | Plain fields behind `&mut self` |
+| Ring, fixed-file table, inboxes | the owning worker only | `&mut dyn IoQueue`; the borrow checker enforces single issuer |
+| Buffer pool | pipelines on the owning worker only | Thread-private; `Busy` when empty. A buffer may travel to another thread (a PUT landing buffer read by the owner's ring) but is returned to the pool only by its home worker (`chunkserver.md` §5.3) |
+| Index | `Writer` writes, every `Reader` reads | Single-writer open-addressing table with per-slot sequence numbers (seqlock reads, `chunkserver.md` §4.4) |
+| Segment state, live bytes, pin counts | `Writer` writes, `Reader` pins/unpins | Atomics |
+
+The current implementation still has two mutexes — the index shards
+(`index.rs`) and the buddy allocator inside `BufferPool` (`pool.rs`). Both are
+removed as part of this change: the index becomes the seqlock table above and
+the pool becomes `!Sync`, with a `Send` claim type for buffers in transit.
+
+## 8. The worker loop
+
+```rust
+let mut queue = UringQueue::new(&QueueOptions { depth: 1024, pool, ..Default::default() })?;
+let mut writers: Vec<Writer> = engines.iter()
+    .map(|e| e.writer(&mut queue))
+    .collect::<Result<_>>()?;
+let mut done = Vec::new();
+
+loop {
+    // Accept requests: writer.put(&mut queue, ..) / delete / flush / reclaim.
+    // Busy → leave the request queued and try again next iteration.
+
+    queue.poll(idle)?;                              // one io_uring_enter
+    for w in &mut writers { w.poll(&mut queue, &mut done)?; }
+    for c in done.drain(..) { /* ack to the client */ }
+}
+```
+
+One syscall per iteration regardless of the number of disks; one place to
+decide whether to busy-poll or sleep (`idle` is false in `busy` mode and true
+in `adaptive` mode once nothing is pending); zero cross-thread traffic inside
+the engine.
+
+For tests and single-threaded tools a helper drives the same loop to a
+predicate:
+
+```rust
+pub fn drive(q: &mut dyn IoQueue, w: &mut Writer, until: impl FnMut(&Completion) -> bool) -> Result<()>;
+```
+
+which replaces every `flush()?` / `get_sync()` in the current tests.
+
+## 9. Change summary
+
+| Area | Today | Proposed |
+|---|---|---|
+| Queue construction | `Device::open_queue` inside `open` and `Reader::ring` | Worker builds `UringQueue::new(opts)`; pipelines attach via `IoQueue::attach` |
+| Types | `Opened`, `Writer`, `Reader` (metadata handle), `ReadRing` | `Engine` (disk), `Writer` and `Reader` (pipelines) |
+| Queue ownership | `Writer` / `ReadRing` own `Box<dyn IoQueue>` | Worker owns it; passed as `&mut dyn IoQueue` to every call |
+| Multiple devices per ring | one fd per ring | `Descriptor` per attachment, fixed-file table, per-descriptor inbox |
+| `Writer::poll(out, wait)` | may block on the ring | `poll(q, out)` never blocks; `IoQueue::poll(wait)` is the only wait |
+| `flush` / `seal_active` / `close` | block until durable | return a `Ticket`; `Outcome::Flush` / `Outcome::Seal` |
+| `delete` | flushes and waits twice, returns `bool` | returns `DeleteOutcome::{Deleted{ticket,lsn}, Missing}` |
+| `reclaim` | runs to completion inline, blocking reads | starts a job; progresses inside `poll`; `Outcome::Reclaim(report)` |
+| Segment boundary in `put` | `wait_inflight` + synchronous footer | old segment parked in `sealing`, footer written asynchronously |
+| Header / footer I/O | `Device::write_at` | through the descriptor with auxiliary tokens |
+| Backpressure | blocks inside `alloc` / `submit_batch`; `IoQueue` drops the buffer on `WouldBlock` | `Busy` only for pool exhaustion; `IoQueue` rejects losslessly (`Err(buf)`) and exposes `vacant()`; ring depth absorbed by per-pipeline ready queues |
+| `Options.queue`, `writer_pool_capacity_multiplier` | engine sizes its own pool | removed; `attach` validates the worker's pool |
+| `BlockingIo` | separate trait for `SyncQueue` | removed; `SyncQueue` uses `Device` |
+| `Device::open_queue` | — | replaced by `Device::fd()` |
+| `Completion { ticket, lsn, result }` | puts only | `Completion { ticket, result: Result<Outcome> }` for every ticketed operation |
+
+Unchanged: on-disk format, `format`, recovery algorithm, `Index`,
+`SegmentTable` and pinning, the single-writer invariant (one `Writer` per
+disk, LSNs and segment allocation stay lock-free), the metadata calls (now on `Engine`),
+`ChunkData` zero-copy views.
+
+## 10. Out of scope
+
+- Moving reclaim's read-and-filter CPU to a helper thread (`chunkserver.md`
+  §4.3 fallback). The API above does not preclude it: the job already runs as
+  a state machine and only its index mutations must stay on the owner.
+- `SQPOLL`. With one ring per worker it becomes an option (one kernel thread
+  per worker rather than per disk), but the API is the same either way.
+- Rebalancing engines between workers at run time.
+- The exact seqlock table layout and resize protocol; §7 fixes the contract
+  (single writer, lock-free readers), not the data structure.

--- a/docs/design/engine-api.md
+++ b/docs/design/engine-api.md
@@ -481,9 +481,9 @@ to it.
   recovery and reclaim validation are unchanged, as are the on-disk record
   headers, checksum arrays and footer encoding. `ChunkData` returns data only;
   checksum transport and client-side verification are not implemented yet.
-- **CRC implementation** uses `crc-fast` throughout. The specialized 64 KiB
-  AVX-512 kernel has been removed. The engine and node benchmarks also disable
-  read verification by default; set `MOAT_BENCH_VERIFY=1` to enable it.
+- **CRC implementation** uses `crc-fast` throughout. The engine and node
+  benchmarks disable read verification by default; set `MOAT_BENCH_VERIFY=1`
+  to enable it.
 - **Pool free lists park blocks** on a per-order stack (up to 8 MiB per
   order) instead of merging on every release and splitting on every
   allocation, and never touch the block's own memory on the hot path (the

--- a/docs/design/engine-api.md
+++ b/docs/design/engine-api.md
@@ -1,10 +1,12 @@
 # moat-engine: a non-blocking API over a shared I/O queue
 
-> Status: proposal. Describes the target public API of `moat-engine` and the
+> Status: implemented (`core/moat-engine`), with the worker runtime in
+> `core/moat-server`. Describes the public API of `moat-engine` and the
 > ownership model behind it, matching the worker topology of `chunkserver.md`
 > §5.3 (one kind of worker, every worker reads every disk, one owner worker
 > per disk holds its writer). The on-disk format (§3, §4 of `chunkserver.md`)
-> is unchanged.
+> is unchanged. §11 lists where the implementation departs from the original
+> proposal.
 
 ## 1. Constraints
 
@@ -256,8 +258,11 @@ and `close`, and the `bool` return of `delete`.
 ### 5.1 Semantics
 
 - **Tickets** come from one counter per writer. Completions for puts and
-  deletes are delivered in ticket order; a barrier completes after every
-  ticket issued before it; reclaim completes whenever it finishes.
+  deletes are delivered in log order (the order their batches are applied,
+  which is LSN order within a batch but not necessarily ticket order across
+  a small pending batch and a large batch submitted at once); a barrier
+  completes after every ticket issued before it; reclaim completes whenever
+  it finishes.
 - **Visibility.** A put is visible to readers and durable when its
   completion reports `Ok`. A delete is invisible to *this writer* immediately
   (a subsequent `put` of the id is not `Exists`) and to readers when its
@@ -325,11 +330,10 @@ and drops `submit`, `poll(wait)` and `get_sync`. Every worker holds one
 `Reader` per disk, all on its own queue, so a GET is served on the worker that
 received it (`chunkserver.md` §5.3, §6.4).
 
-Why readers are many and writers one, in numbers: a single thread issuing
-4 KiB random reads through io_uring without `SQPOLL` tops out well below one
-PCIe 5 NVMe (measured: fio 1.24 M IOPS, the engine 745 k, the disk 2.9 M; four
-threads reach the disk with either). Reads therefore have to fan out over
-cores, while a single core's write bandwidth already matches a disk's.
+Readers can scale across workers independently of disk ownership. Small reads
+may exhaust a submission thread's CPU budget before reaching device capacity,
+so the reader count is configurable. Each disk retains one writer to serialize
+log allocation and index updates without cross-thread coordination.
 
 ## 7. Synchronization: the engine has no locks
 
@@ -345,10 +349,14 @@ lock-free structures:
 | Index | `Writer` writes, every `Reader` reads | Single-writer open-addressing table with per-slot sequence numbers (seqlock reads, `chunkserver.md` §4.4) |
 | Segment state, live bytes, pin counts | `Writer` writes, `Reader` pins/unpins | Atomics |
 
-The current implementation still has two mutexes — the index shards
-(`index.rs`) and the buddy allocator inside `BufferPool` (`pool.rs`). Both are
-removed as part of this change: the index becomes the seqlock table above and
-the pool becomes `!Sync`, with a `Send` claim type for buffers in transit.
+Neither the index nor the pool has a mutex. The index is the seqlock table
+above (`index.rs`: `Index` for readers, `IndexWriter` for the single writer,
+`ReaderSlot` epochs for table retirement). The pool (`moat-common/src/pool.rs`)
+belongs to the thread that created it: only that thread allocates or runs the
+buddy allocator, asserted at run time; a `PooledBuf` dropped on another thread
+pushes its block onto a lock-free return stack that the home thread drains on
+its next allocation. Buffers therefore stay plain `Send` values and need no
+separate claim type.
 
 ## 8. The worker loop
 
@@ -381,7 +389,9 @@ predicate:
 pub fn drive(q: &mut dyn IoQueue, w: &mut Writer, until: impl FnMut(&Completion) -> bool) -> Result<()>;
 ```
 
-which replaces every `flush()?` / `get_sync()` in the current tests.
+which is what the `blocking` module provides (`blocking::wait`, `flush`,
+`seal`, `reclaim`, `get`, `drain`), replacing every `flush()?` / `get_sync()`
+in the tests.
 
 ## 9. Change summary
 
@@ -418,3 +428,67 @@ disk, LSNs and segment allocation stay lock-free), the metadata calls (now on `E
 - Rebalancing engines between workers at run time.
 - The exact seqlock table layout and resize protocol; §7 fixes the contract
   (single writer, lock-free readers), not the data structure.
+
+## 11. Departures from the proposal
+
+Decided while implementing; each is a simplification with the reason next
+to it.
+
+- **Relocated records keep their LSN** (§4.5 of `chunkserver.md` updated).
+  Assigning a fresh LSN to a copy is only safe if no put of the same key is
+  pending or in flight, which is exactly the draining the non-blocking writer
+  can no longer do. With the LSN preserved, reclaim is a physical move and the
+  question does not arise. Before freeing a victim the job still waits until
+  every batch closed before its last decision is applied, so a tombstone or
+  newer version that justified dropping a record is durable first.
+- **Completion order** is log order, not ticket order (§5.1). Enforcing
+  ticket order would need a reorder buffer on the hot path for a property
+  nothing needs.
+- **Footer room** is reserved for records in batches that are enqueued but
+  not yet applied, not only for applied ones (`Active::fits`). Otherwise the
+  footer can grow beyond its reserved space and overwrite the next segment.
+- **Pending batches are placed when closed**, not bound to a segment when
+  their staging buffer is attached. Reserving worst-case footer room up front
+  (one entry per 64 bytes of staging) made small test segments fill with
+  reservations; placing at close time needs no reservation, and a batch that
+  cannot be placed (no free segment, no buffer for a segment header) simply
+  stays pending until the next `poll`.
+- **Readers do not drop corrupt index entries** (the index is single-writer).
+  A read that fails verification reports `Corrupt` every time; reclaim
+  verifies each record it visits and drops the ones whose value fails its
+  checksums (`ReclaimReport::corrupt`) instead of aborting the pass.
+- **`Options`** gained `index_capacity` (initial slots) and
+  `index_memory_budget` (`Error::IndexFull` beyond it) and lost
+  `index_shards`; `QueueOptions` gained `descriptors` (size of the fixed-file
+  table) and lost `force_sync` (the caller picks `UringQueue` or `SyncQueue`).
+  `attach` checks the pool for a maximal large batch and a staging batch
+  only; the reclaim window shrinks to the pool's largest class if it has to.
+- **`Descriptor` completions for a detached descriptor** are dropped by the
+  queue; `Writer::detach` and `Reader::detach` are the only way to release
+  a slot, and dropping a `Writer` without detaching leaks its slot until the
+  queue goes away (the engine's `writer_taken` flag is cleared either way).
+- **io_uring setup** uses `SINGLE_ISSUER` + `DEFER_TASKRUN` when the kernel
+  accepts them (completion work runs only inside our own `io_uring_enter`,
+  so a non-waiting `poll` enters with `GETEVENTS`), falling back to a plain
+  ring.
+- **`Options::verify_reads`** defaults to `false`: readers trust the index and
+  read only the pages covering the requested range without scanning the
+  payload on the CPU. Expiring records still read and validate their header.
+  When enabled, every read validates the header and every complete checksum
+  block touched by the range; empty ranges only validate the header. The
+  separate `verify_header_on_read` option, index CRC copy and headerless
+  single-block verification path have been removed. Checksum generation,
+  recovery and reclaim validation are unchanged, as are the on-disk record
+  headers, checksum arrays and footer encoding. `ChunkData` returns data only;
+  checksum transport and client-side verification are not implemented yet.
+- **CRC implementation** uses `crc-fast` throughout. The specialized 64 KiB
+  AVX-512 kernel has been removed. The engine and node benchmarks also disable
+  read verification by default; set `MOAT_BENCH_VERIFY=1` to enable it.
+- **Pool free lists park blocks** on a per-order stack (up to 8 MiB per
+  order) instead of merging on every release and splitting on every
+  allocation, and never touch the block's own memory on the hot path (the
+  intrusive links live in blocks the device has just written, so touching
+  them was a cache miss per operation). Parked blocks merge when an
+  allocation finds nothing large enough.
+- **`UringQueue` stages SQEs** and copies them into the submission ring once
+  per submit rather than opening the ring's view per entry.

--- a/docs/design/engine-api.md
+++ b/docs/design/engine-api.md
@@ -463,10 +463,19 @@ to it.
   table) and lost `force_sync` (the caller picks `UringQueue` or `SyncQueue`).
   `attach` checks the pool for a maximal large batch and a staging batch
   only; the reclaim window shrinks to the pool's largest class if it has to.
-- **`Descriptor` completions for a detached descriptor** are dropped by the
-  queue; `Writer::detach` and `Reader::detach` are the only way to release
-  a slot, and dropping a `Writer` without detaching leaks its slot until the
-  queue goes away (the engine's `writer_taken` flag is cleared either way).
+- **Descriptor lifetime** extends through every accepted I/O, including staged
+  submissions. Detaching closes the inbox and discards completions, but the
+  slot and fixed-file binding remain reserved until outstanding I/O is reaped.
+  Dropping a pipeline without detaching leaves its descriptor allocated until
+  the queue goes away. Dropping a reader releases all its segment pins,
+  including those for reads waiting for queue room.
+- **Index pinning** revalidates both the table pointer and the entry sequence
+  after taking a segment pin, so a lookup in a retired table cannot bypass
+  reclaim. Capacity reporting uses atomic metadata without dereferencing a
+  potentially retired table.
+- **Auxiliary I/O** checks the transferred length, including segment headers
+  and reclaim reads. A short reclaim read aborts the pass without freeing its
+  source segment.
 - **io_uring setup** uses `SINGLE_ISSUER` + `DEFER_TASKRUN` when the kernel
   accepts them (completion work runs only inside our own `io_uring_enter`,
   so a non-waiting `poll` enters with `GETEVENTS`), falling back to a plain


### PR DESCRIPTION
The engine runs non-blocking read and write pipelines through a worker-owned I/O queue, and `moat-server` provides disk discovery, placement, recovery, and the worker runtime. Each worker owns its queue and readers; each disk has one writer.

Read verification is disabled by default. Setting `Options::verify_reads = true` validates the record header and every checksum block touched by each read. Unchecked range reads fetch only the required pages; expiring records still validate their headers. Checksum generation and verification use `crc-fast`. Stored checksums, recovery/reclaim validation, and the on-disk format are preserved. Benchmarks expose verification through `MOAT_BENCH_VERIFY=1`.

The implementation shares flush/seal barrier construction, stores record offsets once, reuses completion storage, and removes unused counters, types, and wrappers. The unused `Arena::as_slice` interface is removed because it could alias mutable pool buffers. Checksum transport and client-side verification remain unimplemented.

Lifecycle and error handling:

- Detached descriptors retain their slot and fixed-file binding until all accepted I/O completes, including staged submissions. Their completions are discarded.
- Dropping a reader releases pins for both submitted and queued reads. Index lookups revalidate the table and entry after pinning; capacity queries do not dereference retired tables.
- Short auxiliary I/O reports failure, and short reclaim reads preserve the source segment. I/O buffer bounds are enforced in release builds.
- Adaptive workers wait when idle with I/O outstanding. Recovery joins every disk's thread before returning an error.

Validation:

- `cargo test --workspace` (98 tests, including doctests)
- Release-mode regression test for oversized I/O
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `typos`, `taplo fmt --check`, and `cargo sort --workspace --check`
- `cargo-machete` and `license-eye header check`
- `git diff --cached --check`
