### PR TITLE
refactor(engine): remove chunk TTL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ reclaim and randomized model tests against an in-memory device.
 Server-side payload CRC verification is disabled by default
 (`Options::verify_reads = false`). Set it to `true` to verify the record header
 and every 64 KiB checksum block touched by each read. Unchecked reads cover
-only the requested pages; expiring records still read and validate their
-header. Checksum generation and recovery/reclaim validation are unchanged.
+only the requested pages. Checksum generation and recovery/reclaim validation
+are unchanged.
 Client-side transport and verification are not implemented yet.
 
 ## Benchmarking

--- a/core/moat-engine/benches/engine.rs
+++ b/core/moat-engine/benches/engine.rs
@@ -224,7 +224,7 @@ fn read_loop(
         reader.poll(q, &mut out).unwrap();
         for c in out.drain(..) {
             let slot = c.token as usize;
-            let data = c.result.unwrap().expect("not expired");
+            let data = c.result.unwrap();
             assert_eq!(data.len(), len);
             black_box(&*data);
             if let Some(t) = started[slot].take() {

--- a/core/moat-engine/src/blocking.rs
+++ b/core/moat-engine/src/blocking.rs
@@ -97,7 +97,7 @@ pub fn get(q: &mut dyn IoQueue, r: &mut Reader, id: &ChunkId, range: Option<Rang
     loop {
         r.poll(q, &mut out)?;
         if let Some(pos) = out.iter().position(|c| c.token == TOKEN) {
-            return out.swap_remove(pos).result;
+            return out.swap_remove(pos).result.map(Some);
         }
         q.poll(true)?;
     }

--- a/core/moat-engine/src/engine.rs
+++ b/core/moat-engine/src/engine.rs
@@ -20,6 +20,7 @@ use std::{
         Arc,
         atomic::{AtomicBool, AtomicU64, Ordering},
     },
+    time::{SystemTime, UNIX_EPOCH},
 };
 
 use moat_common::{AlignedBuf, ChunkId, PAGE_SIZE};
@@ -34,7 +35,7 @@ use crate::{
         SUPERBLOCK_LEN, SegmentHeader, SegmentKind, SegmentState, Superblock, decode_footer, encode_footer, footer_len,
         large_batch_len,
     },
-    options::{Clock, FormatOptions, Options, SystemClock},
+    options::{FormatOptions, Options},
     reader::Reader,
     scan::{parse_batch, scan_batches_blocking},
     segments::{Geometry, SegmentTable},
@@ -59,7 +60,10 @@ pub fn format(device: &dyn Device, opts: &FormatOptions) -> Result<()> {
         segment_size: opts.segment_size,
         chunk_max: opts.chunk_max,
         segment_count: geometry.segment_count,
-        created_at: SystemClock.now_secs(),
+        created_at: SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs(),
     };
 
     let mut page = AlignedBuf::zeroed(SEGMENT_HEADER_LEN as usize);
@@ -165,8 +169,7 @@ pub struct Engine {
 impl Engine {
     /// Returns metadata about a chunk without touching the disk.
     ///
-    /// Expiry is not evaluated here; an expired chunk still reports its stat
-    /// until reclaim drops it. Management path: a thread that reads regularly
+    /// Management path: a thread that reads regularly
     /// should use [`Reader::stat`] instead.
     pub fn stat(&self, id: &ChunkId) -> Option<ChunkStat> {
         self.shared

--- a/core/moat-engine/src/index.rs
+++ b/core/moat-engine/src/index.rs
@@ -56,21 +56,16 @@ pub(crate) const FLAG_DEAD: u32 = 4;
 /// Index flag: the record lives in a framed batch (header separate from the
 /// page-aligned value).
 pub const FLAG_FRAMED: u32 = 8;
-/// Index flag: the record carries an expiry time in its header.
-pub const FLAG_EXPIRES: u32 = 16;
 
 /// Translates on-disk record flags into index flags.
 pub(crate) fn flags_from_record(record_flags: u8) -> u32 {
-    use crate::layout::{RECORD_FLAG_EXPIRES, RECORD_FLAG_FRAMED, RECORD_FLAG_LARGE};
+    use crate::layout::{RECORD_FLAG_FRAMED, RECORD_FLAG_LARGE};
     let mut flags = 0;
     if record_flags & RECORD_FLAG_LARGE != 0 {
         flags |= FLAG_LARGE;
     }
     if record_flags & RECORD_FLAG_FRAMED != 0 {
         flags |= FLAG_FRAMED;
-    }
-    if record_flags & RECORD_FLAG_EXPIRES != 0 {
-        flags |= FLAG_EXPIRES;
     }
     flags
 }
@@ -113,12 +108,6 @@ impl IndexValue {
         self.flags & FLAG_FRAMED != 0
     }
 
-    /// Whether the record has an expiry time.
-    #[inline]
-    pub fn expires(&self) -> bool {
-        self.flags & FLAG_EXPIRES != 0
-    }
-
     /// Whether the record has been read since written or relocated.
     #[inline]
     pub fn is_accessed(&self) -> bool {
@@ -129,16 +118,13 @@ impl IndexValue {
     /// accounting.
     #[inline]
     pub(crate) fn record_flags(&self) -> u8 {
-        use crate::layout::{RECORD_FLAG_EXPIRES, RECORD_FLAG_FRAMED, RECORD_FLAG_LARGE};
+        use crate::layout::{RECORD_FLAG_FRAMED, RECORD_FLAG_LARGE};
         let mut flags = 0;
         if self.is_large() {
             flags |= RECORD_FLAG_LARGE;
         }
         if self.is_framed() {
             flags |= RECORD_FLAG_FRAMED;
-        }
-        if self.expires() {
-            flags |= RECORD_FLAG_EXPIRES;
         }
         flags
     }

--- a/core/moat-engine/src/layout.rs
+++ b/core/moat-engine/src/layout.rs
@@ -82,8 +82,6 @@ pub const RECORD_FLAG_LARGE: u8 = 1;
 /// Record flag: the record is in a framed batch (header in the batch's header
 /// area, value page aligned).
 pub const RECORD_FLAG_FRAMED: u8 = 2;
-/// Record flag: the record has an expiry time.
-pub const RECORD_FLAG_EXPIRES: u8 = 4;
 
 // ---------------------------------------------------------------------------
 // Superblock
@@ -411,8 +409,6 @@ pub struct RecordHeader {
     pub lsn: u64,
     /// The chunk identifier.
     pub key: ChunkId,
-    /// Unix time (seconds) after which the record is expired; zero for never.
-    pub expire_at: u64,
 }
 
 impl RecordHeader {
@@ -451,8 +447,7 @@ impl RecordHeader {
             .u32(0)
             .u64(self.lsn)
             .bytes(self.key.as_bytes())
-            .u64(self.expire_at)
-            .skip(8);
+            .skip(16); // reserved
         debug_assert_eq!(w.position(), RECORD_HEADER_LEN);
         for c in checksums {
             w.u32(*c);
@@ -489,7 +484,6 @@ impl RecordHeader {
         r.skip(4);
         let lsn = r.u64();
         let key = ChunkId::from_bytes(r.array());
-        let expire_at = r.u64();
         Some((
             Self {
                 kind,
@@ -497,7 +491,6 @@ impl RecordHeader {
                 value_len,
                 lsn,
                 key,
-                expire_at,
             },
             BlockChecksums(&buf[RECORD_HEADER_LEN..meta_len]),
         ))
@@ -829,7 +822,6 @@ mod tests {
             value_len: 65536 * 2 + 1,
             lsn: 9,
             key: ChunkId::from_u128(123),
-            expire_at: 0,
         };
         let sums = [1u32, 2, 3];
         let mut buf = vec![0u8; hdr.meta_len()];

--- a/core/moat-engine/src/lib.rs
+++ b/core/moat-engine/src/lib.rs
@@ -99,9 +99,9 @@ mod writer;
 pub use device::{Device, FileDevice, MemDevice};
 pub use engine::{ChunkStat, Engine, RecoveryReport, Usage, format, open};
 pub use error::{Error, Result};
-pub use index::{FLAG_ACCESSED, FLAG_EXPIRES, FLAG_FRAMED, FLAG_LARGE, IndexValue, Location, MAX_READERS};
+pub use index::{FLAG_ACCESSED, FLAG_FRAMED, FLAG_LARGE, IndexValue, Location, MAX_READERS};
 pub use io::{Descriptor, IoQueue, QueueOptions};
-pub use options::{Clock, FormatOptions, ManualClock, Options, SystemClock};
+pub use options::{FormatOptions, Options};
 pub use reader::{ChunkData, ReadCompletion, ReadOutcome, Reader};
 pub use writer::{
     Completion, DeleteOutcome, LargeValue, Lsn, Outcome, PutOptions, PutOutcome, ReclaimPolicy, ReclaimReport, Ticket,

--- a/core/moat-engine/src/options.rs
+++ b/core/moat-engine/src/options.rs
@@ -14,14 +14,6 @@
 
 //! Runtime and format-time options.
 
-use std::{
-    sync::{
-        Arc,
-        atomic::{AtomicU64, Ordering},
-    },
-    time::{SystemTime, UNIX_EPOCH},
-};
-
 use moat_common::{PAGE_SIZE, is_aligned};
 
 use crate::{
@@ -29,58 +21,10 @@ use crate::{
     layout::{BATCH_HEADER_LEN, SEGMENT_HEADER_LEN, footer_len, large_batch_len},
 };
 
-/// A source of wall-clock time in seconds, used for record expiry.
-pub trait Clock: Send + Sync + 'static {
-    /// Current Unix time in seconds.
-    fn now_secs(&self) -> u64;
-}
-
-/// The system clock.
-#[derive(Debug, Default, Clone, Copy)]
-pub struct SystemClock;
-
-impl Clock for SystemClock {
-    fn now_secs(&self) -> u64 {
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map(|d| d.as_secs())
-            .unwrap_or(0)
-    }
-}
-
-/// A clock that only moves when told to. Intended for tests.
-#[derive(Debug, Default)]
-pub struct ManualClock(AtomicU64);
-
-impl ManualClock {
-    /// Creates a clock at `now`.
-    pub fn new(now: u64) -> Self {
-        Self(AtomicU64::new(now))
-    }
-
-    /// Sets the current time.
-    pub fn set(&self, now: u64) {
-        self.0.store(now, Ordering::Relaxed);
-    }
-
-    /// Advances the current time by `secs`.
-    pub fn advance(&self, secs: u64) {
-        self.0.fetch_add(secs, Ordering::Relaxed);
-    }
-}
-
-impl Clock for ManualClock {
-    fn now_secs(&self) -> u64 {
-        self.0.load(Ordering::Relaxed)
-    }
-}
-
 /// Runtime options. None of these affect the on-disk format; a device may be
 /// opened with different options every time.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Options {
-    /// Clock used for expiry decisions.
-    pub clock: Arc<dyn Clock>,
     /// Values shorter than this are packed together with other small records
     /// into one batch; longer values get a large batch of their own and are
     /// written without copying. Default: 64 KiB.
@@ -105,7 +49,7 @@ pub struct Options {
     pub sync_on_flush: bool,
     /// Verify the record header and every checksum block touched by each `get`.
     /// Default: `false`; reads trust the index and do not scan the payload with
-    /// the CPU. Expiring records still read and validate their header for TTL.
+    /// the CPU.
     /// Writing checksums and recovery/reclaim validation are unaffected.
     pub verify_reads: bool,
 }
@@ -113,7 +57,6 @@ pub struct Options {
 impl Default for Options {
     fn default() -> Self {
         Self {
-            clock: Arc::new(SystemClock),
             pack_threshold: 64 * 1024,
             batch_limit: 1024 * 1024,
             scan_window: 4 * 1024 * 1024,
@@ -122,20 +65,6 @@ impl Default for Options {
             sync_on_flush: false,
             verify_reads: false,
         }
-    }
-}
-
-impl std::fmt::Debug for Options {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Options")
-            .field("pack_threshold", &self.pack_threshold)
-            .field("batch_limit", &self.batch_limit)
-            .field("scan_window", &self.scan_window)
-            .field("index_capacity", &self.index_capacity)
-            .field("index_memory_budget", &self.index_memory_budget)
-            .field("sync_on_flush", &self.sync_on_flush)
-            .field("verify_reads", &self.verify_reads)
-            .finish_non_exhaustive()
     }
 }
 

--- a/core/moat-engine/src/reader.rs
+++ b/core/moat-engine/src/reader.rs
@@ -96,8 +96,8 @@ pub enum ReadOutcome {
 pub struct ReadCompletion {
     /// The token passed to [`Reader::get`].
     pub token: u64,
-    /// The bytes, `None` if the chunk had expired, or an error.
-    pub result: Result<Option<ChunkData>>,
+    /// The bytes, or an error.
+    pub result: Result<ChunkData>,
 }
 
 struct PendingRead {
@@ -145,9 +145,6 @@ impl Reader {
     }
 
     /// Returns metadata about a chunk without touching the disk.
-    ///
-    /// Expiry is not evaluated here; an expired chunk still reports its stat
-    /// until reclaim drops it.
     pub fn stat(&self, id: &ChunkId) -> Option<ChunkStat> {
         self.shared.index.get(&self.slot, id).map(|v| ChunkStat::from_value(&v))
     }
@@ -194,7 +191,7 @@ impl Reader {
             value.value_off as u64,
             value.value_len,
             covered,
-            verify || value.expires(),
+            verify,
         );
         let range = (value.value_off as u64 + range.start - geometry.extent.start) as usize
             ..(value.value_off as u64 + range.end - geometry.extent.start) as usize;
@@ -278,7 +275,7 @@ impl Reader {
     }
 
     /// Applies optional verification and returns the requested range.
-    fn finish(&self, pending: &PendingRead, done: IoCompletion) -> Result<Option<ChunkData>> {
+    fn finish(&self, pending: &PendingRead, done: IoCompletion) -> Result<ChunkData> {
         let id = &pending.id;
         let value = &pending.value;
         let geometry = &pending.geometry;
@@ -304,9 +301,6 @@ impl Reader {
             if header.kind != RecordKind::Data {
                 return Err(Error::corrupt(format!("chunk {id}: index points at a tombstone")));
             }
-            if self.shared.is_expired(header.expire_at) {
-                return Ok(None);
-            }
             if self.shared.options.verify_reads {
                 let covered = &buf[geometry.data_in_extent.clone()];
                 if let Err(block) = verify_blocks_with(covered, pending.first_block, |i| checksums.get(i)) {
@@ -314,10 +308,10 @@ impl Reader {
                 }
             }
         }
-        Ok(Some(ChunkData {
+        Ok(ChunkData {
             buf,
             range: pending.range.clone(),
-        }))
+        })
     }
 }
 

--- a/core/moat-engine/src/shared.rs
+++ b/core/moat-engine/src/shared.rs
@@ -99,13 +99,4 @@ impl Shared {
             record_count: 0,
         }
     }
-
-    pub(crate) fn now(&self) -> u64 {
-        self.options.clock.now_secs()
-    }
-
-    /// Whether a record with the given expiry is expired at the current time.
-    pub(crate) fn is_expired(&self, expire_at: u64) -> bool {
-        expire_at != 0 && self.now() >= expire_at
-    }
 }

--- a/core/moat-engine/src/writer.rs
+++ b/core/moat-engine/src/writer.rs
@@ -74,9 +74,9 @@ use crate::{
     index::{IndexValue, IndexWriter, InsertOutcome, Location, flags_from_record},
     io::{Descriptor, IoCompletion, IoQueue},
     layout::{
-        BATCH_HEADER_LEN, BatchHeader, BatchKind, FooterEntry, RECORD_ALIGN, RECORD_FLAG_EXPIRES, RECORD_FLAG_FRAMED,
-        RECORD_FLAG_LARGE, RecordGeometry, RecordHeader, RecordKind, SEGMENT_HEADER_LEN, SegmentHeader, SegmentKind,
-        SegmentState, encode_footer, footer_len, large_batch_len, large_value_offset, prefer_framed, record_meta_len,
+        BATCH_HEADER_LEN, BatchHeader, BatchKind, FooterEntry, RECORD_ALIGN, RECORD_FLAG_FRAMED, RECORD_FLAG_LARGE,
+        RecordGeometry, RecordHeader, RecordKind, SEGMENT_HEADER_LEN, SegmentHeader, SegmentKind, SegmentState,
+        encode_footer, footer_len, large_batch_len, large_value_offset, prefer_framed, record_meta_len,
     },
     scan::{BatchStep, max_batch_len, next_batch, parse_batch},
     shared::Shared,
@@ -99,9 +99,6 @@ pub struct PutOptions {
     /// default) a put of an existing identifier returns
     /// [`PutOutcome::Exists`] without writing anything.
     pub overwrite: bool,
-    /// Unix time (seconds) after which the chunk reads as missing and reclaim
-    /// drops it. Zero means never.
-    pub expire_at: u64,
 }
 
 /// Result of a `put`.
@@ -189,7 +186,7 @@ pub struct ReclaimReport {
     pub records: u64,
     /// Live data records copied to a cold segment.
     pub relocated: u64,
-    /// Data records dropped (dead, expired, or evicted).
+    /// Data records dropped (dead or evicted).
     pub dropped: u64,
     /// Tombstones copied forward because an older version might still exist.
     pub tombstones_relocated: u64,
@@ -633,36 +630,29 @@ fn batch_slot(kind: BatchKind) -> usize {
 }
 
 /// Chooses how a small (below the pack threshold) value is stored.
-fn small_batch_kind(value_len: u32, expire_at: u64) -> BatchKind {
-    // Expiring records always read their header for TTL; keep it adjacent to
-    // the value so those reads do not span a separate framed header area.
-    if expire_at == 0 && prefer_framed(value_len) {
+fn small_batch_kind(value_len: u32) -> BatchKind {
+    if prefer_framed(value_len) {
         BatchKind::Framed
     } else {
         BatchKind::Inline
     }
 }
 
-fn record_flags(batch: BatchKind, expire_at: u64) -> u8 {
-    let mut flags = match batch {
+fn record_flags(batch: BatchKind) -> u8 {
+    match batch {
         BatchKind::Large => RECORD_FLAG_LARGE,
         BatchKind::Framed => RECORD_FLAG_FRAMED,
         BatchKind::Inline => 0,
-    };
-    if expire_at != 0 {
-        flags |= RECORD_FLAG_EXPIRES;
     }
-    flags
 }
 
-fn header(kind: RecordKind, flags: u8, value_len: u32, lsn: Lsn, key: ChunkId, expire_at: u64) -> RecordHeader {
+fn header(kind: RecordKind, flags: u8, value_len: u32, lsn: Lsn, key: ChunkId) -> RecordHeader {
     RecordHeader {
         kind,
         flags,
         value_len,
         lsn,
         key,
-        expire_at,
     }
 }
 
@@ -750,8 +740,8 @@ impl Writer {
             large.value_mut().copy_from_slice(value);
             self.ensure_room(q, SegmentKind::Hot, large_batch_len(len), 1)?;
             let (ticket, lsn) = self.next_ids();
-            let flags = record_flags(BatchKind::Large, opts.expire_at);
-            let hdr = header(RecordKind::Data, flags, len, lsn, id, opts.expire_at);
+            let flags = record_flags(BatchKind::Large);
+            let hdr = header(RecordKind::Data, flags, len, lsn, id);
             self.write_large(
                 q,
                 SegmentKind::Hot,
@@ -763,11 +753,11 @@ impl Writer {
             );
             Ok(PutOutcome::Written { ticket, lsn })
         } else {
-            let batch = small_batch_kind(len, opts.expire_at);
+            let batch = small_batch_kind(len);
             self.reserve_small(q, SegmentKind::Hot, batch, value.len())?;
             let (ticket, lsn) = self.next_ids();
-            let flags = record_flags(batch, opts.expire_at);
-            let hdr = header(RecordKind::Data, flags, len, lsn, id, opts.expire_at);
+            let flags = record_flags(batch);
+            let hdr = header(RecordKind::Data, flags, len, lsn, id);
             self.append_small(
                 q,
                 SegmentKind::Hot,
@@ -835,8 +825,8 @@ impl Writer {
         };
         self.ensure_room(q, SegmentKind::Hot, large_batch_len(value.len()), 1)?;
         let (ticket, lsn) = self.next_ids();
-        let flags = record_flags(BatchKind::Large, opts.expire_at);
-        let hdr = header(RecordKind::Data, flags, value.len(), lsn, id, opts.expire_at);
+        let flags = record_flags(BatchKind::Large);
+        let hdr = header(RecordKind::Data, flags, value.len(), lsn, id);
         self.write_large(
             q,
             SegmentKind::Hot,
@@ -867,7 +857,7 @@ impl Writer {
         }
         let (ticket, lsn) = self.next_ids();
         self.deleted.insert(*id, Tombstone { lsn, applied: false });
-        let hdr = header(RecordKind::Tombstone, 0, 0, lsn, *id, 0);
+        let hdr = header(RecordKind::Tombstone, 0, 0, lsn, *id);
         self.append_small(
             q,
             SegmentKind::Hot,
@@ -2099,7 +2089,6 @@ impl Writer {
                 // it is dropped rather than copied forward.
                 let intact = verify_blocks_with(value, 0, |b| checksums.get(b as usize).copied()).is_ok();
                 let keep = intact
-                    && !self.shared.is_expired(hdr.expire_at)
                     && match policy {
                         ReclaimPolicy::Storage => true,
                         ReclaimPolicy::Cache { reinsert_accessed } => reinsert_accessed && current.is_accessed(),
@@ -2120,14 +2109,14 @@ impl Writer {
                     let mut large = self.prepare_large(q, hdr.value_len)?;
                     self.ensure_room(q, SegmentKind::Cold, large_batch_len(hdr.value_len), 1)?;
                     large.value_mut().copy_from_slice(value);
-                    let flags = record_flags(BatchKind::Large, hdr.expire_at);
-                    let new = header(RecordKind::Data, flags, hdr.value_len, hdr.lsn, hdr.key, hdr.expire_at);
+                    let flags = record_flags(BatchKind::Large);
+                    let new = header(RecordKind::Data, flags, hdr.value_len, hdr.lsn, hdr.key);
                     self.write_large(q, SegmentKind::Cold, &new, checksums, large.buf, apply, None);
                 } else {
-                    let batch = small_batch_kind(hdr.value_len, hdr.expire_at);
+                    let batch = small_batch_kind(hdr.value_len);
                     self.reserve_small(q, SegmentKind::Cold, batch, value.len())?;
-                    let flags = record_flags(batch, hdr.expire_at);
-                    let new = header(RecordKind::Data, flags, hdr.value_len, hdr.lsn, hdr.key, hdr.expire_at);
+                    let flags = record_flags(batch);
+                    let new = header(RecordKind::Data, flags, hdr.value_len, hdr.lsn, hdr.key);
                     self.append_small(q, SegmentKind::Cold, batch, &new, checksums, value, apply, None);
                 }
                 let report = &mut self.reclaim.as_mut().expect("job exists").report;
@@ -2143,7 +2132,7 @@ impl Writer {
                     self.reclaim.as_mut().expect("job exists").report.tombstones_dropped += 1;
                 } else {
                     self.reserve_small(q, SegmentKind::Cold, BatchKind::Inline, 0)?;
-                    let new = header(RecordKind::Tombstone, 0, 0, hdr.lsn, hdr.key, 0);
+                    let new = header(RecordKind::Tombstone, 0, 0, hdr.lsn, hdr.key);
                     self.append_small(
                         q,
                         SegmentKind::Cold,
@@ -2177,11 +2166,12 @@ mod tests {
 
     #[test]
     fn short_auxiliary_io_fails_without_reclaiming_live_data() {
+        use moat_common::{HugePages, PoolOptions};
+
         use crate::{
             FormatOptions, MemDevice, Options, QueueOptions, blocking,
             io::{CompletionOrder, SyncQueue},
         };
-        use moat_common::{HugePages, PoolOptions};
 
         for reclaim in [false, true] {
             let device = Arc::new(MemDevice::new(5 << 20));
@@ -2247,8 +2237,7 @@ mod tests {
     #[test]
     fn framing_decision_for_near_page_multiples() {
         assert!(prefer_framed(40942));
-        assert_eq!(small_batch_kind(40942, 0), BatchKind::Framed);
-        assert_eq!(small_batch_kind(40942, 5), BatchKind::Inline);
-        assert_eq!(small_batch_kind(5000, 0), BatchKind::Inline);
+        assert_eq!(small_batch_kind(40942), BatchKind::Framed);
+        assert_eq!(small_batch_kind(5000), BatchKind::Inline);
     }
 }

--- a/core/moat-engine/tests/engine.rs
+++ b/core/moat-engine/tests/engine.rs
@@ -23,8 +23,8 @@ use std::{collections::HashMap, sync::Arc};
 
 use moat_common::{ChunkId, HugePages, PoolOptions};
 use moat_engine::{
-    DeleteOutcome, Engine, Error, FormatOptions, IoQueue, ManualClock, MemDevice, Options, Outcome, PutOptions,
-    PutOutcome, QueueOptions, Reader, ReclaimPolicy, Writer, blocking,
+    DeleteOutcome, Engine, Error, FormatOptions, IoQueue, MemDevice, Options, Outcome, PutOptions, PutOutcome,
+    QueueOptions, Reader, ReclaimPolicy, Writer, blocking,
     io::{CompletionOrder, SyncQueue},
 };
 
@@ -334,10 +334,7 @@ fn out_of_order_completions_are_applied_in_order() {
     let mut q = SyncQueue::new(&queue_options(), CompletionOrder::Reverse).unwrap();
     let mut writer = engine.writer(&mut q).unwrap();
     let mut reader = engine.reader(&mut q).unwrap();
-    let overwrite = PutOptions {
-        overwrite: true,
-        ..Default::default()
-    };
+    let overwrite = PutOptions { overwrite: true };
     let mut expected = HashMap::new();
     let mut rng = XorShift(0x5151);
     // Many overwrites of a small key set with mixed sizes: large records are
@@ -534,10 +531,7 @@ fn overwrite_semantics() {
     );
     assert_eq!(read(&mut q, &mut reader, &id(1)).unwrap(), v0);
 
-    let overwrite = PutOptions {
-        overwrite: true,
-        ..Default::default()
-    };
+    let overwrite = PutOptions { overwrite: true };
     let PutOutcome::Written { lsn: lsn1, .. } = writer.put(&mut q, id(1), &v1, overwrite).unwrap() else {
         panic!()
     };
@@ -609,10 +603,7 @@ fn delete_interleaved_with_pending_puts() {
     assert!(matches!(writer.delete(&mut q, &id(4)).unwrap(), DeleteOutcome::Missing));
     // Large put (submitted at once) then a small pending put of the same key,
     // then a delete, then a new put: the last put must be what remains.
-    let overwrite = PutOptions {
-        overwrite: true,
-        ..Default::default()
-    };
+    let overwrite = PutOptions { overwrite: true };
     writer.put(&mut q, id(2), &value_for(2, 0, 70_000), overwrite).unwrap();
     writer.put(&mut q, id(2), b"small", overwrite).unwrap();
     assert!(matches!(
@@ -809,48 +800,36 @@ fn bit_rot_in_sealed_value_is_detected_and_reclaim_drops_it() {
 }
 
 #[test]
-fn header_validation_is_required_for_verification_or_expiry() {
+fn header_validation_is_required_only_for_verified_reads() {
     for verify_reads in [false, true] {
-        for expire_at in [0, u64::MAX] {
-            let device = new_device(4);
-            let engine = open_with(
-                &device,
-                Options {
-                    verify_reads,
-                    ..options()
-                },
-            );
-            let mut q = queue();
-            let mut writer = engine.writer(&mut q).unwrap();
-            let mut reader = engine.reader(&mut q).unwrap();
-            let value = value_for(1, 0, 100_000);
-            writer
-                .put(
-                    &mut q,
-                    id(1),
-                    &value,
-                    PutOptions {
-                        expire_at,
-                        ..Default::default()
-                    },
-                )
-                .unwrap();
-            flush(&mut q, &mut writer);
-            let stat = reader.stat(&id(1)).unwrap();
-            let segment = SEGMENT * (stat.segment as u64 + 1);
-            // The first large batch follows the segment header page.
-            let header = segment as usize + 4096 + moat_engine::layout::BATCH_HEADER_LEN;
-            device.with_data_mut(|data| data[header] ^= 1);
-            for range in [0..10, 70000..70010, 100_000..100_000] {
-                let result = blocking::get(&mut q, &mut reader, &id(1), Some(range.clone()));
-                if verify_reads || expire_at != 0 {
-                    assert!(matches!(result, Err(Error::Corrupt(_))));
-                } else {
-                    assert_eq!(
-                        &*result.unwrap().unwrap(),
-                        &value[range.start as usize..range.end as usize]
-                    );
-                }
+        let device = new_device(4);
+        let engine = open_with(
+            &device,
+            Options {
+                verify_reads,
+                ..options()
+            },
+        );
+        let mut q = queue();
+        let mut writer = engine.writer(&mut q).unwrap();
+        let mut reader = engine.reader(&mut q).unwrap();
+        let value = value_for(1, 0, 100_000);
+        writer.put(&mut q, id(1), &value, PutOptions::default()).unwrap();
+        flush(&mut q, &mut writer);
+        let stat = reader.stat(&id(1)).unwrap();
+        let segment = SEGMENT * (stat.segment as u64 + 1);
+        // The first large batch follows the segment header page.
+        let header = segment as usize + 4096 + moat_engine::layout::BATCH_HEADER_LEN;
+        device.with_data_mut(|data| data[header] ^= 1);
+        for range in [0..10, 70000..70010, 100_000..100_000] {
+            let result = blocking::get(&mut q, &mut reader, &id(1), Some(range.clone()));
+            if verify_reads {
+                assert!(matches!(result, Err(Error::Corrupt(_))));
+            } else {
+                assert_eq!(
+                    &*result.unwrap().unwrap(),
+                    &value[range.start as usize..range.end as usize]
+                );
             }
         }
     }
@@ -897,10 +876,7 @@ fn reclaim_storage_keeps_every_live_chunk() {
     let (engine, mut q, mut writer, mut reader) = setup(&device);
     let mut rng = XorShift(0xbeef);
     let mut model: HashMap<u128, Vec<u8>> = HashMap::new();
-    let overwrite = PutOptions {
-        overwrite: true,
-        ..Default::default()
-    };
+    let overwrite = PutOptions { overwrite: true };
 
     for round in 0..6u32 {
         for i in 0..150u128 {
@@ -957,10 +933,7 @@ fn reclaim_storage_keeps_every_live_chunk() {
 fn reclaim_runs_concurrently_with_foreground_writes() {
     let device = new_device(24);
     let (engine, mut q, mut writer, mut reader) = setup(&device);
-    let overwrite = PutOptions {
-        overwrite: true,
-        ..Default::default()
-    };
+    let overwrite = PutOptions { overwrite: true };
     let mut model: HashMap<u128, Vec<u8>> = HashMap::new();
     let mut rng = XorShift(0xc0ffee);
     for i in 0..200u128 {
@@ -1092,46 +1065,6 @@ fn reclaim_cache_evicts_oldest_and_reinserts_accessed() {
 }
 
 #[test]
-fn expiry_hides_and_reclaim_drops() {
-    let clock = Arc::new(ManualClock::new(1_000));
-    let device = new_device(6);
-    let engine = open_with(
-        &device,
-        Options {
-            clock: clock.clone(),
-            ..options()
-        },
-    );
-    let mut q = queue();
-    let mut writer = engine.writer(&mut q).unwrap();
-    let mut reader = engine.reader(&mut q).unwrap();
-    writer
-        .put(
-            &mut q,
-            id(1),
-            b"ephemeral",
-            PutOptions {
-                expire_at: 1_100,
-                ..Default::default()
-            },
-        )
-        .unwrap();
-    writer.put(&mut q, id(2), b"forever", PutOptions::default()).unwrap();
-    flush(&mut q, &mut writer);
-    assert!(read(&mut q, &mut reader, &id(1)).is_some());
-    clock.set(1_100);
-    assert!(read(&mut q, &mut reader, &id(1)).is_none());
-    assert!(read(&mut q, &mut reader, &id(2)).is_some());
-
-    seal(&mut q, &mut writer);
-    let report = reclaim(&mut q, &mut writer, ReclaimPolicy::Storage).unwrap();
-    assert_eq!(report.dropped, 1);
-    assert_eq!(report.relocated, 1);
-    assert!(!engine.contains(&id(1)));
-    assert!(read(&mut q, &mut reader, &id(2)).is_some());
-}
-
-#[test]
 fn no_space_is_reported_not_panicked() {
     let device = new_device(2);
     let (_engine, mut q, mut writer, _reader) = setup(&device);
@@ -1174,15 +1107,7 @@ fn index_budget_is_enforced() {
     assert_eq!(n, 56, "a 64-slot table takes 7/8 load");
     // Overwrites still work at the budget.
     assert!(matches!(
-        writer.put(
-            &mut q,
-            id(0),
-            b"w",
-            PutOptions {
-                overwrite: true,
-                ..Default::default()
-            }
-        ),
+        writer.put(&mut q, id(0), b"w", PutOptions { overwrite: true }),
         Ok(PutOutcome::Written { .. })
     ));
     // One delete is not enough: a rebuild at the same size needs the live
@@ -1261,16 +1186,7 @@ fn randomized_against_model() {
                 let version = versions.entry(k).or_insert(0);
                 *version += 1;
                 let v = value_for(k, *version, random_len(&mut rng));
-                let outcome = put(
-                    &mut q,
-                    &mut writer,
-                    id(k),
-                    &v,
-                    PutOptions {
-                        overwrite: true,
-                        ..Default::default()
-                    },
-                );
+                let outcome = put(&mut q, &mut writer, id(k), &v, PutOptions { overwrite: true });
                 assert!(matches!(outcome, PutOutcome::Written { .. }));
                 model.insert(k, (*version, v));
             }
@@ -1368,10 +1284,7 @@ fn concurrent_readers_never_see_torn_values() {
         })
         .collect();
 
-    let overwrite = PutOptions {
-        overwrite: true,
-        ..Default::default()
-    };
+    let overwrite = PutOptions { overwrite: true };
     for round in 1..40u32 {
         for k in 0..keys {
             put(&mut q, &mut writer, id(k), &value_for(k, round, len), overwrite);
@@ -1485,25 +1398,10 @@ fn framed_records_roundtrip_recover_and_reclaim() {
         put(&mut q, &mut writer, id(i), &v, PutOptions::default());
         expected.insert(i, v);
     }
-    // An expiring page-sized value must not be framed (its expiry lives in the
-    // header); it still reads back correctly.
-    let clockless = value_for(1000, 0, 4096);
-    writer
-        .put(
-            &mut q,
-            id(1000),
-            &clockless,
-            PutOptions {
-                expire_at: u64::MAX,
-                ..Default::default()
-            },
-        )
-        .unwrap();
     flush(&mut q, &mut writer);
     for (i, v) in &expected {
         assert_eq!(read(&mut q, &mut reader, &id(*i)).unwrap(), *v, "key {i}");
     }
-    assert_eq!(read(&mut q, &mut reader, &id(1000)).unwrap(), clockless);
     // Range reads inside a framed value.
     let got = blocking::get(&mut q, &mut reader, &id(0), Some(100..300))
         .unwrap()
@@ -1535,7 +1433,7 @@ fn framed_records_roundtrip_recover_and_reclaim() {
     let (engine, report) = moat_engine::open(device.clone(), options()).unwrap();
     let mut q = queue();
     let mut reader = engine.reader(&mut q).unwrap();
-    assert_eq!(report.chunks, expected.len() + 1);
+    assert_eq!(report.chunks, expected.len());
     for (i, v) in &expected {
         assert_eq!(
             read(&mut q, &mut reader, &id(*i)).unwrap(),
@@ -1685,7 +1583,7 @@ fn tiny_ring_depth_is_absorbed_by_ready_queues() {
         reader.poll(&mut q, &mut out).unwrap();
         for c in out.drain(..) {
             let i = tokens.remove(&c.token).unwrap();
-            assert_eq!(&*c.result.unwrap().unwrap(), &expected[&i][..]);
+            assert_eq!(&*c.result.unwrap(), &expected[&i][..]);
         }
     }
     assert_eq!(reader.in_flight(), 0);

--- a/core/moat-server/benches/node.rs
+++ b/core/moat-server/benches/node.rs
@@ -346,7 +346,7 @@ impl Load {
             self.read_free.push(slot);
             self.read_outstanding -= 1;
             debug_assert_eq!(d, disk);
-            let data = c.result.unwrap().expect("not expired");
+            let data = c.result.unwrap();
             debug_assert_eq!(data.len(), len);
             if let Some(started) = started {
                 self.hist.record(started.elapsed());

--- a/core/moat-server/tests/worker.rs
+++ b/core/moat-server/tests/worker.rs
@@ -141,7 +141,7 @@ impl Handler for Load {
         for (disk, c) in cx.reads.drain(..) {
             let (d, i) = self.reads_pending.remove(&c.token).expect("known token");
             assert_eq!(d, disk);
-            let data = c.result.unwrap().expect("not expired");
+            let data = c.result.unwrap();
             assert_eq!(&*data, &value(disk, i)[..], "key {i} disk {disk}");
             self.reads_done += 1;
         }

--- a/docs/design/chunkserver.md
+++ b/docs/design/chunkserver.md
@@ -44,7 +44,7 @@
 ### 1.2 Assumptions added by this document
 
 - **Hardware baseline**: PCIe 5 NVMe (~10 GB/s sequential read, ~5–7 GB/s write per disk), 4–8 × 400 Gb/s RDMA NICs (~46 GB/s usable each), 96+ cores, multiple NUMA nodes. 24 disks aggregate to 150–200 GB/s, matching four 400G NICs.
-- **Semantic baseline**: the chunkserver is a **single-node, durable, correct** chunk store. Once a PUT is acknowledged it must be readable after a restart unless the disk fails; the engine must **never return wrong data** (it returns MISS or CORRUPT instead). Cache semantics (eviction, TTL) are a **policy switch** on top of the engine, not a second engine.
+- **Semantic baseline**: the chunkserver is a **single-node, durable, correct** chunk store. Once a PUT is acknowledged it must be readable after a restart unless the disk fails; the engine must **never return wrong data** (it returns MISS or CORRUPT instead). Cache eviction is a **policy switch** on top of the engine, not a second engine.
 - **Enterprise drives have power-loss protection**; by default no flush is issued on the data path. A `sync_mode` option exists for drives without it.
 - **Replication is not inside the chunkserver**: replicas, erasure coding or chain replication are built above it (client-side multi-write or a separate replication layer). The engine exposes `lsn` and `if_absent` primitives so that layer can replay idempotently (see §11).
 
@@ -52,6 +52,7 @@
 
 - POSIX file semantics; partial overwrite inside a chunk (emulate with read-modify-write of a new version at the client).
 - Server-side range listing or prefix scans.
+- 对象 TTL 和生命周期由上层管理；chunkserver 通过显式删除和 GC 回收数据，不按时间使 chunk 过期。
 - Multi-tenancy isolation and encryption (flag bits are reserved in the protocol; not in v0).
 
 ---
@@ -82,14 +83,13 @@ pub struct ChunkId(pub [u8; 16]);          // opaque to the chunkserver
 pub struct PutOptions {
     pub overwrite: bool,      // false: an existing id returns Exists (immutable semantics, default)
                               // true: the new version replaces the old one
-    pub expire_at: u64,       // cache-mode TTL in seconds since the epoch; 0 = never
 }
 
 // server semantics
 put(id, value, block_crcs, opts) -> Ok { lsn } | Exists | Throttle | NoSpace | Err
 get(id, offset, len)               -> Ok { total_len, data } | Miss | Corrupt | Throttle | Err
 delete(id)                         -> Ok | Miss
-stat(id)                           -> Ok { len, lsn, expire_at } | Miss
+stat(id)                           -> Ok { len, lsn } | Miss
 ```
 
 - **Immutable by default**: a repeated PUT of the same id returns `Exists`, which clients treat as success (naturally idempotent). With `overwrite = true` the new record supersedes the old one, which GC collects later.
@@ -155,7 +155,7 @@ struct RecordHdr {          // 64 B; crc covers the rest of the header + block_c
     value_len: u32, block_count: u32,
     lsn: u64,
     key: ChunkId,           // 16 B
-    expire_at: u64,
+    reserved: [u8; 16],
 }
 // followed by block_crcs: [u32; block_count]  (CRC32C per 64 KiB)
 ```
@@ -164,7 +164,7 @@ struct RecordHdr {          // 64 B; crc covers the rest of the header + block_c
 - In a large batch the value starts on the first page boundary after the headers, so the on-disk layout matches the RDMA landing buffer (the client writes to `buf + header_len`) and the batch goes to disk **without a copy**.
 - Fixed overhead per record: 64 B + 4 B per 64 KiB. A large record also pays its header page(s) and tail padding (≈ 0.15% at 4 MiB, ≈ 9% at 64 KiB — hence packing below 64 KiB).
 - A tombstone is a record with `value_len = 0, kind = Tombstone`; it goes into a packed batch and is essentially free.
-- **Page layout for small values.** Inline records are aligned to eight bytes and moved to the next page when necessary to reduce page crossings. Values near a page multiple use a framed layout with grouped headers and page-aligned values. By default, readers use the index to read the requested value pages without a separate header; expiring records still read and validate the header. Enabling `verify_reads` expands the read to the complete checksum blocks touched by the range and includes the record header and checksum array. The index no longer caches a single-block CRC.
+- **Page layout for small values.** Inline records are aligned to eight bytes and moved to the next page when necessary to reduce page crossings. Values near a page multiple use a framed layout with grouped headers and page-aligned values. By default, readers use the index to read the requested value pages without a separate header. Enabling `verify_reads` expands the read to the complete checksum blocks touched by the range and includes the record header and checksum array. The index no longer caches a single-block CRC.
 
 ### 4.3 Write pipeline: one writer per disk
 
@@ -198,7 +198,7 @@ struct Entry {                 // 48 B
     key: ChunkId,              // 16 B
     seg_no: u32, offset: u32,  // location of the record header
     value_off: u32,            // location of the value (differs from the header for framed records)
-    value_len: u32, flags: u32,// LARGE, FRAMED, EXPIRES, ACCESSED
+    value_len: u32, flags: u32,// LARGE, FRAMED, ACCESSED
     crc: u32,                  // CRC32C of the first checksum block: verifies framed reads without the header
     lsn: u64,                  // recovery ordering + external version token
 }
@@ -216,7 +216,7 @@ struct Entry {                 // 48 B
 3. Append a 64 B tombstone (`kind = Tombstone`, fresh lsn) to the current packed batch.
 4. **Acknowledge only after that batch's completion**: a delete means "gone after a crash too"; acknowledging after the in-memory removal alone would let recovery resurrect the old record. Latency is one 4 KiB write plus two messages (~20–40 µs on a PLP drive); a 4 KiB page holds 60+ tombstones.
 
-Data is not touched; space is reclaimed asynchronously. A worker mid-read has pinned the segment (§4.4) and is unaffected. `overwrite = true` needs no tombstone (the higher-lsn data record supersedes the old one). TTL expiry is not a delete: a GET that sees an expired record returns `Miss` and posts a "lazy index removal" to the owner over the forwarding ring; no tombstone is written, and recovery drops expired records on load.
+Data is not touched; space is reclaimed asynchronously. A worker mid-read has pinned the segment (§4.4) and is unaffected. `overwrite = true` needs no tombstone (the higher-lsn data record supersedes the old one).
 
 **GC runs on the owner worker as a state machine advanced by `Writer::poll`, in small steps interleaved with foreground work**, not on its own thread, so it is serialised with PUT/Del by construction and needs no CAS. The reclaim procedure is identical in storage and cache mode:
 
@@ -235,7 +235,7 @@ pick_victim() → sequential read of the whole segment (io_uring, rate limited) 
 | Mode | `pick_victim` | `decide` |
 |---|---|---|
 | Storage | Trigger: free segments < 10%. Greedy: lowest live ratio; plus a forced pick of the oldest segment when it exceeds an age threshold or total tombstone volume exceeds a threshold (bounds tombstone lifetime) | Live → Relocate |
-| Cache | Trigger: free segments below a low-water mark (with hysteresis). FIFO: oldest segment | `ACCESSED` bit set → Relocate to Cold and clear the bit (S3-FIFO / SIEVE style reinsertion, ratio cap configurable); otherwise Drop; expired → Drop |
+| Cache | Trigger: free segments below a low-water mark (with hysteresis). FIFO: oldest segment | `ACCESSED` bit set → Relocate to Cold and clear the bit (S3-FIFO / SIEVE style reinsertion, ratio cap configurable); otherwise Drop |
 
 Reclaim mechanics:
 
@@ -275,7 +275,7 @@ Cost: headers 120 MB + footers ≈ index volume (48 B × records; 8 million ≈ 
    - A low-priority thread per disk copies the hash table in 1 MiB slices (readers are never blocked; a slice whose entries changed underneath, detected through the per-slot sequence numbers, is re-copied), memcpy to staging, then `WriteFixed` into `kind = Index` segments. The writer is never stalled; p99 is untouched.
    - After all slices complete, superblock A/B flips to the new image (with `L0`, replay start positions, the segment table, table capacity, hasher seed, per-slice CRCs); the old image's segments are freed.
    - Recovery: read the image straight into table memory (zero hashing, 21 GB ≈ 2 s); scan the two active segments from the recorded positions and every segment with `seg_seq` above the checkpoint's maximum; replay only records with `lsn ≥ L0`, merging with the image by **highest lsn** (image entries carry their lsn); drop entries pointing at `Free` segments or at segments whose `seg_seq` differs from the checkpoint's table (can be done lazily on read).
-   - Correctness: every index change after T0 is either a record with `lsn ≥ L0` (inserts, overwrites, relocations — taking the *lowest in-flight* lsn is what keeps in-flight writes' late index updates inside the replay range; a delete's index removal and its tombstone lsn are assigned in the same job, so the tombstone has `lsn ≥ L0`), or has no record at all — only cache-mode Drop eviction (caught by the segment-table check; if the segment has not been reused the entry comes back as live, harmless for a cache) and lazy TTL removal (re-evaluated on read). Slices are copied under the lock, so no torn entries.
+   - Correctness: every index change after T0 is either a record with `lsn ≥ L0` (inserts, overwrites, relocations — taking the *lowest in-flight* lsn is what keeps in-flight writes' late index updates inside the replay range; a delete's index removal and its tombstone lsn are assigned in the same job, so the tombstone has `lsn ≥ L0`), or has no record at all — only cache-mode Drop eviction (caught by the segment-table check; if the segment has not been reused the entry comes back as live, harmless for a cache). Slices are copied under the lock, so no torn entries.
    - Trigger: footer bytes written since the last checkpoint reach 10% of the image size (bounding replay to one tenth of a full rebuild), or a time limit, whichever first. At worst-case scale a checkpoint every 10 minutes is ~35 MB/s per disk (0.7% of write bandwidth, 0.1 DWPD); two images occupy 0.14% of the disk. At typical scale these are two orders of magnitude smaller.
    - The gain only shows when the index is very large (worst case 10–20 s → 3–4 s; typical scale barely changes), hence phase two. A clean-shutdown image is a special case (`L0` = next lsn, empty replay); the two share one mechanism.
 
@@ -284,7 +284,7 @@ Each disk recovers and comes online independently; a slow disk does not block th
 ### 4.7 Durability and consistency summary
 
 - PUT acknowledged ⇔ the completion of the record's batch `WriteFixed` has returned (durable on a PLP drive). With `sync_mode = fdatasync_per_batch` an `IORING_OP_FSYNC(DATASYNC)` follows each batch.
-- **Read verification is optional and disabled by default.** With `Options::verify_reads = true`, each read validates `RecordHdr.magic/crc`, key, LSN, value length and record kind, then verifies every 64 KiB checksum block touched by the requested range; failures return `Corrupt`. With verification disabled, readers rely on the index and segment pin to keep the location valid without scanning the payload. Expiring records still read and validate the header for TTL. Stored checksums and recovery/reclaim validation are unchanged. End-to-end client verification and checksum transport remain future network-layer work.
+- **Read verification is optional and disabled by default.** With `Options::verify_reads = true`, each read validates `RecordHdr.magic/crc`, key, LSN, value length and record kind, then verifies every 64 KiB checksum block touched by the requested range; failures return `Corrupt`. With verification disabled, readers rely on the index and segment pin to keep the location valid without scanning the payload. Stored checksums and recovery/reclaim validation are unchanged. End-to-end client verification and checksum transport remain future network-layer work.
 - A crash can only lose unacknowledged writes; "acknowledged but unreadable" cannot happen short of media failure.
 - No partial writes inside a chunk → no COW, no chunk locks, no fragment merging.
 
@@ -368,7 +368,7 @@ Fixed 32 B header + type-specific body, `bytemuck` POD, little endian; DMA'd fir
 
 | Message | Direction | Body |
 |---|---|---|
-| `Put` | C→S | `id, len, flags, expire_at, block_crcs[]`, value inline when `len ≤ INLINE_MAX` |
+| `Put` | C→S | `id, len, flags, block_crcs[]`, value inline when `len ≤ INLINE_MAX` |
 | `PutGrant` | S→C | `addr, rkey` (value start = landing buffer + header length) |
 | `PutResp` | S→C | `status, lsn` |
 | `Get` | C→S | `id, offset, len` |
@@ -554,4 +554,4 @@ Known trade-offs and extension points:
 2. `moat-server` with TCP transport + `moat-client` over TCP: end-to-end usable, developable and testable on machines without RDMA. *(the node layer without a transport is done: `core/moat-server` has NVMe discovery by serial, rendezvous placement, the pinned worker with one io_uring queue per worker and a pluggable request `Handler`, parallel recovery and owner assignment, and a whole-node benchmark; the TCP transport is the next `Handler`)*
 3. `moat-verbs` + `moat-transport::rdma`: reactor, endpoints, leases/fencing; drive to line rate with `moat-tools bench`.
 4. Multi-disk: NVMe discovery, placement, layout epochs, admission.
-5. Cache-mode policies, TTL, `fsck`, observability.
+5. Cache-mode policies, `fsck`, observability.


### PR DESCRIPTION
Chunk expiration belongs to the upper layer that manages object lifetimes and references. Remove chunk TTL from the engine API, record metadata, index flags, reads, and reclaim so chunks no longer become missing or get reclaimed based on wall-clock time.

- Remove `PutOptions::expire_at`, the expiry flags, and the injectable clock types. Choose small-record layouts by value length alone and read headers only when verification is enabled.
- Simplify `ReadCompletion::result` to `Result<ChunkData>`; lookup misses remain `ReadOutcome::Miss`, and the blocking wrapper still returns `Option<ChunkData>`.
- Keep the 64-byte record header with reserved bytes in place of the expiration timestamp. The project is alpha: format version remains 1, with no compatibility migration.
- Update callers, tests, and design documentation to place object TTL in the upper layer.

Validation: `cargo x` passed, including formatting, clippy, 96 tests, the doctest, unused-dependency and license checks, and documentation generation.
