### PR TITLE
feat(engine): support macOS local development with synchronous I/O

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,3 +56,21 @@ jobs:
         run: cargo doc --workspace --no-deps
         env:
           RUSTDOCFLAGS: -D warnings
+
+  macos:
+    name: macOS development
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo clippy --workspace --all-targets
+      - run: cargo test --workspace
+      - run: cargo run -p moat-engine --example local
+      - run: cargo doc --workspace --no-deps
+        env:
+          RUSTDOCFLAGS: -D warnings

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,8 +27,12 @@ env:
 
 jobs:
   check:
-    name: fmt, clippy, test
-    runs-on: ubuntu-latest
+    name: fmt, clippy, test (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -52,25 +56,9 @@ jobs:
         run: cargo clippy --workspace --all-targets
       - name: Test
         run: cargo test --workspace
+      - name: Local example
+        run: cargo run -p moat-engine --example local
       - name: Docs
         run: cargo doc --workspace --no-deps
-        env:
-          RUSTDOCFLAGS: -D warnings
-
-  macos:
-    name: macOS development
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy
-      - uses: Swatinem/rust-cache@v2
-      - run: cargo clippy --workspace --all-targets
-      - run: cargo test --workspace
-      - run: cargo run -p moat-engine --example local
-      - run: cargo doc --workspace --no-deps
         env:
           RUSTDOCFLAGS: -D warnings

--- a/README.md
+++ b/README.md
@@ -33,30 +33,30 @@ The design document lives at [`docs/design/chunkserver.md`](docs/design/chunkser
 use std::sync::Arc;
 use moat_common::ChunkId;
 use moat_engine::{
-    FileDevice, FormatOptions, Options, PutOptions, QueueOptions, blocking, uring::UringQueue,
+    FileDevice, FormatOptions, Options, PutOptions, QueueBackend, QueueOptions, blocking,
 };
 
-let device = Arc::new(FileDevice::create("disk.img", 64 << 30, /* direct */ true)?);
+let device = Arc::new(FileDevice::create("disk.img", 64 << 30, /* direct */ false)?);
 moat_engine::format(&*device, &FormatOptions::default())?;
 
 let (engine, _) = moat_engine::open(device, Options::default())?;
-let mut queue = UringQueue::new(&QueueOptions::default())?;
-let mut writer = engine.writer(&mut queue)?;
-let mut reader = engine.reader(&mut queue)?;
+let mut queue = QueueOptions::default().build(QueueBackend::Auto)?;
+let mut writer = engine.writer(queue.as_mut())?;
+let mut reader = engine.reader(queue.as_mut())?;
 
 let id = ChunkId::from_u128(1);
-writer.put(&mut queue, id, b"hello", PutOptions::default())?;
-blocking::flush(&mut queue, &mut writer)?;
+writer.put(queue.as_mut(), id, b"hello", PutOptions::default())?;
+blocking::flush(queue.as_mut(), &mut writer)?;
 assert_eq!(
-    blocking::get(&mut queue, &mut reader, &id, None)?.as_deref(),
+    blocking::get(queue.as_mut(), &mut reader, &id, None)?.as_deref(),
     Some(&b"hello"[..]),
 );
-blocking::seal(&mut queue, &mut writer)?;
-writer.detach(&mut queue);
-reader.detach(&mut queue);
+blocking::seal(queue.as_mut(), &mut writer)?;
+writer.detach(queue.as_mut());
+reader.detach(queue.as_mut());
 ```
 
-Each worker owns an io_uring queue and a pool of registered buffers. Its readers
+On Linux, each worker owns an io_uring queue and registered buffers. Its readers
 and writers share that queue across disks; each disk has a single writer.
 Values move between buffers and the device without copies
 (`Writer::prepare_large` / `put_large` for writes,
@@ -73,6 +73,28 @@ and every 64 KiB checksum block touched by each read. Unchecked reads cover
 only the requested pages. Checksum generation and recovery/reclaim validation
 are unchanged.
 Client-side transport and verification are not implemented yet.
+
+## macOS 本地开发
+
+macOS 使用普通文件和同步 I/O 后端，用于功能开发与测试。可以直接运行：
+
+```sh
+cargo run -p moat-engine --example local
+cargo test --workspace
+```
+
+示例在临时文件中写入、读取并重新打开一个 4 KiB chunk，退出后自动清理。
+`QueueOptions::build(QueueBackend::Auto)` 在 Linux 选择 io_uring，在 macOS
+选择 `SyncQueue`；可用 `QueueBackend::resolve()` 查看选择结果。Linux 上的
+初始化错误会直接返回。显式指定 `Uring` 在 macOS 上返回 `Unsupported`；
+`MemDevice` 在 Linux 上需要显式指定 `Sync`。
+
+同步后端在调用线程执行阻塞 I/O，然后通过相同的 `poll`/completion 接口交付
+结果，不作为性能路径。Reader、Writer 和磁盘格式不随后端改变。
+macOS 使用 `FileDevice::create/open(..., false)`；显式请求 direct I/O、
+CPU 绑核或强制 huge pages 会返回 `Unsupported`。默认 huge-page 策略降级为
+普通映射，worker 默认使用 `Auto`、不绑核并在空闲时休眠。
+NVMe 自动发现仍仅支持 Linux；macOS 调用方显式提供文件设备。
 
 ## Benchmarking
 

--- a/README.md
+++ b/README.md
@@ -74,27 +74,33 @@ only the requested pages. Checksum generation and recovery/reclaim validation
 are unchanged.
 Client-side transport and verification are not implemented yet.
 
-## macOS 本地开发
+## Local development on macOS
 
-macOS 使用普通文件和同步 I/O 后端，用于功能开发与测试。可以直接运行：
+macOS uses regular files and synchronous I/O for functional development and
+testing. To try it:
 
 ```sh
 cargo run -p moat-engine --example local
 cargo test --workspace
 ```
 
-示例在临时文件中写入、读取并重新打开一个 4 KiB chunk，退出后自动清理。
-`QueueOptions::build(QueueBackend::Auto)` 在 Linux 选择 io_uring，在 macOS
-选择 `SyncQueue`；可用 `QueueBackend::resolve()` 查看选择结果。Linux 上的
-初始化错误会直接返回。显式指定 `Uring` 在 macOS 上返回 `Unsupported`；
-`MemDevice` 在 Linux 上需要显式指定 `Sync`。
+The example writes and reads a 4 KiB chunk, reopens the temporary file to
+verify recovery, and removes the file on exit.
+`QueueOptions::build(QueueBackend::Auto)` selects io_uring on Linux and
+`SyncQueue` on macOS; `QueueBackend::resolve()` reports the selection.
+Initialization errors on Linux are returned directly. Explicitly selecting
+`Uring` on macOS returns `Unsupported`; `MemDevice` on Linux requires an
+explicit `Sync` selection.
 
-同步后端在调用线程执行阻塞 I/O，然后通过相同的 `poll`/completion 接口交付
-结果，不作为性能路径。Reader、Writer 和磁盘格式不随后端改变。
-macOS 使用 `FileDevice::create/open(..., false)`；显式请求 direct I/O、
-CPU 绑核或强制 huge pages 会返回 `Unsupported`。默认 huge-page 策略降级为
-普通映射，worker 默认使用 `Auto`、不绑核并在空闲时休眠。
-NVMe 自动发现仍仅支持 Linux；macOS 调用方显式提供文件设备。
+The synchronous backend performs blocking I/O on the caller's thread and
+delivers results through the same `poll`/completion interface. It is intended
+for development, not the performance path. Reader, Writer, and the disk format
+are shared by both backends.
+On macOS, use `FileDevice::create/open(..., false)`. Explicit requests for
+direct I/O, CPU pinning, or required huge pages return `Unsupported`.
+The default huge-page policy falls back to plain mappings. Workers default to
+`Auto`, without CPU pinning, and sleep when idle.
+NVMe discovery remains Linux-only; macOS callers supply file devices explicitly.
 
 ## Benchmarking
 

--- a/core/moat-common/src/arena.rs
+++ b/core/moat-common/src/arena.rs
@@ -24,6 +24,8 @@
 //! allocation falls back from explicit huge pages (`MAP_HUGETLB`) to
 //! transparent huge pages (`madvise(MADV_HUGEPAGE)`) to plain pages, so the
 //! engine runs everywhere and merely gets faster where huge pages exist.
+//! These huge-page optimizations are Linux-only. Other Unix platforms use
+//! plain mappings unless explicit huge pages are required, which is unsupported.
 
 use std::{io, ptr::NonNull};
 
@@ -77,49 +79,60 @@ impl Arena {
     /// Maps `len` bytes (rounded up to the page size the backing uses).
     pub fn new(len: usize, huge: HugePages) -> io::Result<Self> {
         assert!(len > 0, "arena must not be empty");
-        let mut last_err = None;
-        if huge != HugePages::Disabled {
-            for (page, flag) in [
-                (HUGE_PAGE_1G, libc::MAP_HUGETLB | libc::MAP_HUGE_1GB),
-                (HUGE_PAGE_2M, libc::MAP_HUGETLB | libc::MAP_HUGE_2MB),
-            ] {
-                let rounded = align_up(len as u64, page) as usize;
-                // Do not burn a 1 GiB page on a small arena.
-                if rounded > 2 * len && page == HUGE_PAGE_1G {
-                    continue;
-                }
-                match Self::map(rounded, flag) {
-                    Ok(ptr) => {
-                        let backing = if page == HUGE_PAGE_1G {
-                            Backing::Huge1G
-                        } else {
-                            Backing::Huge2M
-                        };
-                        return Ok(Self {
-                            ptr,
-                            len: rounded,
-                            backing,
-                        });
+        #[cfg(target_os = "linux")]
+        {
+            let mut last_err = None;
+            if huge != HugePages::Disabled {
+                for (page, flag) in [
+                    (HUGE_PAGE_1G, libc::MAP_HUGETLB | libc::MAP_HUGE_1GB),
+                    (HUGE_PAGE_2M, libc::MAP_HUGETLB | libc::MAP_HUGE_2MB),
+                ] {
+                    let rounded = align_up(len as u64, page) as usize;
+                    // Do not burn a 1 GiB page on a small arena.
+                    if rounded > 2 * len && page == HUGE_PAGE_1G {
+                        continue;
                     }
-                    Err(e) => last_err = Some(e),
+                    match Self::map(rounded, flag) {
+                        Ok(ptr) => {
+                            let backing = if page == HUGE_PAGE_1G {
+                                Backing::Huge1G
+                            } else {
+                                Backing::Huge2M
+                            };
+                            return Ok(Self {
+                                ptr,
+                                len: rounded,
+                                backing,
+                            });
+                        }
+                        Err(e) => last_err = Some(e),
+                    }
+                }
+                if huge == HugePages::Required {
+                    return Err(last_err.unwrap_or_else(|| io::Error::other("huge pages unavailable")));
                 }
             }
-            if huge == HugePages::Required {
-                return Err(last_err.unwrap_or_else(|| io::Error::other("huge pages unavailable")));
-            }
+        }
+        #[cfg(not(target_os = "linux"))]
+        if huge == HugePages::Required {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "explicit huge pages are only supported on Linux",
+            ));
         }
 
         let rounded = align_up(len as u64, PAGE_SIZE) as usize;
         let ptr = Self::map(rounded, 0)?;
-        let mut backing = Backing::Plain;
-        if huge != HugePages::Disabled {
+        let backing = Backing::Plain;
+        #[cfg(target_os = "linux")]
+        let backing = if huge != HugePages::Disabled {
             // SAFETY: `ptr..ptr+rounded` is a mapping we own; MADV_HUGEPAGE is
             // advisory and cannot invalidate it.
             let rc = unsafe { libc::madvise(ptr.as_ptr().cast(), rounded, libc::MADV_HUGEPAGE) };
-            if rc == 0 {
-                backing = Backing::Transparent;
-            }
-        }
+            if rc == 0 { Backing::Transparent } else { backing }
+        } else {
+            backing
+        };
         Ok(Self {
             ptr,
             len: rounded,
@@ -208,5 +221,14 @@ mod tests {
         let arena = Arena::new(8 << 20, HugePages::Preferred).unwrap();
         assert!(arena.len() >= 8 << 20);
         assert_eq!(arena.as_ptr() as usize % PAGE_SIZE as usize, 0);
+        #[cfg(not(target_os = "linux"))]
+        assert_eq!(arena.backing(), Backing::Plain);
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    #[test]
+    fn required_huge_pages_are_unsupported() {
+        let err = Arena::new(4096, HugePages::Required).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::Unsupported);
     }
 }

--- a/core/moat-engine/benches/engine.rs
+++ b/core/moat-engine/benches/engine.rs
@@ -46,9 +46,8 @@ use std::{
 
 use moat_common::{ChunkId, HugePages, PoolOptions, block_checksums};
 use moat_engine::{
-    Engine, Error, FileDevice, FormatOptions, IoQueue, Options, PutOptions, PutOutcome, QueueOptions, ReadOutcome,
-    Reader, Writer, blocking,
-    io::{CompletionOrder, SyncQueue},
+    Engine, Error, FileDevice, FormatOptions, IoQueue, Options, PutOptions, PutOutcome, QueueBackend, QueueOptions,
+    ReadOutcome, Reader, Writer, blocking,
 };
 
 const SEGMENT: u64 = 256 << 20;
@@ -72,18 +71,12 @@ fn queue_options() -> QueueOptions {
 
 /// Builds the queue for the calling thread.
 fn queue() -> Box<dyn IoQueue> {
-    let opts = queue_options();
-    if std::env::var_os("MOAT_BENCH_SYNC").is_some() {
-        return Box::new(SyncQueue::new(&opts, CompletionOrder::Fifo).unwrap());
-    }
-    #[cfg(target_os = "linux")]
-    {
-        Box::new(moat_engine::uring::UringQueue::new(&opts).unwrap())
-    }
-    #[cfg(not(target_os = "linux"))]
-    {
-        Box::new(SyncQueue::new(&opts, CompletionOrder::Fifo).unwrap())
-    }
+    let backend = if std::env::var_os("MOAT_BENCH_SYNC").is_some() {
+        QueueBackend::Sync
+    } else {
+        QueueBackend::Auto
+    };
+    queue_options().build(backend).unwrap()
 }
 
 fn gib_per_s(bytes: u64, elapsed: Duration) -> f64 {

--- a/core/moat-engine/examples/local.rs
+++ b/core/moat-engine/examples/local.rs
@@ -1,0 +1,81 @@
+// Copyright 2026- Moat Project Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! File-backed local development on Linux and macOS.
+//!
+//! Run with `cargo run -p moat-engine --example local`.
+//! Uses a temporary file, removed automatically on exit.
+
+use std::sync::Arc;
+
+use moat_common::{ChunkId, PoolOptions};
+use moat_engine::{FileDevice, FormatOptions, Options, PutOptions, QueueBackend, QueueOptions, blocking};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = tempfile::tempdir()?;
+    let path = dir.path().join("disk.img");
+    let device = Arc::new(FileDevice::create(&path, 16 << 20, false)?);
+    moat_engine::format(
+        &*device,
+        &FormatOptions {
+            segment_size: 1 << 20,
+            chunk_max: 64 << 10,
+            ..Default::default()
+        },
+    )?;
+    let options = Options {
+        index_capacity: 1024,
+        batch_limit: 128 << 10,
+        ..Default::default()
+    };
+    let (engine, _) = moat_engine::open(device, options.clone())?;
+    let queue_options = QueueOptions {
+        depth: 16,
+        descriptors: 4,
+        pool: PoolOptions {
+            bytes: 1 << 20,
+            max_class: 128 << 10,
+            ..Default::default()
+        },
+    };
+    let mut queue = queue_options.build(QueueBackend::Auto)?;
+    println!("I/O backend: {:?}", QueueBackend::Auto.resolve());
+    let mut writer = engine.writer(queue.as_mut())?;
+    let mut reader = engine.reader(queue.as_mut())?;
+    let id = ChunkId::from_u128(1);
+    let value = vec![0x42; 4096];
+    writer.put(queue.as_mut(), id, &value, PutOptions::default())?;
+    blocking::flush(queue.as_mut(), &mut writer)?;
+    assert_eq!(
+        blocking::get(queue.as_mut(), &mut reader, &id, None)?.as_deref(),
+        Some(value.as_slice())
+    );
+    blocking::seal(queue.as_mut(), &mut writer)?;
+    writer.detach(queue.as_mut());
+    reader.detach(queue.as_mut());
+    drop(engine);
+    drop(queue);
+
+    let device = Arc::new(FileDevice::open(&path, false)?);
+    let (engine, _) = moat_engine::open(device, options)?;
+    let mut queue = queue_options.build(QueueBackend::Auto)?;
+    let mut reader = engine.reader(queue.as_mut())?;
+    assert_eq!(
+        blocking::get(queue.as_mut(), &mut reader, &id, None)?.as_deref(),
+        Some(value.as_slice())
+    );
+    reader.detach(queue.as_mut());
+    println!("Wrote, read, and recovered a 4 KiB chunk.");
+    Ok(())
+}

--- a/core/moat-engine/src/device.rs
+++ b/core/moat-engine/src/device.rs
@@ -97,6 +97,8 @@ impl FileDevice {
     ///
     /// With `direct` set the file is opened with `O_DIRECT`, bypassing the page
     /// cache. This requires every buffer to be page aligned in memory.
+    /// Outside Linux, `direct = true` returns `Unsupported`; use buffered
+    /// regular files (`direct = false`) for local development.
     pub fn open(path: impl AsRef<Path>, direct: bool) -> io::Result<Self> {
         let mut opts = OpenOptions::new();
         opts.read(true).write(true);
@@ -106,7 +108,12 @@ impl FileDevice {
             opts.custom_flags(libc::O_DIRECT);
         }
         #[cfg(not(target_os = "linux"))]
-        let _ = direct;
+        if direct {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "direct I/O is only supported on Linux",
+            ));
+        }
         let file = opts.open(path)?;
         let len = device_len(&file)?;
         Ok(Self { file, len })
@@ -114,6 +121,14 @@ impl FileDevice {
 
     /// Creates (or truncates) a regular file of `len` bytes and opens it.
     pub fn create(path: impl AsRef<Path>, len: u64, direct: bool) -> io::Result<Self> {
+        // Reject unsupported options before creating or truncating the file.
+        #[cfg(not(target_os = "linux"))]
+        if direct {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "direct I/O is only supported on Linux",
+            ));
+        }
         let file = OpenOptions::new()
             .read(true)
             .write(true)
@@ -244,6 +259,19 @@ impl Device for MemDevice {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(not(target_os = "linux"))]
+    #[test]
+    fn unsupported_direct_io_does_not_truncate_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("existing.img");
+        std::fs::write(&path, b"preserve me").unwrap();
+        let err = FileDevice::create(&path, 4096, true).err().unwrap();
+        assert_eq!(err.kind(), io::ErrorKind::Unsupported);
+        assert_eq!(std::fs::read(&path).unwrap(), b"preserve me");
+        let err = FileDevice::open(&path, true).err().unwrap();
+        assert_eq!(err.kind(), io::ErrorKind::Unsupported);
+    }
 
     #[test]
     fn mem_device_rejects_unaligned() {

--- a/core/moat-engine/src/io.rs
+++ b/core/moat-engine/src/io.rs
@@ -22,14 +22,14 @@
 //! operation and handed back with the completion, so ownership is always
 //! unambiguous and no lifetime crosses the submission boundary.
 //!
-//! Enqueueing never blocks and never touches the device. When `depth`
+//! With io_uring, enqueueing never blocks and never touches the device. When `depth`
 //! operations are already in flight the operation is rejected *losslessly*: the
 //! buffer comes back to the caller, who keeps the operation in its own ready
 //! queue and retries after the next poll. [`IoQueue::vacant`] tells a caller
 //! exactly how many operations it can enqueue without a rejection.
 //!
 //! Two implementations exist: io_uring with registered fixed buffers and a
-//! fixed-file table ([`UringQueue`](crate::uring::UringQueue), Linux, the
+//! fixed-file table (`uring::UringQueue`, Linux, the
 //! production path) and [`SyncQueue`], which performs each operation
 //! immediately through the blocking [`Device`] interface and merely defers the
 //! completion. The sync queue keeps the engine portable and deterministic under
@@ -40,6 +40,30 @@ use std::{io, sync::Arc};
 use moat_common::{BufferPool, PoolOptions, PooledBuf};
 
 use crate::device::Device;
+
+/// Which I/O implementation to use. Selection happens when a queue is built.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum QueueBackend {
+    /// io_uring on Linux; synchronous I/O on other Unix platforms.
+    /// Linux initialization errors are returned, never silently downgraded.
+    #[default]
+    Auto,
+    /// Require io_uring. Returns `Unsupported` outside Linux.
+    Uring,
+    /// Blocking I/O for local development and tests; works with any device.
+    Sync,
+}
+
+impl QueueBackend {
+    /// Resolves `Auto` to the platform's backend, without allocating a queue.
+    pub const fn resolve(self) -> Self {
+        match self {
+            Self::Auto if cfg!(target_os = "linux") => Self::Uring,
+            Self::Auto => Self::Sync,
+            backend => backend,
+        }
+    }
+}
 
 /// Configuration of one [`IoQueue`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -58,6 +82,27 @@ impl Default for QueueOptions {
             depth: 256,
             pool: PoolOptions::default(),
             descriptors: 256,
+        }
+    }
+}
+
+impl QueueOptions {
+    /// Builds a queue on the thread that will drive it.
+    ///
+    /// `Auto` chooses by platform, not by device: in-memory devices require
+    /// `Sync` on Linux. The synchronous backend blocks inside read/write/fsync
+    /// calls and only defers delivery of their completions until `poll`.
+    pub fn build(&self, backend: QueueBackend) -> io::Result<Box<dyn IoQueue>> {
+        match backend.resolve() {
+            QueueBackend::Sync => Ok(Box::new(SyncQueue::new(self, CompletionOrder::Fifo)?)),
+            #[cfg(target_os = "linux")]
+            QueueBackend::Uring => Ok(Box::new(crate::uring::UringQueue::new(self)?)),
+            #[cfg(not(target_os = "linux"))]
+            QueueBackend::Uring => Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "io_uring is only available on Linux",
+            )),
+            QueueBackend::Auto => unreachable!("Auto has been resolved"),
         }
     }
 }
@@ -381,6 +426,36 @@ pub(crate) mod tests {
 
     use super::*;
     use crate::device::MemDevice;
+
+    #[test]
+    fn platform_queue_selection() {
+        let expected = if cfg!(target_os = "linux") {
+            QueueBackend::Uring
+        } else {
+            QueueBackend::Sync
+        };
+        assert_eq!(QueueBackend::Auto.resolve(), expected);
+        assert_eq!(QueueBackend::Sync.resolve(), QueueBackend::Sync);
+        let mut queue = detach_options().build(QueueBackend::Sync).unwrap();
+        check_detach(
+            queue.as_mut(),
+            Arc::new(MemDevice::new(4096)),
+            Arc::new(MemDevice::new(4096)),
+        );
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    #[test]
+    fn auto_uses_sync_and_explicit_uring_is_unsupported() {
+        let mut queue = detach_options().build(QueueBackend::Auto).unwrap();
+        check_detach(
+            queue.as_mut(),
+            Arc::new(MemDevice::new(4096)),
+            Arc::new(MemDevice::new(4096)),
+        );
+        let err = detach_options().build(QueueBackend::Uring).err().unwrap();
+        assert_eq!(err.kind(), io::ErrorKind::Unsupported);
+    }
 
     pub(crate) fn check_detach(q: &mut dyn IoQueue, a: Arc<dyn Device>, b: Arc<dyn Device>) {
         let old = q.attach(&a).unwrap();

--- a/core/moat-engine/src/lib.rs
+++ b/core/moat-engine/src/lib.rs
@@ -39,11 +39,14 @@
 //! engines through it. An [`Engine`] is a disk's shared state; a [`Writer`] or
 //! a [`Reader`] is a pipeline of that disk attached to one queue. Exactly one
 //! writer exists per disk (all mutations, sealing and reclaim go through it);
-//! any number of readers may exist, one per worker in practice. No engine call
+//! any number of readers may exist, one per worker in practice. With io_uring, no pipeline call
 //! blocks: every method does memory work, enqueues I/O and returns a ticket,
 //! or reports [`Error::Busy`] when the pool is out of buffers. Completions are
 //! observed only through `poll`. Values move between pool buffers and the
 //! device without copies.
+//! On macOS, [`QueueOptions::build`] selects a synchronous development backend
+//! for [`QueueBackend::Auto`]. It uses the same pipelines and completion API,
+//! but performs blocking device I/O on the caller's thread.
 //!
 //! # Example
 //!
@@ -100,7 +103,7 @@ pub use device::{Device, FileDevice, MemDevice};
 pub use engine::{ChunkStat, Engine, RecoveryReport, Usage, format, open};
 pub use error::{Error, Result};
 pub use index::{FLAG_ACCESSED, FLAG_FRAMED, FLAG_LARGE, IndexValue, Location, MAX_READERS};
-pub use io::{Descriptor, IoQueue, QueueOptions};
+pub use io::{Descriptor, IoQueue, QueueBackend, QueueOptions};
 pub use options::{FormatOptions, Options};
 pub use reader::{ChunkData, ReadCompletion, ReadOutcome, Reader};
 pub use writer::{

--- a/core/moat-engine/src/reader.rs
+++ b/core/moat-engine/src/reader.rs
@@ -118,7 +118,8 @@ struct ReadyRead {
 }
 
 /// A disk's read pipeline on one queue: looks chunks up, submits reads through
-/// the caller's queue and hands back zero-copy views. Nothing blocks.
+/// the caller's queue and hands back zero-copy views. The io_uring backend
+/// never blocks; the synchronous development backend performs I/O inline.
 pub struct Reader {
     shared: Arc<Shared>,
     desc: Descriptor,
@@ -223,7 +224,7 @@ impl Reader {
     }
 
     /// Finishes reads, appends them to `out`, and pushes reads that
-    /// were waiting for queue room. Never waits. Returns the number appended.
+    /// were waiting for queue room. With io_uring, never waits. Returns the number appended.
     pub fn poll(&mut self, q: &mut dyn IoQueue, out: &mut Vec<ReadCompletion>) -> Result<usize> {
         // A worker visits every disk, but often has requests on only a few.
         // An idle reader cannot have completions in its private descriptor.

--- a/core/moat-engine/src/writer.rs
+++ b/core/moat-engine/src/writer.rs
@@ -20,14 +20,15 @@
 //! thread, the engine needs no locking at all: the index is a single-writer
 //! structure, and everything else the writer touches is owned by it.
 //!
-//! # No call blocks
+//! # Non-blocking with io_uring
 //!
 //! Every method either does memory work and returns, enqueues I/O on the
 //! caller's [`IoQueue`] and returns a [`Ticket`], or reports
 //! [`Error::Busy`] (the pool is out of buffers; poll and retry). Completion is
 //! observed only through [`Writer::poll`], which also advances the state
 //! machines behind sealing, barriers and reclaim. A slow disk therefore never
-//! stalls the other disks that share its worker.
+//! stalls the other disks that share its worker when using io_uring. The
+//! synchronous development backend performs blocking I/O on this thread.
 //!
 //! # I/O pipeline
 //!
@@ -982,7 +983,7 @@ impl Writer {
     /// Applies completions that arrived for this writer, advances the sealing,
     /// barrier and reclaim state machines, submits whatever became ready
     /// (including any partially filled pending batch), and appends the
-    /// resulting [`Completion`]s to `out`. Never waits. Returns the number
+    /// resulting [`Completion`]s to `out`. With io_uring, never waits. Returns the number
     /// appended.
     pub fn poll(&mut self, q: &mut dyn IoQueue, out: &mut Vec<Completion>) -> Result<usize> {
         self.scratch.clear();

--- a/core/moat-engine/tests/engine.rs
+++ b/core/moat-engine/tests/engine.rs
@@ -1305,10 +1305,15 @@ fn concurrent_readers_never_see_torn_values() {
 /// The same engine on a real file, with `O_DIRECT` and io_uring where the
 /// platform supports them (tmpfs does not support `O_DIRECT`; the test then
 /// falls back to buffered I/O).
-#[cfg(target_os = "linux")]
 #[test]
-fn file_device_roundtrip_with_direct_io_and_uring() {
-    use moat_engine::{FileDevice, uring::UringQueue};
+fn file_device_roundtrip_with_platform_and_sync_queues() {
+    for backend in [moat_engine::QueueBackend::Auto, moat_engine::QueueBackend::Sync] {
+        file_device_roundtrip(backend);
+    }
+}
+
+fn file_device_roundtrip(backend: moat_engine::QueueBackend) {
+    use moat_engine::FileDevice;
 
     /// Keep the registered pool below the locked-memory limit of standard
     /// hosted CI runners. The 128 KiB class still accommodates the test
@@ -1351,36 +1356,36 @@ fn file_device_roundtrip_with_direct_io_and_uring() {
     let mut expected = HashMap::new();
     {
         let (engine, _) = moat_engine::open(device.clone(), file_options.clone()).unwrap();
-        let mut q = UringQueue::new(&file_queue_options()).unwrap();
-        let mut writer = engine.writer(&mut q).unwrap();
-        let mut reader = engine.reader(&mut q).unwrap();
+        let mut q = file_queue_options().build(backend).unwrap();
+        let mut writer = engine.writer(q.as_mut()).unwrap();
+        let mut reader = engine.reader(q.as_mut()).unwrap();
         for i in 0..64u128 {
             let len = random_len(&mut rng).min(FILE_CHUNK_MAX as usize);
             let v = value_for(i, 0, len);
-            put(&mut q, &mut writer, id(i), &v, PutOptions::default());
+            put(q.as_mut(), &mut writer, id(i), &v, PutOptions::default());
             expected.insert(i, v);
         }
-        flush(&mut q, &mut writer);
+        flush(q.as_mut(), &mut writer);
         for (i, v) in &expected {
-            assert_eq!(read(&mut q, &mut reader, &id(*i)).unwrap(), *v);
+            assert_eq!(read(q.as_mut(), &mut reader, &id(*i)).unwrap(), *v);
         }
-        // Reclaim through the ring as well.
-        seal(&mut q, &mut writer);
-        reclaim(&mut q, &mut writer, ReclaimPolicy::Storage).unwrap();
+        // Reclaim through the selected queue as well.
+        seal(q.as_mut(), &mut writer);
+        reclaim(q.as_mut(), &mut writer, ReclaimPolicy::Storage).unwrap();
         for (i, v) in &expected {
-            assert_eq!(read(&mut q, &mut reader, &id(*i)).unwrap(), *v);
+            assert_eq!(read(q.as_mut(), &mut reader, &id(*i)).unwrap(), *v);
         }
-        close(&mut q, writer);
-        reader.detach(&mut q);
+        close(q.as_mut(), writer);
+        reader.detach(q.as_mut());
     }
     let reopened = Arc::new(FileDevice::open(&path, false).unwrap());
     let (engine, report) = moat_engine::open(reopened, file_options).unwrap();
-    let mut q = UringQueue::new(&file_queue_options()).unwrap();
-    let mut reader = engine.reader(&mut q).unwrap();
+    let mut q = file_queue_options().build(backend).unwrap();
+    let mut reader = engine.reader(q.as_mut()).unwrap();
     assert_eq!(report.chunks, 64);
     assert_eq!(report.scanned, 0);
     for (i, v) in &expected {
-        assert_eq!(read(&mut q, &mut reader, &id(*i)).unwrap(), *v);
+        assert_eq!(read(q.as_mut(), &mut reader, &id(*i)).unwrap(), *v);
     }
 }
 

--- a/core/moat-server/src/disk.rs
+++ b/core/moat-server/src/disk.rs
@@ -71,11 +71,13 @@ fn read_trimmed(path: &Path) -> Option<String> {
     fs::read_to_string(path).ok().map(|s| s.trim().to_string())
 }
 
+#[cfg(any(target_os = "linux", test))]
 fn read_num<T: std::str::FromStr>(path: &Path) -> Option<T> {
     read_trimmed(path)?.parse().ok()
 }
 
 /// Whether `name` is a whole NVMe namespace (`nvme<ctrl>n<ns>`, no partition).
+#[cfg(any(target_os = "linux", test))]
 fn is_namespace(name: &str) -> bool {
     let Some(rest) = name.strip_prefix("nvme") else {
         return false;
@@ -91,10 +93,21 @@ fn is_namespace(name: &str) -> bool {
 }
 
 /// Lists every NVMe namespace on the machine, in name order.
+#[cfg(target_os = "linux")]
 pub fn discover() -> io::Result<Vec<NvmeDisk>> {
     discover_in(Path::new("/sys/class/block"), Path::new("/proc"))
 }
 
+/// NVMe discovery is Linux-only; open regular files explicitly on other platforms.
+#[cfg(not(target_os = "linux"))]
+pub fn discover() -> io::Result<Vec<NvmeDisk>> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "NVMe discovery is only supported on Linux",
+    ))
+}
+
+#[cfg(any(target_os = "linux", test))]
 fn discover_in(block: &Path, proc: &Path) -> io::Result<Vec<NvmeDisk>> {
     let mounts = fs::read_to_string(proc.join("mounts")).unwrap_or_default();
     let swaps = fs::read_to_string(proc.join("swaps")).unwrap_or_default();
@@ -130,6 +143,7 @@ fn discover_in(block: &Path, proc: &Path) -> io::Result<Vec<NvmeDisk>> {
     Ok(disks)
 }
 
+#[cfg(any(target_os = "linux", test))]
 fn in_use(dir: &Path, name: &str, path: &Path, mounts: &str, swaps: &str) -> Option<InUse> {
     if let Ok(entries) = fs::read_dir(dir)
         && entries
@@ -163,6 +177,7 @@ fn in_use(dir: &Path, name: &str, path: &Path, mounts: &str, swaps: &str) -> Opt
 }
 
 /// Sort key that orders `nvme2n1` before `nvme10n1`.
+#[cfg(any(target_os = "linux", test))]
 fn natural_key(name: &str) -> Vec<u64> {
     name.split(|c: char| !c.is_ascii_digit())
         .filter(|s| !s.is_empty())
@@ -178,6 +193,7 @@ pub fn cpus_of_node(node: usize) -> Vec<usize> {
 }
 
 /// The CPUs this process may run on.
+#[cfg(target_os = "linux")]
 pub fn online_cpus() -> Vec<usize> {
     // SAFETY: a zeroed cpu_set_t is a valid set for sched_getaffinity to fill.
     unsafe {
@@ -189,6 +205,12 @@ pub fn online_cpus() -> Vec<usize> {
             .filter(|&c| libc::CPU_ISSET(c, &set))
             .collect()
     }
+}
+
+/// Logical worker indices based on available parallelism; not affinity IDs.
+#[cfg(not(target_os = "linux"))]
+pub fn online_cpus() -> Vec<usize> {
+    (0..std::thread::available_parallelism().map(usize::from).unwrap_or(1)).collect()
 }
 
 /// Parses a kernel CPU list such as `0-3,8,10-11`.

--- a/core/moat-server/src/worker.rs
+++ b/core/moat-server/src/worker.rs
@@ -14,7 +14,7 @@
 
 //! Worker threads.
 //!
-//! A node runs one kind of worker. Every worker is pinned to a core and owns
+//! A node runs one kind of worker. Every worker may be pinned to a core and owns
 //! exactly one [`IoQueue`] (io_uring, one registered buffer pool, one
 //! fixed-file table) through which it drives every disk: it holds a
 //! [`Reader`] for each disk, so a read is served on the worker that receives
@@ -26,9 +26,9 @@
 //! [`Handler`]: the network reactor in a server, a load generator in a
 //! benchmark, a script in a test. It runs once per loop iteration on the
 //! worker thread, sees the completions the queue delivered since the last
-//! iteration, and issues new operations through the [`Context`]. Nothing here
-//! blocks except the queue's own wait, and only when the worker has nothing
-//! else to do.
+//! iteration, and issues new operations through the [`Context`]. With io_uring,
+//! only the queue's idle wait blocks. The synchronous development backend
+//! performs device I/O inline, so a slow disk can stall its worker.
 
 use std::{
     io,
@@ -41,10 +41,8 @@ use std::{
     time::Duration,
 };
 
-use moat_engine::{
-    Completion, Engine, IoQueue, QueueOptions, ReadCompletion, Reader, Writer, blocking,
-    io::{CompletionOrder, SyncQueue},
-};
+pub use moat_engine::QueueBackend;
+use moat_engine::{Completion, Engine, IoQueue, QueueOptions, ReadCompletion, Reader, Writer, blocking};
 
 /// Index of a disk in a node's disk list.
 pub type DiskId = usize;
@@ -60,15 +58,6 @@ pub enum PollMode {
         /// How long to sleep when neither I/O nor requests are pending.
         idle_sleep: Duration,
     },
-}
-
-/// Which [`IoQueue`] implementation a worker builds.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum QueueBackend {
-    /// io_uring (Linux). Devices must expose a file descriptor.
-    Uring,
-    /// The blocking queue; works with any device, used by tests and tools.
-    Sync,
 }
 
 /// Configuration of one worker.
@@ -89,8 +78,14 @@ impl Default for WorkerOptions {
         Self {
             core: None,
             queue: QueueOptions::default(),
-            backend: QueueBackend::Uring,
-            poll_mode: PollMode::Busy,
+            backend: QueueBackend::Auto,
+            poll_mode: if cfg!(target_os = "linux") {
+                PollMode::Busy
+            } else {
+                PollMode::Adaptive {
+                    idle_sleep: Duration::from_millis(1),
+                }
+            },
         }
     }
 }
@@ -255,6 +250,7 @@ impl<H: Handler> Drop for Worker<H> {
 }
 
 /// Pins the calling thread to `core`.
+#[cfg(target_os = "linux")]
 pub fn pin_to_core(core: usize) -> io::Result<()> {
     // SAFETY: a zeroed cpu_set_t is a valid empty set; CPU_SET writes within
     // its bounds for any core below CPU_SETSIZE, which we check.
@@ -271,17 +267,13 @@ pub fn pin_to_core(core: usize) -> io::Result<()> {
     Ok(())
 }
 
-fn build_queue(opts: &WorkerOptions) -> io::Result<Box<dyn IoQueue>> {
-    match opts.backend {
-        QueueBackend::Sync => Ok(Box::new(SyncQueue::new(&opts.queue, CompletionOrder::Fifo)?)),
-        #[cfg(target_os = "linux")]
-        QueueBackend::Uring => Ok(Box::new(moat_engine::uring::UringQueue::new(&opts.queue)?)),
-        #[cfg(not(target_os = "linux"))]
-        QueueBackend::Uring => Err(io::Error::new(
-            io::ErrorKind::Unsupported,
-            "io_uring is only available on Linux",
-        )),
-    }
+/// CPU pinning is unsupported outside Linux; use `WorkerOptions::core = None`.
+#[cfg(not(target_os = "linux"))]
+pub fn pin_to_core(_core: usize) -> io::Result<()> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "CPU pinning is only available on Linux",
+    ))
 }
 
 fn run_worker<H: Handler>(
@@ -299,7 +291,7 @@ fn run_worker<H: Handler>(
         if let Some(core) = opts.core {
             pin_to_core(core).map_err(io_err)?;
         }
-        let mut queue = build_queue(&opts).map_err(io_err)?;
+        let mut queue = opts.queue.build(opts.backend).map_err(io_err)?;
         let mut slots = Vec::with_capacity(disks.len());
         for (engine, owner) in disks {
             let reader = engine.reader(&mut *queue).map_err(engine_err)?;

--- a/core/moat-server/tests/worker.rs
+++ b/core/moat-server/tests/worker.rs
@@ -61,7 +61,12 @@ fn worker_options() -> WorkerOptions {
             },
             descriptors: 16,
         },
-        backend: QueueBackend::Sync,
+        // MemDevice needs Sync on Linux; exercise the default fallback elsewhere.
+        backend: if cfg!(target_os = "linux") {
+            QueueBackend::Sync
+        } else {
+            WorkerOptions::default().backend
+        },
         poll_mode: PollMode::Adaptive {
             idle_sleep: std::time::Duration::from_micros(50),
         },

--- a/docs/design/chunkserver.md
+++ b/docs/design/chunkserver.md
@@ -52,7 +52,7 @@
 
 - POSIX file semantics; partial overwrite inside a chunk (emulate with read-modify-write of a new version at the client).
 - Server-side range listing or prefix scans.
-- 对象 TTL 和生命周期由上层管理；chunkserver 通过显式删除和 GC 回收数据，不按时间使 chunk 过期。
+- Object TTL and lifecycle management belong to the upper layer. The chunkserver reclaims data through explicit deletion and GC; chunks do not expire based on time.
 - Multi-tenancy isolation and encryption (flag bits are reserved in the protocol; not in v0).
 
 ---

--- a/docs/design/engine-api.md
+++ b/docs/design/engine-api.md
@@ -140,6 +140,11 @@ Two implementations, as today:
 `Device` loses `open_queue` and gains `fn fd(&self) -> Option<BorrowedFd<'_>>`
 (`None` for `MemDevice`, which therefore only works with `SyncQueue`).
 
+队列创建可统一使用 `QueueOptions::build(QueueBackend::Auto)`：Linux 选择
+io_uring，macOS 选择用于本地开发的同步后端。`Auto` 仅按平台选择，不吞掉
+Linux 初始化错误；`Uring` 和 `Sync` 可显式指定。同步后端在提交操作时阻塞
+调用线程，保留相同的完成事件接口，不保证性能路径的非阻塞行为。
+
 Today's `read`/`write` take the buffer by value and return
 `io::ErrorKind::WouldBlock` when the ring is full — which drops the buffer the
 caller just filled. Handing it back makes rejection lossless; `vacant` lets a

--- a/docs/design/engine-api.md
+++ b/docs/design/engine-api.md
@@ -140,10 +140,12 @@ Two implementations, as today:
 `Device` loses `open_queue` and gains `fn fd(&self) -> Option<BorrowedFd<'_>>`
 (`None` for `MemDevice`, which therefore only works with `SyncQueue`).
 
-队列创建可统一使用 `QueueOptions::build(QueueBackend::Auto)`：Linux 选择
-io_uring，macOS 选择用于本地开发的同步后端。`Auto` 仅按平台选择，不吞掉
-Linux 初始化错误；`Uring` 和 `Sync` 可显式指定。同步后端在提交操作时阻塞
-调用线程，保留相同的完成事件接口，不保证性能路径的非阻塞行为。
+Use `QueueOptions::build(QueueBackend::Auto)` to construct a queue through a
+shared entry point: Linux selects io_uring, while macOS selects the synchronous
+backend for local development. `Auto` selects by platform and propagates Linux
+initialization errors; callers can also select `Uring` or `Sync` explicitly.
+The synchronous backend blocks the caller during I/O submission and preserves
+the completion interface, but not the performance path's non-blocking behavior.
 
 Today's `read`/`write` take the buffer by value and return
 `io::ErrorKind::WouldBlock` when the ring is full — which drops the buffer the


### PR DESCRIPTION
macOS local development was blocked by unconditional Linux huge-page and CPU-affinity APIs, despite the engine already having a synchronous I/O backend. Add a portable queue constructor and isolate Linux-specific facilities so the same engine pipelines can run against regular files on macOS.

- Add `QueueOptions::build(QueueBackend)` and `Auto`: io_uring on Linux, synchronous I/O on other Unix platforms. Selection is platform-based; Linux initialization errors remain errors. Keep the existing server re-export of `QueueBackend`.
- Use plain arena mappings on macOS. Explicit io_uring, direct I/O, CPU pinning, required huge pages, and NVMe discovery requests return `Unsupported`; unsupported file creation options are rejected before truncation.
- Default macOS workers to the synchronous backend without CPU pinning and with adaptive idle sleeping. Synchronous operations block the caller and are intended for local development, not the performance path.
- Add a temporary-file example (`cargo run -p moat-engine --example local`), extend file recovery/reclaim tests to both queue selections, and run the same formatting, dependency, clippy, test, example, and documentation checks on Linux and macOS through one CI matrix. The engine pipeline interfaces and disk format are unchanged.

Validation:
- `cargo x`: passed, including 97 tests and the doctest.
- All-target checks and clippy with warnings denied: passed for `aarch64-apple-darwin` and `x86_64-apple-darwin`.
- macOS-target documentation build: passed.
- Local example on Linux: wrote, read, and recovered a 4 KiB chunk.

Native macOS clippy, tests, the example, and documentation passed in CI before consolidation into the shared matrix. Local verification was performed on Linux.

