### PR TITLE
fix(engine): restrict reclaim to storage GC

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The design document lives at [`docs/design/chunkserver.md`](docs/design/chunkser
 | Crate | Purpose | State |
 |---|---|---|
 | [`moat-common`](core/moat-common) | Chunk identifiers, CRC32C block checksums, page alignment, huge-page arenas and the buddy buffer pool | usable |
-| [`moat-engine`](core/moat-engine) | Single-disk engine: segments, index, reclaim/eviction, recovery; io_uring with registered buffers, zero-copy read and write paths | usable on raw devices, files and in memory |
+| [`moat-engine`](core/moat-engine) | Single-disk engine: segments, index, GC, recovery; io_uring with registered buffers, zero-copy read and write paths | usable on raw devices, files and in memory |
 | `moat-transport` | RDMA (verbs) and TCP transports behind one protocol | planned |
 | [`moat-server`](core/moat-server) | Multi-disk node: NVMe discovery, placement, recovery and workers | usable without a network transport |
 | `moat-client` | Node routing, connection management, large-object striping | planned |

--- a/core/moat-engine/src/blocking.rs
+++ b/core/moat-engine/src/blocking.rs
@@ -71,12 +71,8 @@ pub fn seal(q: &mut dyn IoQueue, w: &mut Writer) -> Result<()> {
 
 /// Runs one reclaim pass to completion. `None` if there was nothing to
 /// reclaim.
-pub fn reclaim(
-    q: &mut dyn IoQueue,
-    w: &mut Writer,
-    policy: crate::writer::ReclaimPolicy,
-) -> Result<Option<crate::writer::ReclaimReport>> {
-    let Some(ticket) = w.reclaim(q, policy)? else {
+pub fn reclaim(q: &mut dyn IoQueue, w: &mut Writer) -> Result<Option<crate::writer::ReclaimReport>> {
+    let Some(ticket) = w.reclaim(q)? else {
         return Ok(None);
     };
     match wait(q, w, ticket)? {

--- a/core/moat-engine/src/index.rs
+++ b/core/moat-engine/src/index.rs
@@ -48,9 +48,6 @@ use crate::segments::SegmentTable;
 
 /// Index flag: the record lives in a large batch.
 pub const FLAG_LARGE: u32 = 1;
-/// Index flag: the record has been read since it was written or last
-/// relocated. Used by cache-mode reclaim to decide what to keep.
-pub const FLAG_ACCESSED: u32 = 2;
 /// Index flag (recovery only): the newest record for this key is a tombstone.
 pub(crate) const FLAG_DEAD: u32 = 4;
 /// Index flag: the record lives in a framed batch (header separate from the
@@ -106,12 +103,6 @@ impl IndexValue {
     #[inline]
     pub fn is_framed(&self) -> bool {
         self.flags & FLAG_FRAMED != 0
-    }
-
-    /// Whether the record has been read since written or relocated.
-    #[inline]
-    pub fn is_accessed(&self) -> bool {
-        self.flags & FLAG_ACCESSED != 0
     }
 
     /// The on-disk record flags this entry was derived from, for footprint
@@ -471,7 +462,7 @@ impl Index {
 
     /// Looks a chunk up and pins the segment it lives in before returning,
     /// re-validating the entry after the pin so that a segment reclaim removed
-    /// the entry from is never returned. Marks the entry as accessed.
+    /// the entry from is never returned.
     ///
     /// The caller must unpin the segment once it has finished reading.
     pub fn get_and_pin(&self, slot: &ReaderSlot, id: &ChunkId, segments: &SegmentTable) -> Option<IndexValue> {
@@ -499,9 +490,6 @@ impl Index {
         if std::ptr::eq(table, self.current.load(Ordering::Acquire))
             && table.slots[i].seq.load(Ordering::Relaxed) == seq
         {
-            if value.flags & FLAG_ACCESSED == 0 {
-                table.slots[i].flags.fetch_or(FLAG_ACCESSED, Ordering::Relaxed);
-            }
             return true;
         }
         segments.unpin(value.loc.seg_no);
@@ -653,18 +641,6 @@ impl IndexWriter {
         }
     }
 
-    /// Removes the entry if it still points at `expected`.
-    pub fn remove_if_at(&mut self, id: &ChunkId, expected: Location) -> Option<IndexValue> {
-        let table = self.index.table();
-        match table.locate(id) {
-            Located::Occupied(i, existing) if existing.loc == expected => {
-                self.bury(table, i);
-                Some(existing)
-            }
-            _ => None,
-        }
-    }
-
     fn bury(&self, table: &Table, i: usize) {
         table.slots[i].bury();
         self.index.live.fetch_sub(1, Ordering::Relaxed);
@@ -672,9 +648,6 @@ impl IndexWriter {
     }
 
     /// Replaces the entry with `value` if it still points at `expected`.
-    ///
-    /// The accessed flag of the existing entry is *not* carried over: a
-    /// relocated record starts a fresh access history.
     pub fn replace_if_at(&mut self, id: &ChunkId, expected: Location, value: IndexValue) -> bool {
         let table = self.index.table();
         match table.locate(id) {
@@ -901,14 +874,13 @@ mod tests {
         assert!(!w.replace_if_at(&id, wrong, value(5, 0, 2)));
         assert!(w.replace_if_at(&id, right, value(5, 0, 2)));
         assert_eq!(w.get(&id).unwrap().loc.seg_no, 5);
-        assert!(w.remove_if_at(&id, right).is_none());
-        assert!(w.remove_if_at(&id, Location { seg_no: 5, offset: 0 }).is_some());
+        assert_eq!(w.remove(&id), Some(value(5, 0, 2)));
         assert_eq!(index.len(), 0);
         assert!(w.get(&id).is_none());
     }
 
     #[test]
-    fn pin_and_access_flag() {
+    fn pin_and_relocation() {
         let index = Arc::new(Index::new(16, usize::MAX));
         let segments = SegmentTable::new(4);
         let mut w = IndexWriter::new(index.clone());
@@ -916,14 +888,15 @@ mod tests {
         w.insert_if_newer(id, value(2, 0, 1));
         let slot = index.register().unwrap();
         let v = index.get_and_pin(&slot, &id, &segments).unwrap();
-        assert!(!v.is_accessed(), "the returned snapshot predates the mark");
-        assert!(index.get(&slot, &id).unwrap().is_accessed());
+        assert_eq!(index.get(&slot, &id), Some(v));
         assert_eq!(segments.pins(2), 1);
         segments.unpin(2);
         assert_eq!(segments.pins(2), 0);
-        // Relocation starts a fresh access history.
         assert!(w.replace_if_at(&id, v.loc, value(3, 0, 2)));
-        assert!(!w.get(&id).unwrap().is_accessed());
+        assert_eq!(index.get_and_pin(&slot, &id, &segments), Some(value(3, 0, 2)));
+        assert_eq!(segments.pins(2), 0);
+        assert_eq!(segments.pins(3), 1);
+        segments.unpin(3);
         index.unregister(slot);
     }
 

--- a/core/moat-engine/src/lib.rs
+++ b/core/moat-engine/src/lib.rs
@@ -28,9 +28,9 @@
 //! recovery reads footers instead of data. A lock-free in-memory hash *index*
 //! maps every chunk to its newest record. Deletes append *tombstones*. Space is
 //! reclaimed one segment at a time by relocating what is still live and freeing
-//! the segment; the same mechanism implements cache eviction under a different
-//! policy. There is no separate write-ahead log and no embedded key-value
-//! store: the log is the only source of truth.
+//! the segment. Live chunks are retained until explicitly deleted or overwritten.
+//! There is no separate write-ahead log and no embedded key-value store: the log
+//! is the only source of truth.
 //!
 //! # Queues, engines and pipelines
 //!
@@ -102,11 +102,10 @@ mod writer;
 pub use device::{Device, FileDevice, MemDevice};
 pub use engine::{ChunkStat, Engine, RecoveryReport, Usage, format, open};
 pub use error::{Error, Result};
-pub use index::{FLAG_ACCESSED, FLAG_FRAMED, FLAG_LARGE, IndexValue, Location, MAX_READERS};
+pub use index::{FLAG_FRAMED, FLAG_LARGE, IndexValue, Location, MAX_READERS};
 pub use io::{Descriptor, IoQueue, QueueBackend, QueueOptions};
 pub use options::{FormatOptions, Options};
 pub use reader::{ChunkData, ReadCompletion, ReadOutcome, Reader};
 pub use writer::{
-    Completion, DeleteOutcome, LargeValue, Lsn, Outcome, PutOptions, PutOutcome, ReclaimPolicy, ReclaimReport, Ticket,
-    Writer,
+    Completion, DeleteOutcome, LargeValue, Lsn, Outcome, PutOptions, PutOutcome, ReclaimReport, Ticket, Writer,
 };

--- a/core/moat-engine/src/scan.rs
+++ b/core/moat-engine/src/scan.rs
@@ -16,8 +16,9 @@
 //!
 //! Recovery (for unsealed segments) and reclaim (for every victim) both walk a
 //! segment batch by batch. The scan stops at the first byte range that is not a
-//! well-formed batch of the segment's current incarnation, which is exactly the
-//! end of the log for an active segment and the footer for a sealed one.
+//! well-formed batch of the segment's current incarnation. Active-segment
+//! recovery treats this as the end of the recoverable prefix; reclaim requires
+//! the scan to reach the sealed segment's known data boundary.
 
 use std::ops::ControlFlow;
 

--- a/core/moat-engine/src/writer.rs
+++ b/core/moat-engine/src/writer.rs
@@ -163,21 +163,6 @@ pub struct Completion {
     pub result: Result<Outcome>,
 }
 
-/// How reclaim decides what to keep when it processes a segment.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ReclaimPolicy {
-    /// Every live record is relocated; nothing is ever lost. Victims are the
-    /// sealed segments with the fewest live bytes.
-    Storage,
-    /// Cache semantics: the oldest sealed segment is reclaimed and its live
-    /// records are dropped, except that with `reinsert_accessed` records read
-    /// since they were written are relocated (and their access bit cleared).
-    Cache {
-        /// Relocate records that have been read; drop only the never-read ones.
-        reinsert_accessed: bool,
-    },
-}
-
 /// What a reclaim pass did.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct ReclaimReport {
@@ -187,7 +172,7 @@ pub struct ReclaimReport {
     pub records: u64,
     /// Live data records copied to a cold segment.
     pub relocated: u64,
-    /// Data records dropped (dead or evicted).
+    /// Obsolete data records dropped.
     pub dropped: u64,
     /// Tombstones copied forward because an older version might still exist.
     pub tombstones_relocated: u64,
@@ -195,8 +180,6 @@ pub struct ReclaimReport {
     pub tombstones_dropped: u64,
     /// Value bytes copied.
     pub bytes_relocated: u64,
-    /// Data records whose value failed its checksums (counted in `dropped`).
-    pub corrupt: u64,
 }
 
 /// A pool buffer laid out as a large batch, with the value area exposed for
@@ -548,7 +531,6 @@ struct ReclaimJob {
     seg_no: u32,
     seq: u64,
     kind: SegmentKind,
-    policy: ReclaimPolicy,
     is_oldest: bool,
     end: u64,
     cursor: u64,
@@ -919,18 +901,18 @@ impl Writer {
         ticket
     }
 
-    /// Starts one reclaim pass under `policy`; the completion reports
+    /// Starts one reclaim pass, relocating live records; the completion reports
     /// [`Outcome::Reclaim`]. `None` if there is no sealed segment to reclaim,
     /// [`Error::Busy`] while a previous pass is still running.
     ///
     /// Relocation needs a free segment for the cold log; callers should
     /// reclaim before the free list is exhausted (keeping at least two free
     /// segments is enough).
-    pub fn reclaim(&mut self, q: &mut dyn IoQueue, policy: ReclaimPolicy) -> Result<Option<Ticket>> {
+    pub fn reclaim(&mut self, q: &mut dyn IoQueue) -> Result<Option<Ticket>> {
         if self.reclaim.is_some() {
             return Err(Error::Busy);
         }
-        let Some(seg_no) = self.pick_victim(policy) else {
+        let Some(seg_no) = self.pick_victim() else {
             return Ok(None);
         };
         let (seq, kind, end) = {
@@ -949,7 +931,6 @@ impl Writer {
             seg_no,
             seq,
             kind,
-            policy,
             is_oldest,
             end,
             cursor: self.shared.geometry.data_start(),
@@ -966,16 +947,14 @@ impl Writer {
         Ok(Some(ticket))
     }
 
-    /// Chooses the segment [`Writer::reclaim`] would process next.
-    pub fn pick_victim(&self, policy: ReclaimPolicy) -> Option<u32> {
+    /// Chooses the sealed segment with the fewest live bytes, breaking ties
+    /// by age, that [`Writer::reclaim`] would process next.
+    pub fn pick_victim(&self) -> Option<u32> {
         let segments = &self.shared.segments;
         segments
             .iter()
             .filter(|&s| segments.state(s) == SegmentState::Sealed)
-            .min_by_key(|&s| match policy {
-                ReclaimPolicy::Storage => (segments.live_bytes(s), segments.seq(s)),
-                ReclaimPolicy::Cache { .. } => (segments.seq(s), 0),
-            })
+            .min_by_key(|&s| (segments.live_bytes(s), segments.seq(s)))
     }
 
     // -- progress -----------------------------------------------------------
@@ -2019,9 +1998,9 @@ impl Writer {
         mut rel: usize,
         mut rec: usize,
     ) -> Result<Option<ReclaimStage>> {
-        let (seg_no, seq, cursor, end, policy, is_oldest) = {
+        let (seg_no, seq, cursor, end, is_oldest) = {
             let job = self.reclaim.as_ref().expect("job exists");
-            (job.seg_no, job.seq, job.cursor, job.end, job.policy, job.is_oldest)
+            (job.seg_no, job.seq, job.cursor, job.end, job.is_oldest)
         };
         loop {
             match next_batch(&buf[..len], rel, seq, self.max_batch, end - cursor - rel as u64) {
@@ -2029,8 +2008,8 @@ impl Writer {
                     let batch_off = cursor + rel as u64;
                     // A structurally corrupt batch aborts the pass without
                     // freeing anything: live records behind it could be lost.
-                    // Value checksums are checked per record below, so one
-                    // rotten value only drops that record.
+                    // Live value checksums are checked per record below and
+                    // likewise abort the pass on corruption.
                     let records = parse_batch(&buf[rel..rel + batch_len], &batch, false)?;
                     for (i, r) in records.iter().enumerate().skip(rec) {
                         let loc = Location {
@@ -2040,7 +2019,7 @@ impl Writer {
                         // Reclaim is off the hot path; copying the checksum
                         // array out keeps the re-encoding API simple.
                         let checksums = r.checksums.to_vec();
-                        match self.reclaim_record(q, &r.header, &checksums, r.value, loc, policy, is_oldest) {
+                        match self.reclaim_record(q, &r.header, &checksums, r.value, loc, is_oldest) {
                             Ok(()) => self.reclaim.as_mut().expect("job exists").report.records += 1,
                             Err(Error::Busy) => {
                                 return Ok(Some(ReclaimStage::Process { buf, len, rel, rec: i }));
@@ -2053,8 +2032,16 @@ impl Writer {
                 }
                 BatchStep::NeedMore => break,
                 BatchStep::End => {
-                    let job = self.reclaim.as_mut().expect("job exists");
-                    job.cursor = job.end;
+                    // A sealed segment has a known data boundary. Unlike an
+                    // active recovery scan, an invalid header before that
+                    // boundary is corruption, not an uncommitted tail.
+                    if cursor + rel as u64 != end {
+                        return Err(Error::corrupt(format!(
+                            "segment {seg_no}: invalid batch at {} before data end {end}",
+                            cursor + rel as u64
+                        )));
+                    }
+                    self.reclaim.as_mut().expect("job exists").cursor = end;
                     return Ok(None);
                 }
             }
@@ -2077,32 +2064,21 @@ impl Writer {
         checksums: &[u32],
         value: &[u8],
         loc: Location,
-        policy: ReclaimPolicy,
         is_oldest: bool,
     ) -> Result<()> {
         match hdr.kind {
             RecordKind::Data => {
-                let Some(current) = self.index.get(&hdr.key).filter(|v| v.loc == loc) else {
+                let Some(_) = self.index.get(&hdr.key).filter(|v| v.loc == loc) else {
                     self.reclaim.as_mut().expect("job exists").report.dropped += 1;
                     return Ok(());
                 };
-                // A value that fails its checksums can never be read again;
-                // it is dropped rather than copied forward.
-                let intact = verify_blocks_with(value, 0, |b| checksums.get(b as usize).copied()).is_ok();
-                let keep = intact
-                    && match policy {
-                        ReclaimPolicy::Storage => true,
-                        ReclaimPolicy::Cache { reinsert_accessed } => reinsert_accessed && current.is_accessed(),
-                    };
-                if !keep {
-                    // Decided before any I/O, so a `Busy` retry cannot repeat it.
-                    self.index.remove_if_at(&hdr.key, loc);
-                    let report = &mut self.reclaim.as_mut().expect("job exists").report;
-                    report.dropped += 1;
-                    if !intact {
-                        report.corrupt += 1;
-                    }
-                    return Ok(());
+                // A corrupt live chunk remains indexed and its segment must
+                // not be reused: repair or deletion is an explicit decision.
+                if let Err(block) = verify_blocks_with(value, 0, |b| checksums.get(b as usize).copied()) {
+                    return Err(Error::corrupt(format!(
+                        "chunk {}: checksum block {block} mismatch during reclaim",
+                        hdr.key
+                    )));
                 }
                 // Relocated records keep their LSN (see the module docs).
                 let apply = Apply::Relocate(loc);
@@ -2210,7 +2186,7 @@ mod tests {
             writer.put(&mut queue, key, b"value", PutOptions::default()).unwrap();
             let ticket = if reclaim {
                 blocking::seal(&mut queue, &mut writer).unwrap();
-                writer.reclaim(&mut queue, ReclaimPolicy::Storage).unwrap().unwrap()
+                writer.reclaim(&mut queue).unwrap().unwrap()
             } else {
                 writer.flush(&mut queue).unwrap()
             };

--- a/core/moat-engine/tests/engine.rs
+++ b/core/moat-engine/tests/engine.rs
@@ -24,7 +24,7 @@ use std::{collections::HashMap, sync::Arc};
 use moat_common::{ChunkId, HugePages, PoolOptions};
 use moat_engine::{
     DeleteOutcome, Engine, Error, FormatOptions, IoQueue, MemDevice, Options, Outcome, PutOptions, PutOutcome,
-    QueueOptions, Reader, ReclaimPolicy, Writer, blocking,
+    QueueOptions, Reader, Writer, blocking,
     io::{CompletionOrder, SyncQueue},
 };
 
@@ -124,8 +124,8 @@ fn seal(q: &mut dyn IoQueue, writer: &mut Writer) {
     blocking::seal(q, writer).unwrap();
 }
 
-fn reclaim(q: &mut dyn IoQueue, writer: &mut Writer, policy: ReclaimPolicy) -> Option<moat_engine::ReclaimReport> {
-    blocking::reclaim(q, writer, policy).unwrap()
+fn reclaim(q: &mut dyn IoQueue, writer: &mut Writer) -> Option<moat_engine::ReclaimReport> {
+    blocking::reclaim(q, writer).unwrap()
 }
 
 fn delete(q: &mut dyn IoQueue, writer: &mut Writer, id: &ChunkId) -> bool {
@@ -741,7 +741,7 @@ fn torn_tail_never_returns_wrong_data() {
 }
 
 #[test]
-fn bit_rot_in_sealed_value_is_detected_and_reclaim_drops_it() {
+fn bit_rot_in_sealed_value_aborts_reclaim_without_deleting_it() {
     for verify_reads in [false, true] {
         let device = new_device(4);
         let engine = open_with(
@@ -789,13 +789,72 @@ fn bit_rot_in_sealed_value_is_detected_and_reclaim_drops_it() {
                 );
             }
         }
-        // Reclaim drops the rotten record instead of copying it forward, and
-        // keeps its intact neighbour.
-        let report = reclaim(&mut q, &mut writer, ReclaimPolicy::Storage).unwrap();
-        assert_eq!(report.corrupt, 1);
-        assert_eq!(report.relocated, 1);
-        assert!(!engine.contains(&id(5)));
+        // Corruption must not authorize deletion or reuse of the victim.
+        let free_before = writer.free_segments();
+        let location = engine.stat(&id(5)).unwrap();
+        assert!(matches!(blocking::reclaim(&mut q, &mut writer), Err(Error::Corrupt(_))));
+        assert_eq!(writer.free_segments(), free_before);
+        assert_eq!(engine.stat(&id(5)).unwrap(), location);
         assert_eq!(read(&mut q, &mut reader, &id(6)).unwrap(), b"neighbour");
+        // The original bytes remain available for repair and a later retry.
+        device.with_data_mut(|d| d[pos + 70_000] ^= 1);
+        let report = reclaim(&mut q, &mut writer).unwrap();
+        assert_eq!(report.relocated, 2);
+        assert_eq!(report.dropped, 0);
+        assert_eq!(read(&mut q, &mut reader, &id(5)).unwrap(), v);
+    }
+}
+
+#[test]
+fn corrupt_batch_header_aborts_reclaim_without_freeing_the_segment() {
+    let device = new_device(4);
+    let (engine, mut q, mut writer, mut reader) = setup(&device);
+    put(&mut q, &mut writer, id(1), b"first", PutOptions::default());
+    flush(&mut q, &mut writer);
+    put(&mut q, &mut writer, id(2), b"second", PutOptions::default());
+    seal(&mut q, &mut writer);
+    let location = engine.stat(&id(1)).unwrap();
+    let free_before = writer.free_segments();
+    let header = (SEGMENT * (location.segment as u64 + 1) + moat_engine::layout::SEGMENT_HEADER_LEN) as usize;
+    device.with_data_mut(|d| d[header] ^= 1);
+    assert!(matches!(blocking::reclaim(&mut q, &mut writer), Err(Error::Corrupt(_))));
+    assert_eq!(writer.free_segments(), free_before);
+    assert_eq!(engine.stat(&id(1)).unwrap(), location);
+    assert_eq!(read(&mut q, &mut reader, &id(2)).unwrap(), b"second");
+    device.with_data_mut(|d| d[header] ^= 1);
+    let report = reclaim(&mut q, &mut writer).unwrap();
+    assert_eq!(report.relocated, 2);
+    assert_eq!(report.dropped, 0);
+}
+
+#[test]
+fn reclaim_preserves_unread_chunks_and_allows_only_one_pass() {
+    let device = new_device(12);
+    let (_engine, mut q, mut writer, reader) = setup(&device);
+    for i in 0..100u128 {
+        put(
+            &mut q,
+            &mut writer,
+            id(i),
+            &value_for(i, 0, 48 << 10),
+            PutOptions::default(),
+        );
+    }
+    seal(&mut q, &mut writer);
+    let victim = writer.pick_victim().unwrap();
+    let ticket = writer.reclaim(&mut q).unwrap().unwrap();
+    assert!(matches!(writer.reclaim(&mut q), Err(Error::Busy)));
+    let Outcome::Reclaim(report) = blocking::wait(&mut q, &mut writer, ticket).unwrap() else {
+        panic!("expected reclaim completion");
+    };
+    assert_eq!(report.seg_no, victim);
+    assert!(report.relocated > 0);
+    assert_eq!(report.dropped, 0);
+    close(&mut q, writer);
+    reader.detach(&mut q);
+    let (_engine, mut q, _writer, mut reader) = setup(&device);
+    for i in 0..100u128 {
+        assert_eq!(read(&mut q, &mut reader, &id(i)).unwrap(), value_for(i, 0, 48 << 10));
     }
 }
 
@@ -899,7 +958,7 @@ fn reclaim_storage_keeps_every_live_chunk() {
         }
         flush(&mut q, &mut writer);
         while writer.free_segments() < 6 {
-            let report = reclaim(&mut q, &mut writer, ReclaimPolicy::Storage).expect("victim");
+            let report = reclaim(&mut q, &mut writer).expect("victim");
             assert_eq!(
                 report.records,
                 report.relocated + report.dropped + report.tombstones_relocated + report.tombstones_dropped
@@ -909,7 +968,7 @@ fn reclaim_storage_keeps_every_live_chunk() {
     // A few extra passes exercise the tombstone rules on already-compacted
     // segments (relocated records and forwarded tombstones).
     for _ in 0..8 {
-        if writer.free_segments() < 3 || reclaim(&mut q, &mut writer, ReclaimPolicy::Storage).is_none() {
+        if writer.free_segments() < 3 || reclaim(&mut q, &mut writer).is_none() {
             break;
         }
     }
@@ -945,7 +1004,7 @@ fn reclaim_runs_concurrently_with_foreground_writes() {
 
     // Start a reclaim pass and keep writing (overwrites and deletes of keys
     // the pass is relocating) while it runs; poll both to completion.
-    let ticket = writer.reclaim(&mut q, ReclaimPolicy::Storage).unwrap().expect("victim");
+    let ticket = writer.reclaim(&mut q).unwrap().expect("victim");
     let mut done = Vec::new();
     let mut finished = false;
     let mut round = 1u32;
@@ -994,73 +1053,6 @@ fn reclaim_runs_concurrently_with_foreground_writes() {
             model.get(&k).cloned(),
             "key {k} after reopen"
         );
-    }
-}
-
-#[test]
-fn reclaim_cache_evicts_oldest_and_reinserts_accessed() {
-    let device = new_device(12);
-    let (engine, mut q, mut writer, mut reader) = setup(&device);
-    // Fill several segments with 48 KiB values (packed, ~20 per segment).
-    for i in 0..100u128 {
-        put(
-            &mut q,
-            &mut writer,
-            id(i),
-            &value_for(i, 0, 48 << 10),
-            PutOptions::default(),
-        );
-    }
-    seal(&mut q, &mut writer);
-    let free_before = writer.free_segments();
-
-    // Touch the even keys among the oldest records.
-    for i in (0..20u128).step_by(2) {
-        read(&mut q, &mut reader, &id(i)).unwrap();
-    }
-
-    let report = reclaim(
-        &mut q,
-        &mut writer,
-        ReclaimPolicy::Cache {
-            reinsert_accessed: true,
-        },
-    )
-    .unwrap();
-    assert!(report.relocated > 0 && report.dropped > 0);
-    assert_eq!(
-        writer.free_segments(),
-        free_before + 1 - u32::from(report.relocated > 0)
-    );
-    for i in 0..report.records as u128 {
-        let present = engine.contains(&id(i));
-        assert_eq!(present, i % 2 == 0, "key {i}");
-    }
-
-    // Pure FIFO: the next oldest segment is dropped wholesale.
-    let victim = writer
-        .pick_victim(ReclaimPolicy::Cache {
-            reinsert_accessed: false,
-        })
-        .unwrap();
-    let report = reclaim(
-        &mut q,
-        &mut writer,
-        ReclaimPolicy::Cache {
-            reinsert_accessed: false,
-        },
-    )
-    .unwrap();
-    assert_eq!(report.seg_no, victim);
-    assert_eq!(report.relocated, 0);
-    assert!(report.dropped > 0);
-    // Only one pass at a time.
-    if let Some(t) = writer.reclaim(&mut q, ReclaimPolicy::Storage).unwrap() {
-        assert!(matches!(
-            writer.reclaim(&mut q, ReclaimPolicy::Storage),
-            Err(Error::Busy)
-        ));
-        blocking::wait(&mut q, &mut writer, t).unwrap();
     }
 }
 
@@ -1203,7 +1195,7 @@ fn randomized_against_model() {
             90..=95 => {
                 flush(&mut q, &mut writer);
                 if writer.free_segments() < 6 {
-                    reclaim(&mut q, &mut writer, ReclaimPolicy::Storage);
+                    reclaim(&mut q, &mut writer);
                 }
             }
             _ => {
@@ -1223,7 +1215,7 @@ fn randomized_against_model() {
         if writer.free_segments() < 3 {
             flush(&mut q, &mut writer);
             for _ in 0..32 {
-                if writer.free_segments() >= 6 || reclaim(&mut q, &mut writer, ReclaimPolicy::Storage).is_none() {
+                if writer.free_segments() >= 6 || reclaim(&mut q, &mut writer).is_none() {
                     break;
                 }
             }
@@ -1294,7 +1286,7 @@ fn concurrent_readers_never_see_torn_values() {
             if writer.free_segments() >= 6 {
                 break;
             }
-            reclaim(&mut q, &mut writer, ReclaimPolicy::Storage).unwrap();
+            reclaim(&mut q, &mut writer).unwrap();
         }
     }
     stop.store(true, Ordering::Relaxed);
@@ -1371,7 +1363,7 @@ fn file_device_roundtrip(backend: moat_engine::QueueBackend) {
         }
         // Reclaim through the selected queue as well.
         seal(q.as_mut(), &mut writer);
-        reclaim(q.as_mut(), &mut writer, ReclaimPolicy::Storage).unwrap();
+        reclaim(q.as_mut(), &mut writer).unwrap();
         for (i, v) in &expected {
             assert_eq!(read(q.as_mut(), &mut reader, &id(*i)).unwrap(), *v);
         }
@@ -1425,7 +1417,7 @@ fn framed_records_roundtrip_recover_and_reclaim() {
     seal(&mut q, &mut writer);
     let mut relocated = 0;
     for _ in 0..4 {
-        if let Some(report) = reclaim(&mut q, &mut writer, ReclaimPolicy::Storage) {
+        if let Some(report) = reclaim(&mut q, &mut writer) {
             relocated += report.relocated;
         }
     }
@@ -1670,7 +1662,7 @@ fn check_scan_window_boundary(mode: &str) {
             flush(&mut q, &mut writer);
             if mode == "reclaim" {
                 seal(&mut q, &mut writer);
-                let report = reclaim(&mut q, &mut writer, ReclaimPolicy::Storage).unwrap();
+                let report = reclaim(&mut q, &mut writer).unwrap();
                 assert_eq!(report.relocated, 6, "{mode}");
                 close(&mut q, writer);
             } else if mode == "bad_footer" {
@@ -1737,7 +1729,7 @@ fn dropping_a_reader_releases_pins_for_submitted_and_queued_reads() {
         } else {
             drop(reader);
         }
-        let ticket = writer.reclaim(&mut q, ReclaimPolicy::Storage).unwrap().unwrap();
+        let ticket = writer.reclaim(&mut q).unwrap().unwrap();
         let mut done = Vec::new();
         let mut reclaimed = false;
         for _ in 0..100 {

--- a/docs/design/chunkserver-audit.md
+++ b/docs/design/chunkserver-audit.md
@@ -1,0 +1,62 @@
+当前 chunkserver 实现审查（2026-09-09）
+
+审查基线为 `3e481443fc170233e0312ed5f3603cbe6fc75024`，重点是已实现的 engine 与 node 的数据保留、失败重试和恢复语义。以下发现针对实际实现，不把设计文档中尚未实现的网络、迁移、checkpoint 或调度能力视为已有保证。本次不是完整的并发内存模型或掉电一致性证明。
+
+**本次修改**
+
+- 移除 `ReclaimPolicy`、Cache 淘汰分支、`FLAG_ACCESSED`、访问位更新及专用条件删除方法；`reclaim(queue)` 只执行保留有效 chunk 的 GC，`pick_victim()` 按有效字节数、年龄选择 sealed segment。
+- 有效 chunk 校验失败时，GC 返回 `Corrupt`，保留索引和原 segment，不再删除记录。移除表示这种隐式删除的 `ReclaimReport::corrupt`。
+- sealed segment 在已知数据结束位置之前遇到无效 batch header 时，GC 返回 `Corrupt`，不再将其当作扫描结束并释放 segment。
+- 更新接口调用、测试、README 和设计文档。以上修改不改变磁盘格式，但改变 reclaim 的 Rust API。
+
+GC 的两种损坏场景分别有回归测试覆盖报错、保留原数据位置、修复字节后的成功重试。另有未访问对象经 GC 和重启仍然可读的测试，以及已有随机模型、并发读写和回收测试。
+
+**仍需修复的实现问题**
+
+1. **P1：恢复将不可读 segment 当成空闲，并可能恢复旧版本。**
+
+   `engine.rs::open` 对 segment header 的读取失败、校验失败或身份不符统一计数后跳过；`SegmentTable::new` 的初始状态却是 Free，`Writer::new` 会把这些 segment 加入空闲队列。复现：写入并 seal，破坏其 header，重新 open 成功；chunk 消失，后续新写入复用该 segment。另一个复现中，旧版本在较早的 segment，新版本在损坏 header 的 segment，恢复后旧 LSN 重新成为当前版本。
+
+   建议：正常 open 对未知 segment 状态返回错误；显式 salvage 模式必须隔离该空间，不能直接复用。单纯隔离空间仍不足以防止旧版本恢复，因为不可读区可能包含更新或 tombstone；需要阻止不完整恢复结果作为正常服务视图发布。
+
+   位置：[恢复 header](../../core/moat-engine/src/engine.rs)、[segment 初始状态](../../core/moat-engine/src/segments.rs)、[writer 空闲队列](../../core/moat-engine/src/writer.rs)。
+
+2. **P1：sealed segment 的 footer 回退扫描会截断已确认的数据。**
+
+   footer 校验失败后，`open` 使用与 active segment 相同的 `scan_segment`；任何 record 校验失败都会结束扫描，随后在该位置写入新 footer 并 seal。复现：同一 segment 中两个分别完成写入的 chunk，破坏 footer 和第一个 value，open 成功但完整的第二个 chunk 消失；再次 open 不再报告坏 footer 或重新扫描。
+
+   建议：区分 active 尾部恢复与 sealed 完整性检查。对于后者，至少要求扫描完整覆盖 header 记录的数据范围；不能将中途损坏认定为未确认尾部。先返回错误并保留证据，再设计显式 salvage。active segment 的介质损坏与未完成尾写也不能无条件等同。
+
+   位置：[open / scan_segment / seal_segment_blocking](../../core/moat-engine/src/engine.rs)。
+
+3. **P1：失败的删除重试返回 Missing，重启后对象重新出现。**
+
+   `Writer::delete` 在 tombstone 写入完成之前修改共享索引，使读者也立即看见 Missing；失败路径调用 `untrack` 清理状态，但不恢复旧索引。复现：写入并 seal，提交 delete，对其写入注入 EIO，等待结果失败；恢复设备后重试 delete 返回 Missing；重启后原 chunk 仍然存在。
+
+   建议：分离 writer 的 pending 操作视图和读者的已完成视图，在 tombstone 完成时发布删除；失败时保留可重试状态。同 key 多次 put/delete 的顺序、GC 对 pending tombstone 的依赖需要一起处理，不能只补一次索引回滚。
+
+   位置：[delete / fail_batch / untrack / apply_record](../../core/moat-engine/src/writer.rs)。
+
+4. **P1：重复 PUT 的 Exists 混淆 pending 和已完成状态。**
+
+   `exists` 会查询 `unapplied`，所以第一个 PUT 仍在 pending batch 时，第二个同 ID PUT 已返回不带 ticket 的 `Exists`。复现中，此时共享索引尚无该 chunk；让第一个写入失败之后，最终也没有 chunk。调用者不能把这个 `Exists` 当作可确认的幂等成功。
+
+   建议：仅对已完成的现存 chunk 返回 Exists；pending 重复写应返回可等待的依赖 ticket、共享最终结果或明确的 pending 状态。它与失败删除属于同一组操作状态机问题，适合一起修复。
+
+   位置：[put / put_large / exists](../../core/moat-engine/src/writer.rs)。
+
+5. **P1：重复磁盘 UUID 被接受，导致多盘 placement 退化。**
+
+   `FormatOptions::default` 使用全零 UUID，format 原样写入；`Node::open` 和 `Placement::new` 未验证唯一性。相同 UUID 产生相同 seed，相同容量下所有 key 都选择列表中的同一个磁盘；改变磁盘列表顺序还会改变对应的物理盘。复现使用两个默认 UUID、相同容量的设备，1000 个 key 全部落在同一盘。
+
+   建议：Node 构建 placement 前拒绝重复 UUID；format 要求显式唯一身份，或由明确的格式化入口生成并持久化身份。禁止在每次 open 时重新生成身份，否则重启会改变映射。
+
+   位置：[FormatOptions](../../core/moat-engine/src/options.rs)、[format](../../core/moat-engine/src/engine.rs)、[Node::open](../../core/moat-server/src/node.rs)、[Placement](../../core/moat-server/src/placement.rs)。
+
+以上五项用六个独立的 MemDevice 复现用例验证了当前错误行为；它们尚未在本次修改中修复。优先处理恢复的两个问题，再统一处理 pending mutation 和重复请求，最后收紧多盘身份检查。
+
+**需要明确的已有约束**
+
+`verify_reads = false` 是现有显式性能选择，当前网络层尚未提供端到端校验，因此不能同时宣称默认读取绝不会返回损坏数据。`sync_on_flush` 只在显式 barrier 上安排同步，PUT 的单次 completion 不等于无 PLP 设备上的掉电持久化；GC 搬迁与 Free header 的持久化顺序也需要在非 PLP 支持中单独证明。这些需要确定支持契约，本次未擅自改变配置默认值，也未进行硬件掉电验证。
+
+单盘独占 writer、opaque ChunkId、chunk 范围读取、小对象 batch、物理 GC 和明确请求的覆盖写都属于 chunkserver 的合理职责，没有因 foyer 的需求而移除。

--- a/docs/design/chunkserver-audit.md
+++ b/docs/design/chunkserver-audit.md
@@ -1,62 +1,62 @@
-当前 chunkserver 实现审查（2026-09-09）
+Chunkserver implementation audit (2026-09-09)
 
-审查基线为 `3e481443fc170233e0312ed5f3603cbe6fc75024`，重点是已实现的 engine 与 node 的数据保留、失败重试和恢复语义。以下发现针对实际实现，不把设计文档中尚未实现的网络、迁移、checkpoint 或调度能力视为已有保证。本次不是完整的并发内存模型或掉电一致性证明。
+The baseline for this audit is `3e481443fc170233e0312ed5f3603cbe6fc75024`. It focuses on data retention, failure retries, and recovery semantics in the implemented engine and node layers. The findings concern actual code; networking, migration, checkpoints, and scheduling described in the design documents are not treated as implemented guarantees. This is not a complete proof of concurrent memory ordering or power-loss consistency.
 
-**本次修改**
+**Changes in this PR**
 
-- 移除 `ReclaimPolicy`、Cache 淘汰分支、`FLAG_ACCESSED`、访问位更新及专用条件删除方法；`reclaim(queue)` 只执行保留有效 chunk 的 GC，`pick_victim()` 按有效字节数、年龄选择 sealed segment。
-- 有效 chunk 校验失败时，GC 返回 `Corrupt`，保留索引和原 segment，不再删除记录。移除表示这种隐式删除的 `ReclaimReport::corrupt`。
-- sealed segment 在已知数据结束位置之前遇到无效 batch header 时，GC 返回 `Corrupt`，不再将其当作扫描结束并释放 segment。
-- 更新接口调用、测试、README 和设计文档。以上修改不改变磁盘格式，但改变 reclaim 的 Rust API。
+- Remove `ReclaimPolicy`, cache eviction, `FLAG_ACCESSED`, access-bit updates, and the dedicated conditional removal method. `reclaim(queue)` performs storage GC that retains live chunks; `pick_victim()` selects a sealed segment by live bytes, breaking ties by age.
+- When a live chunk fails checksum verification, GC returns `Corrupt` and retains its index entry and original segment instead of deleting it. Remove `ReclaimReport::corrupt`, which counted these implicit deletions.
+- When a sealed segment contains an invalid batch header before its known data boundary, GC returns `Corrupt` instead of treating it as the end of the scan and freeing the segment.
+- Update callers, tests, the README, and design documents. These changes affect the Rust reclaim API but do not change the on-disk format.
 
-GC 的两种损坏场景分别有回归测试覆盖报错、保留原数据位置、修复字节后的成功重试。另有未访问对象经 GC 和重启仍然可读的测试，以及已有随机模型、并发读写和回收测试。
+Regression tests cover both GC corruption cases: returning an error, retaining the original data location, and successfully retrying after the damaged bytes are repaired. Another test verifies that unread chunks remain readable after GC and restart. Existing randomized model, concurrent read/write, and reclaim tests provide additional coverage.
 
-**仍需修复的实现问题**
+**Outstanding implementation issues**
 
-1. **P1：恢复将不可读 segment 当成空闲，并可能恢复旧版本。**
+1. **P1: Recovery treats unreadable segments as free and can resurrect older versions.**
 
-   `engine.rs::open` 对 segment header 的读取失败、校验失败或身份不符统一计数后跳过；`SegmentTable::new` 的初始状态却是 Free，`Writer::new` 会把这些 segment 加入空闲队列。复现：写入并 seal，破坏其 header，重新 open 成功；chunk 消失，后续新写入复用该 segment。另一个复现中，旧版本在较早的 segment，新版本在损坏 header 的 segment，恢复后旧 LSN 重新成为当前版本。
+   `engine.rs::open` counts and skips segment headers that cannot be read, fail validation, or have mismatched identities. However, `SegmentTable::new` initializes every segment as Free, and `Writer::new` adds those segments to its free list. Reproduction: write and seal a chunk, corrupt its segment header, and reopen successfully. The chunk disappears, and a subsequent write reuses the segment. In a separate reproduction, an older version resides in an earlier segment and the newer version resides in the segment with the damaged header; recovery makes the old LSN current again.
 
-   建议：正常 open 对未知 segment 状态返回错误；显式 salvage 模式必须隔离该空间，不能直接复用。单纯隔离空间仍不足以防止旧版本恢复，因为不可读区可能包含更新或 tombstone；需要阻止不完整恢复结果作为正常服务视图发布。
+   Recommendation: normal open should return an error when a segment's state is unknown. An explicit salvage mode must quarantine that space instead of reusing it. Quarantine alone does not prevent old versions from reappearing: the unreadable region may contain updates or tombstones. Incomplete recovery results must not be published as a normal serving view.
 
-   位置：[恢复 header](../../core/moat-engine/src/engine.rs)、[segment 初始状态](../../core/moat-engine/src/segments.rs)、[writer 空闲队列](../../core/moat-engine/src/writer.rs)。
+   Code: [header recovery](../../core/moat-engine/src/engine.rs), [initial segment state](../../core/moat-engine/src/segments.rs), [writer free list](../../core/moat-engine/src/writer.rs).
 
-2. **P1：sealed segment 的 footer 回退扫描会截断已确认的数据。**
+2. **P1: Footer fallback scanning can truncate acknowledged data in sealed segments.**
 
-   footer 校验失败后，`open` 使用与 active segment 相同的 `scan_segment`；任何 record 校验失败都会结束扫描，随后在该位置写入新 footer 并 seal。复现：同一 segment 中两个分别完成写入的 chunk，破坏 footer 和第一个 value，open 成功但完整的第二个 chunk 消失；再次 open 不再报告坏 footer 或重新扫描。
+   After footer validation fails, `open` uses the same `scan_segment` routine as active-segment recovery. Any record validation failure ends the scan, after which recovery writes a new footer at that position and seals the segment. Reproduction: write two chunks in the same segment and wait for each write to complete, then corrupt the footer and the first value. Open succeeds, but the intact second chunk disappears. A subsequent open no longer reports a bad footer or rescans the segment.
 
-   建议：区分 active 尾部恢复与 sealed 完整性检查。对于后者，至少要求扫描完整覆盖 header 记录的数据范围；不能将中途损坏认定为未确认尾部。先返回错误并保留证据，再设计显式 salvage。active segment 的介质损坏与未完成尾写也不能无条件等同。
+   Recommendation: distinguish active-tail recovery from sealed-segment integrity checking. The latter must at least require the scan to cover the entire data range recorded in the header; corruption in the middle cannot be classified as an unacknowledged tail. Return an error and preserve the evidence before introducing explicit salvage. Media corruption in an active segment must not automatically be equated with an incomplete tail write either.
 
-   位置：[open / scan_segment / seal_segment_blocking](../../core/moat-engine/src/engine.rs)。
+   Code: [open / scan_segment / seal_segment_blocking](../../core/moat-engine/src/engine.rs).
 
-3. **P1：失败的删除重试返回 Missing，重启后对象重新出现。**
+3. **P1: Retrying a failed delete returns Missing, but the chunk reappears after restart.**
 
-   `Writer::delete` 在 tombstone 写入完成之前修改共享索引，使读者也立即看见 Missing；失败路径调用 `untrack` 清理状态，但不恢复旧索引。复现：写入并 seal，提交 delete，对其写入注入 EIO，等待结果失败；恢复设备后重试 delete 返回 Missing；重启后原 chunk 仍然存在。
+   `Writer::delete` changes the shared index before the tombstone write completes, so readers immediately see Missing as well. The failure path calls `untrack` to clear operation state without restoring the old index entry. Reproduction: write and seal a chunk, submit a delete, inject EIO into its write, and observe the failed completion. After restoring the device, retrying the delete returns Missing; after restart, the original chunk still exists.
 
-   建议：分离 writer 的 pending 操作视图和读者的已完成视图，在 tombstone 完成时发布删除；失败时保留可重试状态。同 key 多次 put/delete 的顺序、GC 对 pending tombstone 的依赖需要一起处理，不能只补一次索引回滚。
+   Recommendation: separate the writer's pending-operation view from the readers' completed-operation view, publishing deletion when the tombstone completes and preserving retryable state on failure. Ordering among multiple puts and deletes of the same key, and GC dependencies on pending tombstones, must be handled together. A single index rollback is insufficient.
 
-   位置：[delete / fail_batch / untrack / apply_record](../../core/moat-engine/src/writer.rs)。
+   Code: [delete / fail_batch / untrack / apply_record](../../core/moat-engine/src/writer.rs).
 
-4. **P1：重复 PUT 的 Exists 混淆 pending 和已完成状态。**
+4. **P1: Exists for duplicate PUTs conflates pending and completed writes.**
 
-   `exists` 会查询 `unapplied`，所以第一个 PUT 仍在 pending batch 时，第二个同 ID PUT 已返回不带 ticket 的 `Exists`。复现中，此时共享索引尚无该 chunk；让第一个写入失败之后，最终也没有 chunk。调用者不能把这个 `Exists` 当作可确认的幂等成功。
+   `exists` checks `unapplied`, so a second PUT for the same ID returns `Exists` without a ticket while the first PUT is still in a pending batch. In the reproduction, the shared index does not yet contain the chunk; after the first write fails, the chunk remains absent. Callers cannot treat this `Exists` as an acknowledged idempotent success.
 
-   建议：仅对已完成的现存 chunk 返回 Exists；pending 重复写应返回可等待的依赖 ticket、共享最终结果或明确的 pending 状态。它与失败删除属于同一组操作状态机问题，适合一起修复。
+   Recommendation: return Exists only for a completed, existing chunk. A duplicate pending write should return a waitable dependency ticket, share the eventual result, or explicitly report a pending state. This issue belongs to the same operation state machine as failed deletes and should be fixed alongside them.
 
-   位置：[put / put_large / exists](../../core/moat-engine/src/writer.rs)。
+   Code: [put / put_large / exists](../../core/moat-engine/src/writer.rs).
 
-5. **P1：重复磁盘 UUID 被接受，导致多盘 placement 退化。**
+5. **P1: Duplicate disk UUIDs are accepted and collapse multi-disk placement.**
 
-   `FormatOptions::default` 使用全零 UUID，format 原样写入；`Node::open` 和 `Placement::new` 未验证唯一性。相同 UUID 产生相同 seed，相同容量下所有 key 都选择列表中的同一个磁盘；改变磁盘列表顺序还会改变对应的物理盘。复现使用两个默认 UUID、相同容量的设备，1000 个 key 全部落在同一盘。
+   `FormatOptions::default` supplies an all-zero UUID, which format writes unchanged. Neither `Node::open` nor `Placement::new` checks uniqueness. Identical UUIDs produce identical seeds; with equal capacities, every key selects the same disk in the list. Reordering the disk list also changes the selected physical disk. The reproduction uses two devices with default UUIDs and equal capacities: all 1,000 keys land on one disk.
 
-   建议：Node 构建 placement 前拒绝重复 UUID；format 要求显式唯一身份，或由明确的格式化入口生成并持久化身份。禁止在每次 open 时重新生成身份，否则重启会改变映射。
+   Recommendation: reject duplicate UUIDs before Node builds placement. Formatting should require an explicit unique identity, or a designated formatting entry point should generate and persist one. Do not regenerate identities on each open, which would change placement after restart.
 
-   位置：[FormatOptions](../../core/moat-engine/src/options.rs)、[format](../../core/moat-engine/src/engine.rs)、[Node::open](../../core/moat-server/src/node.rs)、[Placement](../../core/moat-server/src/placement.rs)。
+   Code: [FormatOptions](../../core/moat-engine/src/options.rs), [format](../../core/moat-engine/src/engine.rs), [Node::open](../../core/moat-server/src/node.rs), [Placement](../../core/moat-server/src/placement.rs).
 
-以上五项用六个独立的 MemDevice 复现用例验证了当前错误行为；它们尚未在本次修改中修复。优先处理恢复的两个问题，再统一处理 pending mutation 和重复请求，最后收紧多盘身份检查。
+Six independent MemDevice reproductions confirmed the current behavior behind these five findings. They remain unfixed by this PR. Prioritize the two recovery issues, then address pending mutations and duplicate requests together, followed by disk identity validation.
 
-**需要明确的已有约束**
+**Existing constraints that need explicit contracts**
 
-`verify_reads = false` 是现有显式性能选择，当前网络层尚未提供端到端校验，因此不能同时宣称默认读取绝不会返回损坏数据。`sync_on_flush` 只在显式 barrier 上安排同步，PUT 的单次 completion 不等于无 PLP 设备上的掉电持久化；GC 搬迁与 Free header 的持久化顺序也需要在非 PLP 支持中单独证明。这些需要确定支持契约，本次未擅自改变配置默认值，也未进行硬件掉电验证。
+`verify_reads = false` is an existing, deliberate performance choice. The network layer does not yet provide end-to-end verification, so default reads cannot also be claimed to never return corrupt data. `sync_on_flush` schedules synchronization only at explicit barriers: an individual PUT completion does not establish power-loss durability on a device without power-loss protection (PLP). The persistence ordering between GC relocations and Free headers also needs a separate proof for non-PLP support. These contracts need to be specified; this PR does not change the configuration defaults or claim hardware power-loss validation.
 
-单盘独占 writer、opaque ChunkId、chunk 范围读取、小对象 batch、物理 GC 和明确请求的覆盖写都属于 chunkserver 的合理职责，没有因 foyer 的需求而移除。
+A single writer per disk, opaque ChunkId addressing, chunk range reads, small-object batching, physical GC, and explicitly requested overwrites are appropriate chunkserver responsibilities. They have not been removed to accommodate foyer.

--- a/docs/design/chunkserver.md
+++ b/docs/design/chunkserver.md
@@ -20,7 +20,7 @@
 | Who handles variable length | **Two layers**: anything up to `CHUNK_MAX` is handled natively and efficiently by the chunkserver (bytes to megabytes, no upper-layer packing); anything larger is split by the **client library** into chunks written in parallel across all disks and nodes |
 | Per-disk engine | **One independent log-structured engine per disk**: fixed-size segments (default 1 GiB) + append-only records + footer index per sealed segment + in-memory hash index + segment-granular reclaim |
 | Metadata persistence | **No RocksDB, no separate WAL.** The log is the WAL. Recovery = read every segment header + footers of sealed segments + forward scan of at most two active segments |
-| Reclaim | **GC and cache eviction are one code path**: pick a segment → decide per record whether to relocate or drop → free the segment. Storage mode uses greedy + age rules; cache mode uses FIFO + reinsertion by access bit |
+| Reclaim | **Storage GC only**: choose a sealed segment with the fewest live bytes, relocate live records, discard obsolete records, then free the segment. Valid chunks are never evicted |
 | Disk placement | **Deterministic**: weighted rendezvous hashing of `ChunkId` over disks (weight = capacity). Engines are fully independent; adding, removing or losing a disk affects nothing else |
 | Threads | One kind of pinned, busy-polling **worker** (private RDMA reactor + io_uring + arena), with a configurable count bounded by the CPU budget. Every worker reads every disk directly; each disk has exactly one **owner worker** that is also its writer (sole owner of the log tail, index mutations and reclaim). Clients route PUTs to the owner, so the hot path has no cross-thread hop; a forwarding ring between workers is the cold fallback. tokio for the management plane only |
 | RDMA data path | RC QPs, inline SEND control messages. **PUT = server-grant / client-push**; **GET = client RDMA READ pull**; values ≤ `INLINE_MAX` (default 4 KiB) travel inline in one round trip |
@@ -44,7 +44,7 @@
 ### 1.2 Assumptions added by this document
 
 - **Hardware baseline**: PCIe 5 NVMe (~10 GB/s sequential read, ~5–7 GB/s write per disk), 4–8 × 400 Gb/s RDMA NICs (~46 GB/s usable each), 96+ cores, multiple NUMA nodes. 24 disks aggregate to 150–200 GB/s, matching four 400G NICs.
-- **Semantic baseline**: the chunkserver is a **single-node, durable, correct** chunk store. Once a PUT is acknowledged it must be readable after a restart unless the disk fails; the engine must **never return wrong data** (it returns MISS or CORRUPT instead). Cache eviction is a **policy switch** on top of the engine, not a second engine.
+- **Semantic baseline**: the chunkserver is a **single-node, durable, correct** chunk store. Once a PUT is acknowledged it must be readable after a restart unless the disk fails; the engine must **never return wrong data** (it returns MISS or CORRUPT instead). Valid chunks remain stored until explicitly deleted or overwritten; storage pressure never authorizes eviction.
 - **Enterprise drives have power-loss protection**; by default no flush is issued on the data path. A `sync_mode` option exists for drives without it.
 - **Replication is not inside the chunkserver**: replicas, erasure coding or chain replication are built above it (client-side multi-write or a separate replication layer). The engine exposes `lsn` and `if_absent` primitives so that layer can replay idempotently (see §11).
 
@@ -198,7 +198,7 @@ struct Entry {                 // 48 B
     key: ChunkId,              // 16 B
     seg_no: u32, offset: u32,  // location of the record header
     value_off: u32,            // location of the value (differs from the header for framed records)
-    value_len: u32, flags: u32,// LARGE, FRAMED, ACCESSED
+    value_len: u32, flags: u32,// LARGE, FRAMED
     crc: u32,                  // CRC32C of the first checksum block: verifies framed reads without the header
     lsn: u64,                  // recovery ordering + external version token
 }
@@ -207,7 +207,7 @@ struct Entry {                 // 48 B
 - Memory ≈ 48 B / (7/8 load) ≈ 55 B per entry. 4 MiB average → 24 disks × 8 million ≈ 11 GB; 64 KiB average → ~170 GB. The extra 8 B over a minimal entry buy single-page reads for page-sized values (see §4.2). The engine enforces an `index_memory_budget`; beyond it PUT returns `NoSpace(index)`. **Deployments dominated by tiny objects must raise the budget or pack at the client.** This is a documented capacity constraint, not a hidden OOM.
 - **Reader pin protocol**: a GET reads the entry, increments the target segment's `pin_count` (atomic), then rechecks the current table pointer and the entry's sequence number; if either changed, the reader unpins and retries against the current table. Reclaim removes or rewrites entries first and only then waits for `pin_count == 0`, so a reader whose pin is visible to reclaim also saw the entry before removal. A reader therefore never observes a reused segment (optional post-read verification also checks data integrity).
 
-### 4.5 Delete, GC and eviction
+### 4.5 Delete and GC
 
 **Delete** is a variant of the write path and runs on the disk's owner worker (routed like a PUT, §6.3):
 
@@ -218,11 +218,11 @@ struct Entry {                 // 48 B
 
 Data is not touched; space is reclaimed asynchronously. A worker mid-read has pinned the segment (§4.4) and is unaffected. `overwrite = true` needs no tombstone (the higher-lsn data record supersedes the old one).
 
-**GC runs on the owner worker as a state machine advanced by `Writer::poll`, in small steps interleaved with foreground work**, not on its own thread, so it is serialised with PUT/Del by construction and needs no CAS. The reclaim procedure is identical in storage and cache mode:
+**GC runs on the owner worker as a state machine advanced by `Writer::poll`, in small steps interleaved with foreground work**, not on its own thread, so it is serialised with PUT/Del by construction and needs no CAS. Reclaim preserves every live chunk:
 
 ```
 pick_victim() → sequential read of the whole segment (io_uring, rate limited) → per record:
-    Data      and index[key].loc == this record        → decide(record) ∈ {Relocate → Cold segment, Drop}
+    Data      and index[key].loc == this record        → Relocate to Cold segment; abort on corruption
     Data      and index points elsewhere / absent      → Drop (overwritten or deleted)
     Tombstone and index[key] is Live                   → Drop (a newer data version supersedes it)
     Tombstone and this is the oldest non-Free segment  → Drop (no older data can exist)
@@ -230,12 +230,7 @@ pick_victim() → sequential read of the whole segment (io_uring, rate limited) 
 → all relocations done and index repointed → wait pin_count == 0 → header state = Free
 ```
 
-`pick_victim` and `decide` are the only two policy points:
-
-| Mode | `pick_victim` | `decide` |
-|---|---|---|
-| Storage | Trigger: free segments < 10%. Greedy: lowest live ratio; plus a forced pick of the oldest segment when it exceeds an age threshold or total tombstone volume exceeds a threshold (bounds tombstone lifetime) | Live → Relocate |
-| Cache | Trigger: free segments below a low-water mark (with hysteresis). FIFO: oldest segment | `ACCESSED` bit set → Relocate to Cold and clear the bit (S3-FIFO / SIEVE style reinsertion, ratio cap configurable); otherwise Drop |
+`pick_victim()` chooses the sealed segment with the fewest live bytes, breaking ties by age. Callers explicitly start `Writer::reclaim(queue)` before free space is exhausted. Automatic watermarks, age-based scheduling and throttling are not implemented. With no free segment, writes report `NoSpace`; reclaim does not discard live chunks to make room.
 
 Reclaim mechanics:
 
@@ -243,7 +238,7 @@ Reclaim mechanics:
 - A relocated record **keeps its lsn** and goes into the Cold active segment. Reclaim is thereby a purely physical move: the set of `(key, lsn, kind, value)` records recovery sees is unchanged by it, the lsn a client observed for a chunk stays valid across compaction, and no ordering argument between reclaim and concurrent foreground writes is needed. **When the relocation's completion arrives, `index[key].loc` is compared with the old location in the victim**: if unchanged the entry is repointed; if a foreground PUT interleaved between the reclaim decision and the completion has overwritten the key, the entry is left alone and the copy is immediately dead data in the Cold segment (the PUT's lsn is higher, so recovery agrees).
 - After every record is processed, every relocation completed and no index entry points at the victim any more, wait for `pin_count == 0`, rewrite the header as `Free`, push the segment onto the free list.
 - Cost of reclaiming a 1 GiB segment ≈ read 1 GiB + write the live bytes + one index lookup per record (a segment full of 4 KiB records is 260k lookups, tens of milliseconds of CPU). At 1.5 GB/s the read takes ~0.7 s.
-- Write amplification: storage mode with greedy selection and hot/cold separation is typically 1.5–3× at 85–90% utilisation, which is why storage mode reports `NoSpace` around 90% instead of filling up; cache mode is `1 + reinsertion ratio`, capped at 1.2×.
+- Write amplification depends on the live fraction of each victim. Callers must reserve free space for relocation; the engine does not enforce a utilization watermark. Corrupt live values or malformed batches before the sealed data boundary abort reclaim without freeing the victim.
 - The read path is unaffected by GC (reads bypass the writer; segments are freed only after pins drain); GC writes share the writer pipeline but foreground PUTs go first.
 - **Hot/Cold active segments**: foreground writes go to Hot, relocations to Cold. Hot/cold separation markedly lowers write amplification (the classic LFS result) at the cost of scanning two active segments on recovery.
 
@@ -275,7 +270,7 @@ Cost: headers 120 MB + footers ≈ index volume (48 B × records; 8 million ≈ 
    - A low-priority thread per disk copies the hash table in 1 MiB slices (readers are never blocked; a slice whose entries changed underneath, detected through the per-slot sequence numbers, is re-copied), memcpy to staging, then `WriteFixed` into `kind = Index` segments. The writer is never stalled; p99 is untouched.
    - After all slices complete, superblock A/B flips to the new image (with `L0`, replay start positions, the segment table, table capacity, hasher seed, per-slice CRCs); the old image's segments are freed.
    - Recovery: read the image straight into table memory (zero hashing, 21 GB ≈ 2 s); scan the two active segments from the recorded positions and every segment with `seg_seq` above the checkpoint's maximum; replay only records with `lsn ≥ L0`, merging with the image by **highest lsn** (image entries carry their lsn); drop entries pointing at `Free` segments or at segments whose `seg_seq` differs from the checkpoint's table (can be done lazily on read).
-   - Correctness: every index change after T0 is either a record with `lsn ≥ L0` (inserts, overwrites, relocations — taking the *lowest in-flight* lsn is what keeps in-flight writes' late index updates inside the replay range; a delete's index removal and its tombstone lsn are assigned in the same job, so the tombstone has `lsn ≥ L0`), or has no record at all — only cache-mode Drop eviction (caught by the segment-table check; if the segment has not been reused the entry comes back as live, harmless for a cache). Slices are copied under the lock, so no torn entries.
+   - Correctness remains to be specified before implementing checkpoints: relocations preserve their original LSN, so a replay filter of `lsn ≥ L0` alone cannot recover physical moves. Replay must also account for relocated records and segment incarnation changes; index slices require seqlock validation. The current implementation rebuilds from segment headers, footers and active scans and does not use checkpoints.
    - Trigger: footer bytes written since the last checkpoint reach 10% of the image size (bounding replay to one tenth of a full rebuild), or a time limit, whichever first. At worst-case scale a checkpoint every 10 minutes is ~35 MB/s per disk (0.7% of write bandwidth, 0.1 DWPD); two images occupy 0.14% of the disk. At typical scale these are two orders of magnitude smaller.
    - The gain only shows when the index is very large (worst case 10–20 s → 3–4 s; typical scale barely changes), hence phase two. A clean-shutdown image is a special case (`L0` = next lsn, empty replay); the two share one mechanism.
 
@@ -302,8 +297,8 @@ Each disk recovers and comes online independently; a slow disk does not block th
 `disk_of(id) = argmax_d  H(id, disk_uuid_d) ^ (1 / weight_d)` (weighted rendezvous hashing, weight = capacity).
 
 - No central table, no state, O(disks); adding or removing a disk moves the minimum number of keys.
-- The node keeps a `layout_epoch` and `[current, previous]` disk sets: GET consults the current disk first and, on a miss, the previous one if different; a background migration moves keys from previous disks that now belong elsewhere, then drops the previous layout. Cache mode may disable migration (accept one round of 1/N misses). **During a transition `Del` must be delivered to both the current and the previous disk** (each acting on its own index); otherwise the key stays on the previous disk while the current one answers Miss without a tombstone, and the GET fallback resurrects it. Overwrites are unaffected (GET checks current first).
-- Why not "PUT picks the emptiest disk + a global index": deterministic placement makes the 24 engines fully independent (their own recovery, failures and GC) with no global index or cross-disk state. The price is that a slow disk slows 1/N of the keyspace; it is isolated through that disk's write window saturating → `Throttle` (in cache mode, "do not cache this batch of keys").
+- The node keeps a `layout_epoch` and `[current, previous]` disk sets: GET consults the current disk first and, on a miss, the previous one if different; a background migration moves keys from previous disks that now belong elsewhere, then drops the previous layout. **During a transition `Del` must be delivered to both the current and the previous disk** (each acting on its own index); otherwise the key stays on the previous disk while the current one answers Miss without a tombstone, and the GET fallback resurrects it. Overwrites are unaffected (GET checks current first).
+- Why not "PUT picks the emptiest disk + a global index": deterministic placement makes the 24 engines fully independent (their own recovery, failures and GC) with no global index or cross-disk state. The price is that a slow disk slows 1/N of the keyspace; it is isolated through that disk's write window saturating → `Throttle`.
 
 ### 5.3 Threads
 
@@ -412,10 +407,10 @@ Client                                        Server worker
 
 Read path essentials:
 
-- **The whole path stays on the worker that received the request; there is no cross-thread hand-off.** It touches three shared things, none of them a lock: a seqlock-protected index entry (memory only), the per-disk read-window atomic, and a segment pin counter (§4.4). Cache mode's `ACCESSED` bit is an atomic or on the entry's flags.
+- **The whole path stays on the worker that received the request; there is no cross-thread hand-off.** It touches three shared things, none of them a lock: a seqlock-protected index entry (memory only), the per-disk read-window atomic, and a segment pin counter (§4.4).
 - **I/O count.** The current reader submits one contiguous I/O per request. By default it covers only the requested value pages. With verification enabled, it includes the complete checksum blocks touched by the range and extends back to the header and checksum array. Expiring records also include the header. Separate SQEs for the header and data range are not implemented.
 - **System calls**: each poll iteration submits all pending SQEs with one `io_uring_enter`; completions are read from the mmap'd ring and RDMA completions via user-space `ibv_poll_cq`. Amortised, less than one syscall per GET.
-- **Server-side CRC verification is optional.** The engine defaults to `verify_reads = false`; enabling it validates the header and requested checksum blocks on every GET. Readers report corruption without mutating the index; reclaim removes corrupt records through the single writer. The planned network layer must transmit stored `block_crcs` to the client for verification after receipt; that transport path is not implemented yet.
+- **Server-side CRC verification is optional.** The engine defaults to `verify_reads = false`; enabling it validates the header and requested checksum blocks on every GET. Readers report corruption without mutating the index; reclaim reports corruption and retains the victim instead of deleting live records. The planned network layer must transmit stored `block_crcs` to the client for verification after receipt; that transport path is not implemented yet.
 - **A late READ hitting a reused server buffer is safe** (the client's CRC check fails and it retries), so read buffers may be reclaimed on lease expiry without destroying the QP, unlike PUT landing buffers.
 
 Latency estimate (PCIe 5 NVMe, 60–90 µs random 4 KiB read, 8–10 GB/s per disk; 400G NIC ≈ 46 GB/s):
@@ -513,7 +508,7 @@ moat-tools       format / fsck / dump / bench
 
 ## 10. Correctness and testing
 
-1. **Deterministic engine model tests**: `moat-engine` runs randomized operations against an in-memory reference model on a `MemDevice`, "crashing" at arbitrary I/O boundaries (truncating or damaging the tail) and asserting that acknowledged reads are consistent, unacknowledged writes are either visible or missing, and wrong data is never returned. GC, eviction and the tombstone rules are part of the same model.
+1. **Deterministic engine model tests**: `moat-engine` runs randomized operations against an in-memory reference model on a `MemDevice`, "crashing" at arbitrary I/O boundaries (truncating or damaging the tail) and asserting that acknowledged reads are consistent, unacknowledged writes are either visible or missing, and wrong data is never returned. GC and the tombstone rules are part of the same model.
 2. **Protocol state-machine tests**: `moat-transport` drives PUT/GET/timeout/fence paths with a mock transport and asserts the buffer-ownership invariants (a granted buffer is never reused before the immediate completion or a fence).
 3. **Fault injection**: per-disk EIO / slow disk / disk loss; QP errors, interrupted handshakes, clients dying mid-operation.
 4. **Benchmarks**: `cargo bench -p moat-engine` exercises the single-disk engine with a temporary file by default or an explicitly supplied `MOAT_BENCH_DEVICE`; it reports throughput and p50/p99/p999. The future `moat-tools bench` command adds fio-style multi-client load with configurable point and log-normal size distributions for end-to-end testing.
@@ -537,7 +532,7 @@ moat-tools       format / fsck / dump / bench
 
 Relation to two classic systems:
 
-- **Bitcask** (Riak's backend) is this engine's direct ancestor: active file → segment; keydir → sharded in-memory index; hint file → footer; merge → reclaim/eviction; timestamp ordering → lsn ordering (immune to clock skew). Bitcask's three known weaknesses — merge dropping tombstones and resurrecting old values (later fixed by recording enough in the tombstone to drop it only when no older file can exist), the keydir having to fit in memory, and O(records) startup — map to §4.5's tombstone rules, §4.4's memory budget, and §4.6's parallel rebuild and checkpoint. On top of it this design adds raw devices with 4 KiB alignment, small-value packing, per-64 KiB CRCs, hot/cold active segments, concurrent readers under pin counts, and cache eviction.
+- **Bitcask** (Riak's backend) is this engine's direct ancestor: active file → segment; keydir → sharded in-memory index; hint file → footer; merge → reclaim; timestamp ordering → lsn ordering (immune to clock skew). Bitcask's three known weaknesses — merge dropping tombstones and resurrecting old values (later fixed by recording enough in the tombstone to drop it only when no older file can exist), the keydir having to fit in memory, and O(records) startup — map to §4.5's tombstone rules, §4.4's memory budget, and §4.6's parallel rebuild and checkpoint. On top of it this design adds raw devices with 4 KiB alignment, small-value packing, per-64 KiB CRCs, hot/cold active segments, concurrent readers under pin counts.
 - **SPDK blobstore / BlobFS** is the other road: page (4 KiB) / cluster (1 MiB allocation unit by default) / blob, extent RLE and xattrs in metadata page chains, in-place writes, no data journal, no data CRC, recovery by scanning metadata pages to rebuild bitmaps, single-threaded metadata. BlobFS is a thin "one file, one blob, flat namespace" layer for RocksDB. Not chosen because a 1 MiB allocation unit rules out small objects (supporting them means rewriting this engine inside a blob), SPDK requires VFIO unbinding, hugepages and dedicated polling cores (hurting open-source generality) while io_uring + `O_DIRECT` gets within a few percent of line rate for large I/O, and single-threaded metadata does not fit one independent engine per disk. Its allocation model is the extent-plus-bitmap family rather than a log.
 
 Known trade-offs and extension points:

--- a/docs/design/engine-api.md
+++ b/docs/design/engine-api.md
@@ -230,7 +230,7 @@ impl Writer {
     pub fn seal(&mut self, q: &mut dyn IoQueue) -> Result<Ticket>;
     /// Starts one reclaim pass. `None` if there is no sealed segment.
     /// `Busy` while a previous pass is still running.
-    pub fn reclaim(&mut self, q: &mut dyn IoQueue, policy: ReclaimPolicy) -> Result<Option<Ticket>>;
+    pub fn reclaim(&mut self, q: &mut dyn IoQueue) -> Result<Option<Ticket>>;
 
     // -- progress -----------------------------------------------------------
 
@@ -243,7 +243,7 @@ impl Writer {
     pub fn in_flight(&self) -> usize;
     pub fn free_segments(&self) -> u32;
     pub fn next_lsn(&self) -> Lsn;
-    pub fn pick_victim(&self, policy: ReclaimPolicy) -> Option<u32>;
+    pub fn pick_victim(&self) -> Option<u32>;
 
     /// Closes the descriptor. Call after `seal` has completed and `in_flight()`
     /// is zero; otherwise in-flight batches are abandoned (recovery handles
@@ -461,9 +461,9 @@ to it.
   cannot be placed (no free segment, no buffer for a segment header) simply
   stays pending until the next `poll`.
 - **Readers do not drop corrupt index entries** (the index is single-writer).
-  A read that fails verification reports `Corrupt` every time; reclaim
-  verifies each record it visits and drops the ones whose value fails its
-  checksums (`ReclaimReport::corrupt`) instead of aborting the pass.
+  A read that fails verification reports `Corrupt` every time. Reclaim
+  aborts with `Corrupt` on an invalid live value or a malformed batch before
+  the sealed data boundary, retaining the victim for repair or explicit deletion.
 - **`Options`** gained `index_capacity` (initial slots) and
   `index_memory_budget` (`Error::IndexFull` beyond it) and lost
   `index_shards`; `QueueOptions` gained `descriptors` (size of the fixed-file


### PR DESCRIPTION
moat is a chunkserver, but reclaim could evict valid chunks through `ReclaimPolicy::Cache` and discard corrupt live records even in storage mode. Reclaim now only relocates live records and removes obsolete records. A corrupt live value or an invalid batch header before a sealed segment's known data boundary fails the pass and retains the victim for repair or explicit deletion.

Remove `ReclaimPolicy`, the `ACCESSED` flag and its read-path updates, and simplify the reclaim APIs and callers. Update the documentation and replace cache eviction coverage with regressions for unread chunk retention across GC/restart and corruption followed by repair and retry. The Rust API changes; the on-disk format does not.

The accompanying `docs/design/chunkserver-audit.md` records five additional issues confirmed with six independent MemDevice reproductions. Those recovery, pending mutation, and disk identity issues remain unfixed by this PR.

Validation:
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`, `git diff --check`, and `typos`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- `cargo run -p moat-engine --example local` using io_uring on Linux
